### PR TITLE
chore(rust/cardano-chain-follower): Bump crate version to 0.0.4

### DIFF
--- a/rust/cardano-chain-follower/Cargo.toml
+++ b/rust/cardano-chain-follower/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cardano-chain-follower"
-version = "0.0.3"
+version = "0.0.4"
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
# Description

Bumps version of the crate to `v0.0.4`.

## Related Pull Requests

#56

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
