### PR TITLE
fix(rbac-registration): Fix extraction of Cardano Addresses from a cardano address URI string

### DIFF
--- a/rust/rbac-registration/src/cardano/cip509/utils/cip134.rs
+++ b/rust/rbac-registration/src/cardano/cip509/utils/cip134.rs
@@ -1,0 +1,111 @@
+//! Utility functions for CIP-0134 address.
+
+use anyhow::{anyhow, Context, Result};
+use pallas::ledger::addresses::Address;
+
+/// Parses CIP-0134 URI and returns an address.
+///
+/// # Errors
+/// - Invalid URI.
+///
+/// # Examples
+///
+/// ```
+/// use pallas::ledger::addresses::{Address, Network};
+/// use rbac_registration::cardano::cip509::utils::parse_cip0134_uri;
+///
+/// let uri = "web+cardano://addr/stake1uyehkck0lajq8gr28t9uxnuvgcqrc6070x3k9r8048z8y5gh6ffgw";
+/// let Address::Stake(address) = parse_cip0134_uri(uri).unwrap() else {
+///     panic!("Unexpected address type");
+/// };
+/// assert_eq!(address.network(), Network::Mainnet);
+/// ```
+pub fn parse_cip0134_uri(uri: &str) -> Result<Address> {
+    let bech32 = uri
+        .strip_prefix("web+cardano://addr/")
+        .ok_or_else(|| anyhow!("Missing schema part of URI"))?;
+    Address::from_bech32(bech32).context("Unable to parse bech32 part of URI")
+}
+
+#[cfg(test)]
+mod tests {
+    use pallas::ledger::addresses::{Address, Network};
+
+    use super::*;
+
+    #[test]
+    fn invalid_prefix() {
+        let test_uris = [
+            "addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x",
+            "//addr/addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x",
+            "web+cardano:/addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x",
+            "somthing+unexpected://addr/addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x",
+        ];
+
+        for uri in test_uris {
+            let err = format!("{:?}", parse_cip0134_uri(uri).expect_err(&format!("{uri}")));
+            assert_eq!("Missing schema part of URI", err);
+        }
+    }
+
+    #[test]
+    fn invalid_bech32() {
+        let uri = "web+cardano://addr/adr1qx2fxv2umyh";
+        let err = format!("{:?}", parse_cip0134_uri(uri).unwrap_err());
+        assert!(err.starts_with("Unable to parse bech32 part of URI"));
+    }
+
+    #[test]
+    fn stake_address() {
+        let test_data = [
+            (
+                "web+cardano://addr/stake_test1uqehkck0lajq8gr28t9uxnuvgcqrc6070x3k9r8048z8y5gssrtvn",
+                Network::Testnet,
+                "337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251",
+            ),
+            (
+                "web+cardano://addr/stake1uyehkck0lajq8gr28t9uxnuvgcqrc6070x3k9r8048z8y5gh6ffgw",
+                Network::Mainnet,
+                "337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251",
+            ),
+            (
+                "web+cardano://addr/drep_vk17axh4sc9zwkpsft3tlgpjemfwc0u5mnld80r85zw7zdqcst6w54sdv4a4e",
+                Network::Other(7),
+                "4d7ac30513ac1825715fd0196769761fca6e7f69de33d04ef09a0c41",
+            )
+        ];
+
+        for (uri, network, payload) in test_data {
+            let Address::Stake(address) = parse_cip0134_uri(uri).unwrap() else {
+                panic!("Unexpected address type ({uri})");
+            };
+            assert_eq!(network, address.network());
+            assert_eq!(payload, address.payload().as_hash().to_string());
+        }
+    }
+
+    #[test]
+    fn shelley_address() {
+        let test_data = [
+            (
+                "web+cardano://addr/addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x",
+                Network::Mainnet,
+            ),
+            (
+                "web+cardano://addr/addr_test1gz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer5pnz75xxcrdw5vky",
+                Network::Testnet,
+            ),
+            (
+                "web+cardano://addr/cc_hot_vk10y48lq72hypxraew74lwjjn9e2dscuwphckglh2nrrpkgweqk5hschnzv5",
+                Network::Other(9),
+            )
+        ];
+
+        for (uri, network) in test_data {
+            let Address::Shelley(address) = parse_cip0134_uri(uri).unwrap() else {
+                panic!("Unexpected address type ({uri})");
+            };
+            assert_eq!(network, address.network());
+        }
+    }
+}

--- a/rust/rbac-registration/src/cardano/cip509/utils/cip19.rs
+++ b/rust/rbac-registration/src/cardano/cip509/utils/cip19.rs
@@ -1,38 +1,8 @@
 //! Utility functions for CIP-19 address.
 
 use anyhow::bail;
-use regex::Regex;
 
 use crate::cardano::transaction::witness::TxWitness;
-
-/// Extracts the CIP-19 bytes from a URI.
-/// Example input: `web+cardano://addr/<cip-19 address string>`
-/// <https://github.com/cardano-foundation/CIPs/tree/6bae5165dde5d803778efa5e93bd408f3317ca03/CPS-0016>
-/// URI = scheme ":" ["//" authority] path ["?" query] ["#" fragment]
-#[must_use]
-pub fn extract_cip19_hash(uri: &str, prefix: Option<&str>) -> Option<Vec<u8>> {
-    // Regex pattern to match the expected URI format
-    let r = Regex::new("^.+://addr/(.+)$").ok()?;
-
-    // Apply the regex pattern to capture the CIP-19 address string
-    let address = r
-        .captures(uri)
-        .and_then(|cap| cap.get(1).map(|m| m.as_str().to_string()));
-
-    match address {
-        Some(addr) => {
-            if let Some(prefix) = prefix {
-                if !addr.starts_with(prefix) {
-                    return None;
-                }
-            }
-            let addr = bech32::decode(&addr).ok()?.1;
-            // As in CIP19, the first byte is the header, so extract only the payload
-            extract_key_hash(&addr)
-        },
-        None => None,
-    }
-}
 
 /// Extract the first 28 bytes from the given key
 /// Refer to <https://cips.cardano.org/cip/CIP-19> for more information.
@@ -66,72 +36,4 @@ pub(crate) fn compare_key_hash(
 
         Ok(())
     })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    // Test data from https://cips.cardano.org/cip/CIP-19
-    // cSpell:disable
-    const STAKE_ADDR: &str = "stake_test1uqehkck0lajq8gr28t9uxnuvgcqrc6070x3k9r8048z8y5gssrtvn";
-    const PAYMENT_ADDR: &str = "addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgs68faae";
-    // cSpell:enable
-
-    #[test]
-    fn test_extract_cip19_hash_with_stake() {
-        // Additional tools to check for bech32 https://slowli.github.io/bech32-buffer/
-        let uri = &format!("web+cardano://addr/{STAKE_ADDR}");
-        // Given:
-        // e0337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251
-        // The first byte is the header, so extract only the payload
-        let bytes = hex::decode("337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251")
-            .expect("Failed to decode bytes");
-        assert_eq!(
-            extract_cip19_hash(uri, Some("stake")).expect("Failed to extract CIP-19 hash"),
-            bytes
-        );
-    }
-
-    #[test]
-    fn test_extract_cip19_hash_with_addr_with_prefix_set() {
-        let uri = &format!("web+cardano://addr/{PAYMENT_ADDR}");
-        let result = extract_cip19_hash(uri, Some("stake"));
-        assert_eq!(result, None);
-    }
-
-    #[test]
-    fn test_extract_cip19_hash_with_addr_without_prefix_set() {
-        let uri = &format!("web+cardano://addr/{PAYMENT_ADDR}");
-        let result = extract_cip19_hash(uri, None);
-        assert!(result.is_some());
-    }
-
-    #[test]
-    fn test_extract_cip19_hash_invalid_uri() {
-        let uri = "invalid_uri";
-        let result = extract_cip19_hash(uri, None);
-        assert_eq!(result, None);
-    }
-
-    #[test]
-    fn test_extract_cip19_hash_non_bech32_address() {
-        let uri = "example://addr/not_bech32";
-        let result = extract_cip19_hash(uri, None);
-        assert_eq!(result, None);
-    }
-
-    #[test]
-    fn test_extract_cip19_hash_empty_uri() {
-        let uri = "";
-        let result = extract_cip19_hash(uri, None);
-        assert_eq!(result, None);
-    }
-
-    #[test]
-    fn test_extract_cip19_hash_no_address() {
-        let uri = "example://addr/";
-        let result = extract_cip19_hash(uri, None);
-        assert_eq!(result, None);
-    }
 }

--- a/rust/rbac-registration/src/cardano/cip509/utils/mod.rs
+++ b/rust/rbac-registration/src/cardano/cip509/utils/mod.rs
@@ -1,3 +1,6 @@
 //! Utility functions for CIP-509
 
 pub mod cip19;
+pub use cip134::parse_cip0134_uri;
+
+mod cip134;

--- a/rust/rbac-registration/src/cardano/cip509/validation.rs
+++ b/rust/rbac-registration/src/cardano/cip509/validation.rs
@@ -28,7 +28,7 @@ use pallas::{
         minicbor::{Encode, Encoder},
         utils::Bytes,
     },
-    ledger::traverse::MultiEraTx,
+    ledger::{addresses::Address, traverse::MultiEraTx},
 };
 use x509_cert::der::{oid::db::rfc5912::ID_CE_SUBJECT_ALT_NAME, Decode};
 
@@ -38,7 +38,10 @@ use super::{
         certs::{C509Cert, X509DerCert},
         role_data::{LocalRefInt, RoleData},
     },
-    utils::cip19::{compare_key_hash, extract_cip19_hash, extract_key_hash},
+    utils::{
+        cip19::{compare_key_hash, extract_key_hash},
+        parse_cip0134_uri,
+    },
     Cip509, TxInputHash, TxWitness,
 };
 use crate::utils::general::zero_out_last_n_bytes;
@@ -166,10 +169,11 @@ pub(crate) fn validate_stake_public_key(
 
                                                     // Extract the CIP19 hash and push into
                                                     // array
-                                                    if let Some(h) =
-                                                        extract_cip19_hash(&addr, Some("stake"))
+                                                    if let Ok(Address::Stake(a)) =
+                                                        parse_cip0134_uri(&addr)
                                                     {
-                                                        pk_addrs.push(h);
+                                                        pk_addrs
+                                                            .push(a.payload().as_hash().to_vec());
                                                     }
                                                 },
                                                 Err(e) => {
@@ -218,9 +222,9 @@ pub(crate) fn validate_stake_public_key(
                                                             if name.gn_type() == &c509_certificate::general_names::general_name::GeneralNameTypeRegistry::UniformResourceIdentifier {
                                                                 match name.gn_value() {
                                                                     GeneralNameValue::Text(s) => {
-                                                                            if let Some(h) = extract_cip19_hash(s, Some("stake")) {
-                                                                                pk_addrs.push(h);
-                                                                            }
+                                                                        if let Ok(Address::Stake(a)) = parse_cip0134_uri(s) {
+                                                                            pk_addrs.push(a.payload().as_hash().to_vec());
+                                                                        }
                                                                     },
                                                                     _ => {
                                                                         validation_report.push(


### PR DESCRIPTION
# Description

- The `extract_cip19_hash` was replaced by `parse_cip0134_uri`.

## Related Issue(s)

Closes https://github.com/input-output-hk/catalyst-libs/issues/100.

## Breaking Changes

- The `extract_cip19_hash` function was removed.

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
