### PR TITLE
feat(rust/vote-tx-v2): Finish `GeneralisedTx` CBOR decoding functionality

### DIFF
--- a/rust/vote-tx-v1/src/decoding.rs
+++ b/rust/vote-tx-v1/src/decoding.rs
@@ -1,4 +1,5 @@
 //! V1 transaction objects decoding implementation.
+//! <https://input-output-hk.github.io/catalyst-libs/architecture/08_concepts/catalyst_voting/abnf/jorm.abnf>
 
 use std::io::Read;
 

--- a/rust/vote-tx-v2/Cargo.toml
+++ b/rust/vote-tx-v2/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 [dependencies]
 anyhow = "1.0.89"
 minicbor = { version = "0.25.1", features = ["alloc", "half"] }
+coset = { version = "0.3.8" }
 
 [dev-dependencies]
 proptest = { version = "1.5.0" }

--- a/rust/vote-tx-v2/Cargo.toml
+++ b/rust/vote-tx-v2/Cargo.toml
@@ -15,10 +15,11 @@ workspace = true
 
 [dependencies]
 anyhow = "1.0.89"
-minicbor = { version = "0.25.1", features = ["alloc"] }
+minicbor = { version = "0.25.1", features = ["alloc", "half"] }
 
 [dev-dependencies]
 proptest = { version = "1.5.0" }
+proptest-derive = { version = "0.5.0" }
 # Potentially it could be replaced with using `proptest::property_test` attribute macro,
 # after this PR will be merged https://github.com/proptest-rs/proptest/pull/523
 test-strategy = "0.4.0"

--- a/rust/vote-tx-v2/src/decoding.rs
+++ b/rust/vote-tx-v2/src/decoding.rs
@@ -407,8 +407,7 @@ mod tests {
             voter_data: VoterData(voter_data),
         };
 
-        let signature = coset::CoseSign::default();
-        let generalized_tx = GeneralizedTx { tx_body, signature };
+        let generalized_tx = GeneralizedTx::new(tx_body);
 
         let bytes = generalized_tx.to_bytes().unwrap();
         let decoded = GeneralizedTx::from_bytes(&bytes).unwrap();

--- a/rust/vote-tx-v2/src/decoding.rs
+++ b/rust/vote-tx-v2/src/decoding.rs
@@ -36,9 +36,12 @@ impl Decode<'_, ()> for GeneralizedTx {
         let signature = {
             let sign_bytes = read_cbor_bytes(d)
                 .map_err(|_| minicbor::decode::Error::message("missing `signature` field"))?;
-            coset::CoseSign::from_slice(&sign_bytes).map_err(|_| {
+            let mut sign = coset::CoseSign::from_slice(&sign_bytes).map_err(|_| {
                 minicbor::decode::Error::message("`signature` must be COSE_Sign encoded object")
-            })?
+            })?;
+            // We dont need to hold the original encoded data of the COSE protected header
+            sign.protected.original_data = None;
+            sign
         };
 
         Ok(Self { tx_body, signature })

--- a/rust/vote-tx-v2/src/decoding.rs
+++ b/rust/vote-tx-v2/src/decoding.rs
@@ -39,7 +39,7 @@ impl Decode<'_, ()> for GeneralizedTx {
             let mut sign = coset::CoseSign::from_slice(&sign_bytes).map_err(|_| {
                 minicbor::decode::Error::message("`signature` must be COSE_Sign encoded object")
             })?;
-            // We dont need to hold the original encoded data of the COSE protected header
+            // We don't need to hold the original encoded data of the COSE protected header
             sign.protected.original_data = None;
             sign
         };

--- a/rust/vote-tx-v2/src/lib.rs
+++ b/rust/vote-tx-v2/src/lib.rs
@@ -72,6 +72,24 @@ pub struct Proof(Vec<u8>);
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PropId(Vec<u8>);
 
+impl GeneralizedTx {
+    /// Creates a new `GeneralizedTx` struct.
+    #[must_use]
+    pub fn new(tx_body: TxBody) -> Self {
+        let signature = coset::CoseSignBuilder::new()
+            .protected(Self::cose_protected_header())
+            .build();
+        Self { tx_body, signature }
+    }
+
+    /// Returns the COSE protected header.
+    fn cose_protected_header() -> coset::Header {
+        coset::HeaderBuilder::new()
+            .content_format(coset::iana::CoapContentFormat::Cbor)
+            .build()
+    }
+}
+
 /// Cbor encodable and decodable type trait.
 pub trait Cbor<'a>: Encode<()> + Decode<'a, ()> {
     /// Encodes to CBOR encoded bytes.

--- a/rust/vote-tx-v2/src/lib.rs
+++ b/rust/vote-tx-v2/src/lib.rs
@@ -2,7 +2,7 @@
 //! [spec](https://input-output-hk.github.io/catalyst-libs/architecture/08_concepts/catalyst_voting/v2/)
 
 use anyhow::anyhow;
-use minicbor::{Decode, Decoder, Encode, Encoder};
+use minicbor::{data::Int, Decode, Decoder, Encode, Encoder};
 
 mod decoding;
 
@@ -18,6 +18,8 @@ pub struct GeneralizedTx {
 pub struct TxBody {
     /// `vote-type` field
     vote_type: Uuid,
+    /// `event` field
+    event: EventMap,
     /// `votes` field
     votes: Vec<Vote>,
     /// `voter-data` field
@@ -33,6 +35,19 @@ pub struct Vote {
     proof: Proof,
     /// `prop-id` field
     prop_id: PropId,
+}
+
+/// A CBOR map
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EventMap(Vec<(EventKey, Vec<u8>)>);
+
+/// An `event-key` type defintion.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EventKey {
+    /// CBOR `int` type
+    Int(Int),
+    /// CBOR `text` type
+    Text(String),
 }
 
 /// A UUID struct.

--- a/rust/vote-tx-v2/src/lib.rs
+++ b/rust/vote-tx-v2/src/lib.rs
@@ -7,10 +7,12 @@ use minicbor::{data::Int, Decode, Decoder, Encode, Encoder};
 mod decoding;
 
 /// A generalized tx struct.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct GeneralizedTx {
-    /// `tx-body`
+    /// `tx-body` field
     tx_body: TxBody,
+    /// `signature` field
+    signature: coset::CoseSign,
 }
 
 /// A tx body struct.

--- a/rust/vote-tx-v2/src/lib.rs
+++ b/rust/vote-tx-v2/src/lib.rs
@@ -1,6 +1,8 @@
 //! A Catalyst vote transaction v1 object, structured following this
 //! [spec](https://input-output-hk.github.io/catalyst-libs/architecture/08_concepts/catalyst_voting/v2/)
 
+// cspell: words Coap
+
 use anyhow::anyhow;
 use minicbor::{data::Int, Decode, Decoder, Encode, Encoder};
 
@@ -43,7 +45,7 @@ pub struct Vote {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EventMap(Vec<(EventKey, Vec<u8>)>);
 
-/// An `event-key` type defintion.
+/// An `event-key` type definition.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EventKey {
     /// CBOR `int` type


### PR DESCRIPTION
# Description

Added a final pieces for the `GeneralisedTx` CBOR decoding functionality.

## Related Issue(s)

Closes #75

## Description of Changes

- Added missing `signature: coset::CoseSign` field with decoding implementation.
- Added missing `event: EventMap` field and underlying structs with decoding implementation.
