### PR TITLE
feat(rust/catalyst-voting): Parallel iter usage for `fn encrypt_vote`

### DIFF
--- a/rust/catalyst-voting/Cargo.toml
+++ b/rust/catalyst-voting/Cargo.toml
@@ -23,6 +23,7 @@ rand_chacha = "0.3.1"
 curve25519-dalek = { version = "4.1.3", features = ["digest", "rand_core"] }
 ed25519-dalek = { version = "2.1.1", features = ["rand_core"] }
 blake2b_simd = "1.0.2"
+rayon = "1.10.0"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/rust/catalyst-voting/src/vote_protocol/voter/mod.rs
+++ b/rust/catalyst-voting/src/vote_protocol/voter/mod.rs
@@ -5,6 +5,7 @@ pub mod proof;
 
 use anyhow::{anyhow, bail, ensure};
 use rand_core::CryptoRngCore;
+use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 
 use super::committee::{ElectionPublicKey, ElectionSecretKey};
 use crate::crypto::{
@@ -97,8 +98,8 @@ pub fn encrypt_vote<R: CryptoRngCore>(
 
     let unit_vector = vote.to_unit_vector();
     let ciphers = unit_vector
-        .iter()
-        .zip(randomness.0.iter())
+        .par_iter()
+        .zip(randomness.0.par_iter())
         .map(|(m, r)| encrypt(m, &public_key.0, r))
         .collect();
 


### PR DESCRIPTION
# Description

- Added `rayon` lib
- Updated `encrypt_vote` function with the parallel iterator usage.

Performance measurements on `Apple M1`
Old version:
```
vote protocol benchmark/vote encryption
                        time:   [243.70 µs 243.88 µs 244.14 µs]
```
New version:
```
vote protocol benchmark/vote encryption
                        time:   [139.87 µs 141.72 µs 144.27 µs]
                        change: [-42.351% -41.334% -40.375%] (p = 0.00 < 0.05)
                        Performance has improved.
```