### PR TITLE
fix(rust/rbac-registration): Record CIP509 validation data

### DIFF
--- a/rust/rbac-registration/Cargo.toml
+++ b/rust/rbac-registration/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rbac-registration"
 description = "Role Based Access Control Registration"
 keywords = ["cardano", "catalyst", "rbac registration"]
-version = "0.0.1"
+version = "0.0.2"
 authors = [
     "Arissara Chotivichit <arissara.chotivichit@iohk.io>"
 ]

--- a/rust/rbac-registration/src/utils/general.rs
+++ b/rust/rbac-registration/src/utils/general.rs
@@ -25,3 +25,10 @@ pub(crate) fn decode_utf8(content: &[u8]) -> anyhow::Result<String> {
             )
         })
 }
+
+/// Zero out the last n bytes
+pub(crate) fn zero_out_last_n_bytes(vec: &mut [u8], n: usize) {
+    if let Some(slice) = vec.get_mut(vec.len().saturating_sub(n)..) {
+        slice.fill(0);
+    }
+}


### PR DESCRIPTION
# Description

- Create a struct that hold the validation result of CIP509, also include any additional data computed from the validation (currently contains precomputed auxiliary)

