### PR TITLE
refactor(chain-follower): update `MultiEraBlock` and `MultiEraTx` to use with `WithRawAuxiliary` suffix

### DIFF
--- a/rust/cardano-chain-follower/src/follow.rs
+++ b/rust/cardano-chain-follower/src/follow.rs
@@ -361,13 +361,15 @@ impl ChainFollower {
 
 #[cfg(test)]
 mod tests {
+    use pallas::ledger::traverse::MultiEraBlockWithRawAuxiliary;
+
     use super::*;
 
     fn mock_block() -> MultiEraBlock {
         let raw_block = hex::decode(include_str!("./../test_data/shelley.block"))
             .expect("Failed to decode hex block.");
 
-        let pallas_block = pallas::ledger::traverse::MultiEraBlock::decode(raw_block.as_slice())
+        let pallas_block = MultiEraBlockWithRawAuxiliary::decode(raw_block.as_slice())
             .expect("cannot decode block");
 
         let previous_point = Point::new(

--- a/rust/cardano-chain-follower/src/metadata/cip36.rs
+++ b/rust/cardano-chain-follower/src/metadata/cip36.rs
@@ -91,8 +91,8 @@ impl Cip36 {
     /// Nothing.  IF CIP36 Metadata is found it will be updated in `decoded_metadata`.
     #[allow(clippy::too_many_lines)]
     pub(crate) fn decode_and_validate(
-        decoded_metadata: &DecodedMetadata, slot: u64, txn: &MultiEraTxWithRawAuxiliary, raw_aux_data: &RawAuxData,
-        catalyst_strict: bool, chain: Network,
+        decoded_metadata: &DecodedMetadata, slot: u64, txn: &MultiEraTxWithRawAuxiliary,
+        raw_aux_data: &RawAuxData, catalyst_strict: bool, chain: Network,
     ) {
         let k61284 = raw_aux_data.get_metadata(LABEL);
         let k61285 = raw_aux_data.get_metadata(SIG_LABEL);

--- a/rust/cardano-chain-follower/src/metadata/cip36.rs
+++ b/rust/cardano-chain-follower/src/metadata/cip36.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use ed25519_dalek::Verifier;
 use minicbor::Decoder;
-use pallas::ledger::traverse::MultiEraTx;
+use pallas::ledger::traverse::MultiEraTxWithRawAuxiliary;
 use tracing::debug;
 
 use super::{
@@ -91,7 +91,7 @@ impl Cip36 {
     /// Nothing.  IF CIP36 Metadata is found it will be updated in `decoded_metadata`.
     #[allow(clippy::too_many_lines)]
     pub(crate) fn decode_and_validate(
-        decoded_metadata: &DecodedMetadata, slot: u64, txn: &MultiEraTx, raw_aux_data: &RawAuxData,
+        decoded_metadata: &DecodedMetadata, slot: u64, txn: &MultiEraTxWithRawAuxiliary, raw_aux_data: &RawAuxData,
         catalyst_strict: bool, chain: Network,
     ) {
         let k61284 = raw_aux_data.get_metadata(LABEL);
@@ -377,7 +377,7 @@ impl Cip36 {
     /// Decode the Payment Address Metadata in the CIP36 Metadata map.
     fn decode_payment_address(
         &mut self, decoder: &mut Decoder, validation_report: &mut ValidationReport,
-        decoded_metadata: &DecodedMetadata, _txn: &MultiEraTx, chain: Network,
+        decoded_metadata: &DecodedMetadata, _txn: &MultiEraTxWithRawAuxiliary, chain: Network,
     ) -> Option<usize> {
         let raw_address = match decoder.bytes() {
             Ok(address) => address,
@@ -969,7 +969,7 @@ mod tests {
         let mut cip36 = create_empty_cip36(false);
         let mut decoder = Decoder::new(&hex_data);
         let mut report = ValidationReport::new();
-        let multi_era_tx: *const MultiEraTx = std::ptr::null();
+        let multi_era_tx: *const MultiEraTxWithRawAuxiliary = std::ptr::null();
         let multi_era_tx = unsafe { &*multi_era_tx };
 
         let rc = cip36.decode_payment_address(

--- a/rust/cardano-chain-follower/src/metadata/cip509/mod.rs
+++ b/rust/cardano-chain-follower/src/metadata/cip509/mod.rs
@@ -24,7 +24,7 @@ use pallas::{
         minicbor::{Encode, Encoder},
         utils::Bytes,
     },
-    ledger::traverse::MultiEraTx,
+    ledger::traverse::MultiEraTxWithRawAuxiliary,
 };
 use rbac::{certs::C509Cert, role_data::RoleData};
 use strum::FromRepr;
@@ -189,7 +189,7 @@ impl Cip509 {
     ///
     /// Nothing.  IF CIP509 Metadata is found it will be updated in `decoded_metadata`.
     pub(crate) fn decode_and_validate(
-        decoded_metadata: &DecodedMetadata, txn: &MultiEraTx, raw_aux_data: &RawAuxData,
+        decoded_metadata: &DecodedMetadata, txn: &MultiEraTxWithRawAuxiliary, raw_aux_data: &RawAuxData,
         txn_idx: usize,
     ) {
         // Get the CIP509 metadata if possible
@@ -297,13 +297,13 @@ impl Cip509 {
     /// Transaction inputs hash validation.
     /// Must exist and match the hash of the transaction inputs.
     fn validate_txn_inputs_hash(
-        &self, txn: &MultiEraTx, validation_report: &mut ValidationReport,
+        &self, txn: &MultiEraTxWithRawAuxiliary, validation_report: &mut ValidationReport,
         decoded_metadata: &DecodedMetadata,
     ) -> Option<bool> {
         let mut buffer = Vec::new();
         let mut e = Encoder::new(&mut buffer);
         match txn {
-            MultiEraTx::AlonzoCompatible(tx, _) => {
+            MultiEraTxWithRawAuxiliary::AlonzoCompatible(tx, _) => {
                 let inputs = tx.transaction_body.inputs.clone();
                 if let Err(e) = e.array(inputs.len() as u64) {
                     self.validation_failure(
@@ -324,7 +324,7 @@ impl Cip509 {
                     }
                 }
             },
-            MultiEraTx::Babbage(tx) => {
+            MultiEraTxWithRawAuxiliary::Babbage(tx) => {
                 let inputs = tx.transaction_body.inputs.clone();
                 if let Err(e) = e.array(inputs.len() as u64) {
                     self.validation_failure(
@@ -345,7 +345,7 @@ impl Cip509 {
                     }
                 }
             },
-            MultiEraTx::Conway(tx) => {
+            MultiEraTxWithRawAuxiliary::Conway(tx) => {
                 let inputs = tx.transaction_body.inputs.clone();
                 if let Err(e) = e.array(inputs.len() as u64) {
                     self.validation_failure(
@@ -398,11 +398,11 @@ impl Cip509 {
     /// Also log out the pre-computed hash where the validation signature (99) set to
     /// zero.
     fn validate_aux(
-        &mut self, txn: &MultiEraTx, validation_report: &mut ValidationReport,
+        &mut self, txn: &MultiEraTxWithRawAuxiliary, validation_report: &mut ValidationReport,
         decoded_metadata: &DecodedMetadata,
     ) -> Option<bool> {
         match txn {
-            MultiEraTx::AlonzoCompatible(tx, _) => {
+            MultiEraTxWithRawAuxiliary::AlonzoCompatible(tx, _) => {
                 if let pallas::codec::utils::Nullable::Some(a) = &tx.auxiliary_data {
                     let original_aux = a.raw_cbor();
                     let aux_data_hash =
@@ -432,7 +432,7 @@ impl Cip509 {
                     None
                 }
             },
-            MultiEraTx::Babbage(tx) => {
+            MultiEraTxWithRawAuxiliary::Babbage(tx) => {
                 if let pallas::codec::utils::Nullable::Some(a) = &tx.auxiliary_data {
                     let original_aux = a.raw_cbor();
                     let aux_data_hash =
@@ -462,7 +462,7 @@ impl Cip509 {
                     None
                 }
             },
-            MultiEraTx::Conway(tx) => {
+            MultiEraTxWithRawAuxiliary::Conway(tx) => {
                 if let pallas::codec::utils::Nullable::Some(a) = &tx.auxiliary_data {
                     let original_aux = a.raw_cbor();
                     let aux_data_hash =
@@ -535,12 +535,12 @@ impl Cip509 {
     /// Validate the stake public key in the certificate with witness set in transaction.
     #[allow(clippy::too_many_lines)]
     fn validate_stake_public_key(
-        &self, txn: &MultiEraTx, validation_report: &mut ValidationReport,
+        &self, txn: &MultiEraTxWithRawAuxiliary, validation_report: &mut ValidationReport,
         decoded_metadata: &DecodedMetadata, txn_idx: usize,
     ) -> Option<bool> {
         let mut pk_addrs = Vec::new();
         match txn {
-            MultiEraTx::AlonzoCompatible(..) | MultiEraTx::Babbage(_) | MultiEraTx::Conway(_) => {
+            MultiEraTxWithRawAuxiliary::AlonzoCompatible(..) | MultiEraTxWithRawAuxiliary::Babbage(_) | MultiEraTxWithRawAuxiliary::Conway(_) => {
                 // X509 certificate
                 if let Some(x509_certs) = &self.x509_chunks.0.x509_certs {
                     for cert in x509_certs {
@@ -740,7 +740,7 @@ impl Cip509 {
     /// Validate the payment key
     #[allow(clippy::too_many_lines)]
     fn validate_payment_key(
-        &self, txn: &MultiEraTx, validation_report: &mut ValidationReport,
+        &self, txn: &MultiEraTxWithRawAuxiliary, validation_report: &mut ValidationReport,
         decoded_metadata: &DecodedMetadata, txn_idx: usize, role_data: &RoleData,
     ) -> Option<bool> {
         if let Some(payment_key) = role_data.payment_key {
@@ -754,7 +754,7 @@ impl Cip509 {
                 return None;
             }
             match txn {
-                MultiEraTx::AlonzoCompatible(tx, _) => {
+                MultiEraTxWithRawAuxiliary::AlonzoCompatible(tx, _) => {
                     // Handle negative payment keys (reference to tx output)
                     if payment_key < 0 {
                         let witness = match TxWitness::new(&[txn.clone()]) {
@@ -819,7 +819,7 @@ impl Cip509 {
                     }
                     return Some(true);
                 },
-                MultiEraTx::Babbage(tx) => {
+                MultiEraTxWithRawAuxiliary::Babbage(tx) => {
                     // Negative indicates reference to tx output
                     if payment_key < 0 {
                         let index = match decremented_index(payment_key.abs()) {
@@ -887,7 +887,7 @@ impl Cip509 {
                     }
                     return Some(true);
                 },
-                MultiEraTx::Conway(tx) => {
+                MultiEraTxWithRawAuxiliary::Conway(tx) => {
                     // Negative indicates reference to tx output
                     if payment_key < 0 {
                         let index = match decremented_index(payment_key.abs()) {
@@ -1025,7 +1025,7 @@ mod tests {
         .expect("Failed to decode hex block.")
     }
 
-    fn cip_509_aux_data(tx: &MultiEraTx<'_>) -> Vec<u8> {
+    fn cip_509_aux_data(tx: &pallas::ledger::traverse::MultiEraTxWithRawAuxiliary<'_>) -> Vec<u8> {
         let raw_auxiliary_data = tx
             .as_conway()
             .unwrap()
@@ -1079,7 +1079,7 @@ mod tests {
         let decoded_metadata = DecodedMetadata(DashMap::new());
         let mut validation_report = ValidationReport::new();
         let conway_block_data = conway_1();
-        let multi_era_block = pallas::ledger::traverse::MultiEraBlock::decode(&conway_block_data)
+        let multi_era_block = pallas::ledger::traverse::MultiEraBlockWithRawAuxiliary::decode(&conway_block_data)
             .expect("Failed to decode MultiEraBlock");
 
         let transactions = multi_era_block.txs();
@@ -1101,7 +1101,7 @@ mod tests {
         let decoded_metadata = DecodedMetadata(DashMap::new());
         let mut validation_report = ValidationReport::new();
         let conway_block_data = conway_1();
-        let multi_era_block = pallas::ledger::traverse::MultiEraBlock::decode(&conway_block_data)
+        let multi_era_block = pallas::ledger::traverse::MultiEraBlockWithRawAuxiliary::decode(&conway_block_data)
             .expect("Failed to decode MultiEraBlock");
 
         let transactions = multi_era_block.txs();
@@ -1124,7 +1124,7 @@ mod tests {
         let decoded_metadata = DecodedMetadata(DashMap::new());
         let mut validation_report = ValidationReport::new();
         let conway_block_data = conway_1();
-        let multi_era_block = pallas::ledger::traverse::MultiEraBlock::decode(&conway_block_data)
+        let multi_era_block = pallas::ledger::traverse::MultiEraBlockWithRawAuxiliary::decode(&conway_block_data)
             .expect("Failed to decode MultiEraBlock");
 
         let transactions = multi_era_block.txs();
@@ -1147,7 +1147,7 @@ mod tests {
         let decoded_metadata = DecodedMetadata(DashMap::new());
         let mut validation_report = ValidationReport::new();
         let conway_block_data = conway_1();
-        let multi_era_block = pallas::ledger::traverse::MultiEraBlock::decode(&conway_block_data)
+        let multi_era_block = pallas::ledger::traverse::MultiEraBlockWithRawAuxiliary::decode(&conway_block_data)
             .expect("Failed to decode MultiEraBlock");
 
         let transactions = multi_era_block.txs();
@@ -1183,7 +1183,7 @@ mod tests {
         let decoded_metadata = DecodedMetadata(DashMap::new());
         let mut validation_report = ValidationReport::new();
         let conway_block_data = conway_3();
-        let multi_era_block = pallas::ledger::traverse::MultiEraBlock::decode(&conway_block_data)
+        let multi_era_block = pallas::ledger::traverse::MultiEraBlockWithRawAuxiliary::decode(&conway_block_data)
             .expect("Failed to decode MultiEraBlock");
 
         let transactions = multi_era_block.txs();
@@ -1220,7 +1220,7 @@ mod tests {
         let decoded_metadata = DecodedMetadata(DashMap::new());
         let mut validation_report = ValidationReport::new();
         let conway_block_data = conway_2();
-        let multi_era_block = pallas::ledger::traverse::MultiEraBlock::decode(&conway_block_data)
+        let multi_era_block = pallas::ledger::traverse::MultiEraBlockWithRawAuxiliary::decode(&conway_block_data)
             .expect("Failed to decode MultiEraBlock");
 
         let transactions = multi_era_block.txs();

--- a/rust/cardano-chain-follower/src/metadata/cip509/mod.rs
+++ b/rust/cardano-chain-follower/src/metadata/cip509/mod.rs
@@ -189,8 +189,8 @@ impl Cip509 {
     ///
     /// Nothing.  IF CIP509 Metadata is found it will be updated in `decoded_metadata`.
     pub(crate) fn decode_and_validate(
-        decoded_metadata: &DecodedMetadata, txn: &MultiEraTxWithRawAuxiliary, raw_aux_data: &RawAuxData,
-        txn_idx: usize,
+        decoded_metadata: &DecodedMetadata, txn: &MultiEraTxWithRawAuxiliary,
+        raw_aux_data: &RawAuxData, txn_idx: usize,
     ) {
         // Get the CIP509 metadata if possible
         let Some(k509) = raw_aux_data.get_metadata(LABEL) else {
@@ -540,7 +540,9 @@ impl Cip509 {
     ) -> Option<bool> {
         let mut pk_addrs = Vec::new();
         match txn {
-            MultiEraTxWithRawAuxiliary::AlonzoCompatible(..) | MultiEraTxWithRawAuxiliary::Babbage(_) | MultiEraTxWithRawAuxiliary::Conway(_) => {
+            MultiEraTxWithRawAuxiliary::AlonzoCompatible(..)
+            | MultiEraTxWithRawAuxiliary::Babbage(_)
+            | MultiEraTxWithRawAuxiliary::Conway(_) => {
                 // X509 certificate
                 if let Some(x509_certs) = &self.x509_chunks.0.x509_certs {
                     for cert in x509_certs {
@@ -1079,8 +1081,9 @@ mod tests {
         let decoded_metadata = DecodedMetadata(DashMap::new());
         let mut validation_report = ValidationReport::new();
         let conway_block_data = conway_1();
-        let multi_era_block = pallas::ledger::traverse::MultiEraBlockWithRawAuxiliary::decode(&conway_block_data)
-            .expect("Failed to decode MultiEraBlock");
+        let multi_era_block =
+            pallas::ledger::traverse::MultiEraBlockWithRawAuxiliary::decode(&conway_block_data)
+                .expect("Failed to decode MultiEraBlock");
 
         let transactions = multi_era_block.txs();
         // Forth transaction of this test data contains the CIP509 auxiliary data
@@ -1101,8 +1104,9 @@ mod tests {
         let decoded_metadata = DecodedMetadata(DashMap::new());
         let mut validation_report = ValidationReport::new();
         let conway_block_data = conway_1();
-        let multi_era_block = pallas::ledger::traverse::MultiEraBlockWithRawAuxiliary::decode(&conway_block_data)
-            .expect("Failed to decode MultiEraBlock");
+        let multi_era_block =
+            pallas::ledger::traverse::MultiEraBlockWithRawAuxiliary::decode(&conway_block_data)
+                .expect("Failed to decode MultiEraBlock");
 
         let transactions = multi_era_block.txs();
         // Forth transaction of this test data contains the CIP509 auxiliary data
@@ -1124,8 +1128,9 @@ mod tests {
         let decoded_metadata = DecodedMetadata(DashMap::new());
         let mut validation_report = ValidationReport::new();
         let conway_block_data = conway_1();
-        let multi_era_block = pallas::ledger::traverse::MultiEraBlockWithRawAuxiliary::decode(&conway_block_data)
-            .expect("Failed to decode MultiEraBlock");
+        let multi_era_block =
+            pallas::ledger::traverse::MultiEraBlockWithRawAuxiliary::decode(&conway_block_data)
+                .expect("Failed to decode MultiEraBlock");
 
         let transactions = multi_era_block.txs();
         // Forth transaction of this test data contains the CIP509 auxiliary data
@@ -1147,8 +1152,9 @@ mod tests {
         let decoded_metadata = DecodedMetadata(DashMap::new());
         let mut validation_report = ValidationReport::new();
         let conway_block_data = conway_1();
-        let multi_era_block = pallas::ledger::traverse::MultiEraBlockWithRawAuxiliary::decode(&conway_block_data)
-            .expect("Failed to decode MultiEraBlock");
+        let multi_era_block =
+            pallas::ledger::traverse::MultiEraBlockWithRawAuxiliary::decode(&conway_block_data)
+                .expect("Failed to decode MultiEraBlock");
 
         let transactions = multi_era_block.txs();
         // Forth transaction of this test data contains the CIP509 auxiliary data
@@ -1183,8 +1189,9 @@ mod tests {
         let decoded_metadata = DecodedMetadata(DashMap::new());
         let mut validation_report = ValidationReport::new();
         let conway_block_data = conway_3();
-        let multi_era_block = pallas::ledger::traverse::MultiEraBlockWithRawAuxiliary::decode(&conway_block_data)
-            .expect("Failed to decode MultiEraBlock");
+        let multi_era_block =
+            pallas::ledger::traverse::MultiEraBlockWithRawAuxiliary::decode(&conway_block_data)
+                .expect("Failed to decode MultiEraBlock");
 
         let transactions = multi_era_block.txs();
         // First transaction of this test data contains the CIP509 auxiliary data
@@ -1220,8 +1227,9 @@ mod tests {
         let decoded_metadata = DecodedMetadata(DashMap::new());
         let mut validation_report = ValidationReport::new();
         let conway_block_data = conway_2();
-        let multi_era_block = pallas::ledger::traverse::MultiEraBlockWithRawAuxiliary::decode(&conway_block_data)
-            .expect("Failed to decode MultiEraBlock");
+        let multi_era_block =
+            pallas::ledger::traverse::MultiEraBlockWithRawAuxiliary::decode(&conway_block_data)
+                .expect("Failed to decode MultiEraBlock");
 
         let transactions = multi_era_block.txs();
         // Forth transaction of this test data contains the CIP509 auxiliary data

--- a/rust/cardano-chain-follower/src/metadata/mod.rs
+++ b/rust/cardano-chain-follower/src/metadata/mod.rs
@@ -50,7 +50,8 @@ pub(crate) struct DecodedMetadata(DashMap<u64, Arc<DecodedMetadataItem>>);
 impl DecodedMetadata {
     /// Create new decoded metadata for a transaction.
     fn new(
-        chain: Network, slot: u64, txn: &MultiEraTxWithRawAuxiliary, raw_aux_data: &RawAuxData, txn_idx: usize,
+        chain: Network, slot: u64, txn: &MultiEraTxWithRawAuxiliary, raw_aux_data: &RawAuxData,
+        txn_idx: usize,
     ) -> Self {
         let decoded_metadata = Self(DashMap::new());
 

--- a/rust/cardano-chain-follower/src/metadata/mod.rs
+++ b/rust/cardano-chain-follower/src/metadata/mod.rs
@@ -5,7 +5,7 @@ use std::{fmt::Debug, sync::Arc};
 use cip36::Cip36;
 use cip509::Cip509;
 use dashmap::DashMap;
-use pallas::ledger::traverse::{MultiEraBlock, MultiEraTx};
+use pallas::ledger::traverse::{MultiEraBlockWithRawAuxiliary, MultiEraTxWithRawAuxiliary};
 use raw_aux_data::RawAuxData;
 use tracing::error;
 
@@ -50,7 +50,7 @@ pub(crate) struct DecodedMetadata(DashMap<u64, Arc<DecodedMetadataItem>>);
 impl DecodedMetadata {
     /// Create new decoded metadata for a transaction.
     fn new(
-        chain: Network, slot: u64, txn: &MultiEraTx, raw_aux_data: &RawAuxData, txn_idx: usize,
+        chain: Network, slot: u64, txn: &MultiEraTxWithRawAuxiliary, raw_aux_data: &RawAuxData, txn_idx: usize,
     ) -> Self {
         let decoded_metadata = Self(DashMap::new());
 
@@ -98,7 +98,7 @@ impl DecodedTransaction {
     /// Insert another transaction worth of data into the Decoded Aux Data
     fn insert(
         &mut self, chain: Network, slot: u64, txn_idx: u32, cbor_data: &[u8],
-        transactions: &[MultiEraTx],
+        transactions: &[MultiEraTxWithRawAuxiliary],
     ) {
         let txn_idx = usize_from_saturating(txn_idx);
 
@@ -115,7 +115,7 @@ impl DecodedTransaction {
     }
 
     /// Create a new `DecodedTransaction`.
-    pub(crate) fn new(chain: Network, block: &MultiEraBlock) -> Self {
+    pub(crate) fn new(chain: Network, block: &MultiEraBlockWithRawAuxiliary) -> Self {
         let mut decoded_aux_data = DecodedTransaction {
             raw: DashMap::new(),
             decoded: DashMap::new(),

--- a/rust/cardano-chain-follower/src/mithril_snapshot_iterator.rs
+++ b/rust/cardano-chain-follower/src/mithril_snapshot_iterator.rs
@@ -86,8 +86,7 @@ impl MithrilSnapshotIterator {
 
             match next {
                 Some(Ok(raw_block)) => {
-                    let Ok(block) = MultiEraBlockWithRawAuxiliary::decode(&raw_block)
-                    else {
+                    let Ok(block) = MultiEraBlockWithRawAuxiliary::decode(&raw_block) else {
                         return None;
                     };
 
@@ -238,9 +237,7 @@ impl Iterator for MithrilSnapshotIteratorInner {
 
                 // We cannot fully decode this block because we don't know its previous point,
                 // So this MUST be the first block in iteration, so use it as the previous.
-                if let Ok(raw_decoded_block) =
-                MultiEraBlockWithRawAuxiliary::decode(&block)
-                {
+                if let Ok(raw_decoded_block) = MultiEraBlockWithRawAuxiliary::decode(&block) {
                     // debug!("Pre Previous update 2 : {:?}", self.previous);
                     self.previous =
                         Point::new(raw_decoded_block.slot(), raw_decoded_block.hash().to_vec());

--- a/rust/cardano-chain-follower/src/mithril_snapshot_iterator.rs
+++ b/rust/cardano-chain-follower/src/mithril_snapshot_iterator.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use logcall::logcall;
+use pallas::ledger::traverse::MultiEraBlockWithRawAuxiliary;
 use tokio::task;
 use tracing::{debug, error};
 use tracing_log::log;
@@ -85,7 +86,7 @@ impl MithrilSnapshotIterator {
 
             match next {
                 Some(Ok(raw_block)) => {
-                    let Ok(block) = pallas::ledger::traverse::MultiEraBlock::decode(&raw_block)
+                    let Ok(block) = MultiEraBlockWithRawAuxiliary::decode(&raw_block)
                     else {
                         return None;
                     };
@@ -238,7 +239,7 @@ impl Iterator for MithrilSnapshotIteratorInner {
                 // We cannot fully decode this block because we don't know its previous point,
                 // So this MUST be the first block in iteration, so use it as the previous.
                 if let Ok(raw_decoded_block) =
-                    pallas::ledger::traverse::MultiEraBlock::decode(&block)
+                MultiEraBlockWithRawAuxiliary::decode(&block)
                 {
                     // debug!("Pre Previous update 2 : {:?}", self.previous);
                     self.previous =

--- a/rust/cardano-chain-follower/src/multi_era_block_data.rs
+++ b/rust/cardano-chain-follower/src/multi_era_block_data.rs
@@ -10,6 +10,7 @@
 use std::{cmp::Ordering, fmt::Display, sync::Arc};
 
 use ouroboros::self_referencing;
+use pallas::ledger::traverse::MultiEraBlockWithRawAuxiliary;
 use tracing::debug;
 
 use crate::{
@@ -30,7 +31,7 @@ pub(crate) struct SelfReferencedMultiEraBlock {
     /// References the `raw_data` field.
     #[borrows(raw_data)]
     #[covariant]
-    block: pallas::ledger::traverse::MultiEraBlock<'this>,
+    block: MultiEraBlockWithRawAuxiliary<'this>,
 }
 
 /// Multi-era block - inner.
@@ -89,7 +90,7 @@ impl MultiEraBlock {
         let builder = SelfReferencedMultiEraBlockTryBuilder {
             raw_data,
             block_builder: |raw_data| -> Result<_, Error> {
-                pallas::ledger::traverse::MultiEraBlock::decode(raw_data)
+                MultiEraBlockWithRawAuxiliary::decode(raw_data)
                     .map_err(|err| Error::Codec(err.to_string()))
             },
         };
@@ -104,7 +105,7 @@ impl MultiEraBlock {
 
         let byron_block = matches!(
             decoded_block,
-            pallas::ledger::traverse::MultiEraBlock::Byron(_)
+            MultiEraBlockWithRawAuxiliary::Byron(_)
         );
 
         // debug!("New Block: {slot} {point} {}", *previous);
@@ -180,7 +181,7 @@ impl MultiEraBlock {
     /// The decoded block data, which can easily be processed by a consumer.
     #[must_use]
     #[allow(clippy::missing_panics_doc)]
-    pub fn decode(&self) -> &pallas::ledger::traverse::MultiEraBlock {
+    pub fn decode(&self) -> &MultiEraBlockWithRawAuxiliary {
         self.inner.data.borrow_block()
     }
 
@@ -308,15 +309,15 @@ impl Display for MultiEraBlock {
         };
 
         let block_era = match block {
-            pallas::ledger::traverse::MultiEraBlock::EpochBoundary(_) => {
+            MultiEraBlockWithRawAuxiliary::EpochBoundary(_) => {
                 "Byron Epoch Boundary".to_string()
             },
-            pallas::ledger::traverse::MultiEraBlock::AlonzoCompatible(_, era) => {
+            MultiEraBlockWithRawAuxiliary::AlonzoCompatible(_, era) => {
                 format!("{era}")
             },
-            pallas::ledger::traverse::MultiEraBlock::Babbage(_) => "Babbage".to_string(),
-            pallas::ledger::traverse::MultiEraBlock::Byron(_) => "Byron".to_string(),
-            pallas::ledger::traverse::MultiEraBlock::Conway(_) => "Conway".to_string(),
+            MultiEraBlockWithRawAuxiliary::Babbage(_) => "Babbage".to_string(),
+            MultiEraBlockWithRawAuxiliary::Byron(_) => "Byron".to_string(),
+            MultiEraBlockWithRawAuxiliary::Conway(_) => "Conway".to_string(),
             _ => "Unknown".to_string(),
         };
         write!(f, "{block_era} block : {}, Previous {} : Slot# {slot} : {fork} : Block# {block_number} : Size {size} : Txns {txns} : AuxData? {aux_data}",
@@ -373,6 +374,7 @@ pub(crate) mod tests {
 
     use anyhow::Ok;
 
+    use super::*;
     use crate::{point::ORIGIN_POINT, MultiEraBlock, Network, Point};
 
     struct TestRecord {
@@ -457,7 +459,7 @@ pub(crate) mod tests {
     fn test_multi_era_block_point_compare_1() -> anyhow::Result<()> {
         for (i, test_block) in test_blocks().into_iter().enumerate() {
             let pallas_block =
-                pallas::ledger::traverse::MultiEraBlock::decode(test_block.raw.as_slice())?;
+                MultiEraBlockWithRawAuxiliary::decode(test_block.raw.as_slice())?;
 
             let previous_point = Point::new(
                 pallas_block.slot().add(i as u64),
@@ -482,7 +484,7 @@ pub(crate) mod tests {
     fn test_multi_era_block_point_compare_2() -> anyhow::Result<()> {
         for test_block in test_blocks() {
             let pallas_block =
-                pallas::ledger::traverse::MultiEraBlock::decode(test_block.raw.as_slice())?;
+                MultiEraBlockWithRawAuxiliary::decode(test_block.raw.as_slice())?;
 
             let previous_point = Point::new(pallas_block.slot() - 1, vec![0; 32]);
 
@@ -500,7 +502,7 @@ pub(crate) mod tests {
     fn test_multi_era_block_point_compare_3() -> anyhow::Result<()> {
         for test_block in test_blocks() {
             let pallas_block =
-                pallas::ledger::traverse::MultiEraBlock::decode(test_block.raw.as_slice())?;
+                MultiEraBlockWithRawAuxiliary::decode(test_block.raw.as_slice())?;
 
             let previous_point = Point::new(
                 pallas_block.slot() - 1,
@@ -525,7 +527,7 @@ pub(crate) mod tests {
         raw_blocks
             .iter()
             .map(|block| {
-                let prev_point = pallas::ledger::traverse::MultiEraBlock::decode(block.as_slice())
+                let prev_point = MultiEraBlockWithRawAuxiliary::decode(block.as_slice())
                     .map(|block| {
                         Point::new(
                             block.slot() - 1,
@@ -549,7 +551,7 @@ pub(crate) mod tests {
         raw_blocks
             .iter()
             .map(|block| {
-                pallas::ledger::traverse::MultiEraBlock::decode(block.as_slice())
+                MultiEraBlockWithRawAuxiliary::decode(block.as_slice())
                     .map(|block| {
                         Point::new(
                             block.slot(),

--- a/rust/cardano-chain-follower/src/multi_era_block_data.rs
+++ b/rust/cardano-chain-follower/src/multi_era_block_data.rs
@@ -103,10 +103,7 @@ impl MultiEraBlock {
 
         let point = Point::new(slot, decoded_block.hash().to_vec());
 
-        let byron_block = matches!(
-            decoded_block,
-            MultiEraBlockWithRawAuxiliary::Byron(_)
-        );
+        let byron_block = matches!(decoded_block, MultiEraBlockWithRawAuxiliary::Byron(_));
 
         // debug!("New Block: {slot} {point} {}", *previous);
 
@@ -309,9 +306,7 @@ impl Display for MultiEraBlock {
         };
 
         let block_era = match block {
-            MultiEraBlockWithRawAuxiliary::EpochBoundary(_) => {
-                "Byron Epoch Boundary".to_string()
-            },
+            MultiEraBlockWithRawAuxiliary::EpochBoundary(_) => "Byron Epoch Boundary".to_string(),
             MultiEraBlockWithRawAuxiliary::AlonzoCompatible(_, era) => {
                 format!("{era}")
             },
@@ -458,8 +453,7 @@ pub(crate) mod tests {
     #[test]
     fn test_multi_era_block_point_compare_1() -> anyhow::Result<()> {
         for (i, test_block) in test_blocks().into_iter().enumerate() {
-            let pallas_block =
-                MultiEraBlockWithRawAuxiliary::decode(test_block.raw.as_slice())?;
+            let pallas_block = MultiEraBlockWithRawAuxiliary::decode(test_block.raw.as_slice())?;
 
             let previous_point = Point::new(
                 pallas_block.slot().add(i as u64),
@@ -483,8 +477,7 @@ pub(crate) mod tests {
     #[test]
     fn test_multi_era_block_point_compare_2() -> anyhow::Result<()> {
         for test_block in test_blocks() {
-            let pallas_block =
-                MultiEraBlockWithRawAuxiliary::decode(test_block.raw.as_slice())?;
+            let pallas_block = MultiEraBlockWithRawAuxiliary::decode(test_block.raw.as_slice())?;
 
             let previous_point = Point::new(pallas_block.slot() - 1, vec![0; 32]);
 
@@ -501,8 +494,7 @@ pub(crate) mod tests {
     #[test]
     fn test_multi_era_block_point_compare_3() -> anyhow::Result<()> {
         for test_block in test_blocks() {
-            let pallas_block =
-                MultiEraBlockWithRawAuxiliary::decode(test_block.raw.as_slice())?;
+            let pallas_block = MultiEraBlockWithRawAuxiliary::decode(test_block.raw.as_slice())?;
 
             let previous_point = Point::new(
                 pallas_block.slot() - 1,

--- a/rust/cardano-chain-follower/src/witness.rs
+++ b/rust/cardano-chain-follower/src/witness.rs
@@ -117,8 +117,9 @@ mod tests {
         assert!(tx_witness_alonzo.check_witness_in_tx(&vkey1_hash, 0));
 
         let babbage = babbage_block();
-        let babbage_block = pallas::ledger::traverse::MultiEraBlockWithRawAuxiliary::decode(&babbage)
-            .expect("Failed to decode MultiEraBlock");
+        let babbage_block =
+            pallas::ledger::traverse::MultiEraBlockWithRawAuxiliary::decode(&babbage)
+                .expect("Failed to decode MultiEraBlock");
         let txs_babbage = babbage_block.txs();
         let tx_witness_babbage = TxWitness::new(&txs_babbage).expect("Failed to create TxWitness");
         let vkey2_hash: [u8; 28] =


### PR DESCRIPTION
# Description

Updated `MultiEraBlock` and `MultiEraTx` to use with `WithRawAuxiliary` suffix.
According to this [fix](https://github.com/input-output-hk/catalyst-pallas/pull/2)

## Related Issue(s)

Closes [#1037](https://github.com/input-output-hk/catalyst-voices/issues/1037)

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
