### PR TITLE
chore(general): Bump CI to cat voices ci branch

### DIFF
--- a/.config/dictionaries/project.dic
+++ b/.config/dictionaries/project.dic
@@ -1,7 +1,6 @@
 aarch
 abcz
 ABNF
-abnf
 addrr
 adminer
 anypolicy
@@ -23,12 +22,10 @@ BROTLI
 cantopen
 cardano
 CBOR
-cbor
 cbork
 cdylib
 CEST
 CHAINCODE
-chaincode
 chainsync
 childs
 Chotivichit
@@ -58,7 +55,6 @@ dotglob
 drep
 dreps
 Earthfile
-earthfile
 encryptor
 Errno
 Eternl
@@ -127,7 +123,6 @@ mdlint
 mdns
 memx
 Metadatum
-metadatum
 mimalloc
 minicbor
 miniprotocol
@@ -192,7 +187,6 @@ retriggering
 rlib
 rulelist
 RULENAME
-rulename
 runable
 rustc
 rustdoc
@@ -246,13 +240,11 @@ utimensat
 UTXO
 vitss
 Vkey
-vkey
 vkeywitness
 voteplan
 voteplans
 wallclock
 WASI
-wasi
 wasip
 wasmtime
 webasm
@@ -261,6 +253,5 @@ webpki
 WORKDIR
 xprivate
 XPRV
-xprv
 xpub
 yoroi

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,7 +1,7 @@
 {
     // markdownlint JSON(C) configuration for Catalyst Standards
     // Do not individually set markdown lint rules in documents.
-    // It is permissable to disable a rule in a document if it is a false positive.
+    // It is permissible to disable a rule in a document if it is a false positive.
     // Keep the scope of the lint disable to as small as possible.
     // See: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
     // Default state for all rules

--- a/Earthfile
+++ b/Earthfile
@@ -1,7 +1,7 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/mdlint:feat/cat-gateway-changes AS mdlint-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cspell:feat/cat-gateway-changes AS cspell-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/mdlint:v3.2.03 AS mdlint-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cspell:v3.2.03 AS cspell-ci
 
 FROM debian:stable-slim
 

--- a/Earthfile
+++ b/Earthfile
@@ -1,7 +1,7 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/mdlint:v3.2.00 AS mdlint-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cspell:v3.2.00 AS cspell-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/mdlint:feat/cat-gateway-changes AS mdlint-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cspell:feat/cat-gateway-changes AS cspell-ci
 
 FROM debian:stable-slim
 
@@ -15,13 +15,9 @@ markdown-check-fix:
 
     DO mdlint-ci+MDLINT_LOCALLY --src=$(echo ${PWD}) --fix=--fix
 
-# Make sure the project dictionary is properly sorted.
+# clean-spelling-list : Make sure the project dictionary is properly sorted.
 clean-spelling-list:
-    COPY .config/dictionaries/project.dic project.dic
-    RUN sort -d -f project.dic > new.dic
-    IF ! diff -q project.dic new.dic
-        SAVE ARTIFACT new.dic AS LOCAL .config/dictionaries/project.dic
-    END
+    DO cspell-ci+CLEAN
         
 # check-spelling : Check spelling in this repo inside a container.
 check-spelling:

--- a/docs/Earthfile
+++ b/docs/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs::feat/cat-gateway-changes AS docs-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:feat/cat-gateway-changes AS docs-ci
 
 IMPORT .. AS repo
 

--- a/docs/Earthfile
+++ b/docs/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:feat/cat-gateway-changes AS docs-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.2.03 AS docs-ci
 
 IMPORT .. AS repo
 

--- a/docs/Earthfile
+++ b/docs/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.2.00 AS docs-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs::feat/cat-gateway-changes AS docs-ci
 
 IMPORT .. AS repo
 

--- a/integration_tests/rust/Earthfile
+++ b/integration_tests/rust/Earthfile
@@ -1,25 +1,26 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/mithril_snapshot:v3.1.8 AS mithril-snapshot-ci
 IMPORT ../../rust AS rust-workspace
 
-local-build:
-    FROM rust-workspace+builder
+# TODO: This needs reworking, because we no longer have mithril snapshots inside CI.
 
-    WORKDIR crates/cardano-chain-follower/testbed
-    RUN cargo build -p overhead_benchmark --release
+#local-build:
+#    FROM rust-workspace+builder
 
-    SAVE ARTIFACT target/release/overhead_benchmark overhead_benchmark
+#    WORKDIR crates/cardano-chain-follower/testbed
+#    RUN cargo build -p overhead_benchmark --release
 
-local-run-preprod:
-    ARG --required BENCH_NAME
+#    SAVE ARTIFACT target/release/overhead_benchmark overhead_benchmark
 
-    FROM +local-build
+#local-run-preprod:
+#    ARG --required BENCH_NAME
 
-    COPY --dir mithril-snapshot-ci+package-preprod-snapshot/snapshot/immutable mithril_snapshot 
-    COPY +build/overhead_benchmark overhead_benchmark_bin
-    RUN ./overhead_benchmark_bin --bench-name $BENCH_NAME --mithril-snapshot-path ./mithril_snapshot
+#    FROM +local-build
 
-local-save-preprod-snapshot:
-    FROM mithril-snapshot-ci+package-preprod-snapshot
-    SAVE ARTIFACT immutable AS LOCAL local_preprod_mithril_snapshot 
+    #COPY --dir mithril-snapshot-ci+package-preprod-snapshot/snapshot/immutable mithril_snapshot 
+    #COPY +build/overhead_benchmark overhead_benchmark_bin
+    #RUN ./overhead_benchmark_bin --bench-name $BENCH_NAME --mithril-snapshot-path ./mithril_snapshot
+
+#local-save-preprod-snapshot:
+    #FROM mithril-snapshot-ci+package-preprod-snapshot
+    #SAVE ARTIFACT immutable AS LOCAL local_preprod_mithril_snapshot 

--- a/integration_tests/rust/overhead_benchmark/README.md
+++ b/integration_tests/rust/overhead_benchmark/README.md
@@ -11,7 +11,7 @@ It doesn't matter which network the snapshot is from because the benchmark will 
 There are 2 modes in which the benchmark can be executed:
 
 | Benchmark name           | Description  |
----------------------------|--------------|
+|--------------------------|--------------|
 | pallas                 | When executed with `--bench-name pallas`, the benchmark reads the Mithril snapshot from origin to its tip using only the `pallas` crate mechanisms |
 | cardano&#x2011;chain&#x2011;follower | When executed with `--bench-name cardano-chain-follower` it uses the `cardano-chain-follower` crate to follow the chain from origin to the tip of the specified snapshot |
 

--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:feat/cat-gateway-changes AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.2.03 AS rust-ci
 
 # sync-cfg: Synchronize local config with CI version.
 # Must be run by the developer manually.

--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -1,10 +1,11 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:feat/cardano-chain-follower-changes AS rust-ci
-#IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.2.00 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:feat/cat-gateway-changes AS rust-ci
 
-# Use when debugging cat-ci locally.
-# IMPORT ../../catalyst-ci/earthly/rust AS rust-ci
+# sync-cfg: Synchronize local config with CI version.
+# Must be run by the developer manually.
+sync-cfg:
+    DO rust-ci+SYNC_STD_CFG
 
 # builder : Set up our target toolchains, and copy our files.
 builder:

--- a/rust/Justfile
+++ b/rust/Justfile
@@ -11,6 +11,10 @@ default:
 cargo-tree:
     cargo tree -e features,normal,build -f "{p}[{f}]" --workspace --frozen
 
+# Synchronize STD Configs with the CI Version in use.
+sync-cfg:
+    earthly +sync-cfg
+
 # Check Dependency licenses and CVE's
 license-check:
     cargo deny check --exclude-dev
@@ -26,4 +30,7 @@ code-lint:
     cargo lint
 
 # Pre Push Checks
-pre-push: code-format code-lint license-check
+pre-push: sync-cfg code-format code-lint license-check
+    # Make sure we can actually build inside Earthly which needs to happen in CI.
+    earthly +check
+    earthly +build

--- a/rust/c509-certificate/Earthfile
+++ b/rust/c509-certificate/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.2.00 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust::feat/cat-gateway-changes AS rust-ci
 
 IMPORT .. AS rust-local
 IMPORT ../.. AS repo

--- a/rust/c509-certificate/Earthfile
+++ b/rust/c509-certificate/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust::feat/cat-gateway-changes AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust::v3.2.03 AS rust-ci
 
 IMPORT .. AS rust-local
 IMPORT ../.. AS repo

--- a/rust/cardano-chain-follower/src/mithril_snapshot_sync.rs
+++ b/rust/cardano-chain-follower/src/mithril_snapshot_sync.rs
@@ -164,13 +164,13 @@ async fn get_snapshot(
             if let Some(snapshot) = snapshot {
                 snapshot
             } else {
-                // Some kind of communications error has ocurred.
+                // Some kind of communications error has occurred.
                 error!("No snapshot returned for {} ???", network);
                 return None;
             }
         },
         Err(err) => {
-            // Some kind of communications error has ocurred.
+            // Some kind of communications error has occurred.
             error!(
                 "Failure to get the latest snapshot for {} with error: {}",
                 network, err

--- a/rust/cbork-abnf-parser/tests/testsuite/alternations.rs
+++ b/rust/cbork-abnf-parser/tests/testsuite/alternations.rs
@@ -1,3 +1,7 @@
+//! Test Alternations through the parser.
+
+// cspell: words nbaz
+
 use cbork_abnf_parser::{self, abnf_test::Rule};
 
 use crate::common::*;

--- a/rust/cbork/Earthfile
+++ b/rust/cbork/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust::feat/cat-gateway-changes AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust::v3.2.03 AS rust-ci
 
 IMPORT .. AS rust-local
 

--- a/rust/cbork/Earthfile
+++ b/rust/cbork/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.2.00 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust::feat/cat-gateway-changes AS rust-ci
 
 IMPORT .. AS rust-local
 

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -26,10 +26,13 @@ ignore = [
 multiple-versions = "warn"
 wildcards = 'deny'
 deny = [
-    # { crate = "git2", use-instead = "gix" },
-    { crate = "openssl", use-instead = "rustls" },
-    { crate = "openssl-sys", use-instead = "rustls" },
+    # Scylla DB Drivers currently require OpenSSL.  Its unavoidable.
+    # However, there is movement to enable support for Rustls. 
+    # So, for now, allow open-ssl but it needs to be disabled as soon as Scylla DB enables Rustls.
+    #{ crate = "openssl", use-instead = "rustls" },
+    #{ crate = "openssl-sys", use-instead = "rustls" },
     "libssh2-sys",
+    # { crate = "git2", use-instead = "gix" },
     # { crate = "cmake", use-instead = "cc" },
     # { crate = "windows", reason = "bloated and unnecessary", use-instead = "ideally inline bindings, practically, windows-sys" },
 ]

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,4 +1,3 @@
 [toolchain]
 channel = "1.80"
 profile = "default"
-targets = ["x86_64-unknown-linux-musl"]

--- a/rust/rustfmt.toml
+++ b/rust/rustfmt.toml
@@ -1,6 +1,3 @@
-# Compatibility:
-edition = "2021"
-
 # Enable unstable features:
 # * imports_indent
 # * imports_layout
@@ -23,32 +20,49 @@ edition = "2021"
 # * overflow_delimited_expr
 unstable_features = true
 
-blank_lines_upper_bound = 1
-comment_width = 90
-condense_wildcard_suffixes = true
-fn_params_layout = "Compressed"
-force_multiline_blocks = true
-format_code_in_doc_comments = true
-format_generated_files = false
-group_imports = "StdExternalCrate"
+# Compatibility:
+edition = "2021"
+
+# Tabs & spaces - Defaults, listed for clarity
+tab_spaces = 4
 hard_tabs = false
-hex_literal_case = "Upper"
-imports_granularity = "Crate"
-imports_indent = "Block"
-imports_layout = "Mixed"
-inline_attribute_width = 0
+
+# Commas.
+trailing_comma = "Vertical"
 match_block_trailing_comma = true
+
+# General width constraints.
 max_width = 100
+
+# Comments:
 normalize_comments = true
 normalize_doc_attributes = true
-overflow_delimited_expr = true
-reorder_impl_items = true
-reorder_imports = true
-tab_spaces = 4
-trailing_comma = "Vertical"
-use_field_init_shorthand = true
-use_small_heuristics = "Default"
-where_single_line = true
 wrap_comments = true
+comment_width = 90      # small excess is okay but prefer 80
+format_code_in_doc_comments = true
+format_generated_files = false
 
+# Imports.
+imports_indent = "Block"
+imports_layout = "Mixed"
+group_imports = "StdExternalCrate"
+reorder_imports = true
+imports_granularity = "Crate"
+
+# Arguments:
+use_small_heuristics = "Default"
+fn_params_layout = "Compressed"
+overflow_delimited_expr = true
+where_single_line = true
+
+# Misc:
+inline_attribute_width = 0
+blank_lines_upper_bound = 1
+reorder_impl_items = true
+use_field_init_shorthand = true
+force_multiline_blocks = true
+condense_wildcard_suffixes = true
+hex_literal_case = "Upper"
+
+# Ignored files:
 ignore = []


### PR DESCRIPTION
# Description

This change just bumps CI to use the same branch that cat-voices is using.
It will be changed to a proper version number, once both cat-voices and cat-libs pass CI with it.

## Related Pull Requests

* https://github.com/input-output-hk/catalyst-ci/pull/306

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
