### PR TITLE
fix(rust): Fix recommended vscode settings for rust-analyzer

### DIFF
--- a/.vscode/settings.recommended.json
+++ b/.vscode/settings.recommended.json
@@ -9,7 +9,9 @@
   },
   "files.autoSave": "afterDelay",
   "editor.formatOnType": true,
-  "editor.rulers": [100],
+  "editor.rulers": [
+    100
+  ],
   "editor.tabSize": 4,
   "debug.openDebug": "openOnDebugBreak",
   "debug.internalConsoleOptions": "openOnSessionStart",
@@ -17,7 +19,9 @@
   "[dart]": {
     "editor.formatOnSave": true,
     "editor.formatOnType": true,
-    "editor.rulers": [80],
+    "editor.rulers": [
+      80
+    ],
     "editor.codeActionsOnSave": {
       "source.fixAll": true,
       "source.organizeImports": true
@@ -46,8 +50,11 @@
   "files.associations": {
     "Earthfile": "earthfile"
   },
-  "rust-analyzer.linkedProjects": ["crates/*"],
-  "rust-analyzer.check.overrideCommand": ["bash", "-c", "cargo lint-vscode"],
+  "rust-analyzer.check.overrideCommand": [
+    "bash",
+    "-c",
+    "cargo lint-vscode"
+  ],
   "yaml.schemas": {
     "https://squidfunk.github.io/mkdocs-material/schema.json": "mkdocs.yml"
   },
@@ -64,6 +71,8 @@
     "files.trimTrailingWhitespace": true,
     "editor.defaultFormatter": "DavidAnson.vscode-markdownlint"
   },
-  "rust-analyzer.rustfmt.extraArgs": ["+nightly"],
+  "rust-analyzer.rustfmt.extraArgs": [
+    "+nightly"
+  ],
   "rust-analyzer.lens.enable": true
 }


### PR DESCRIPTION
# Description

Fixes rust analyzer finding the workspace in vscode.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
