### PR TITLE
feat(rust/rbac-registration): Store decoded x509 certificates

### DIFF
--- a/rust/rbac-registration/src/cardano/cip509/utils/cip134/uri_set.rs
+++ b/rust/rbac-registration/src/cardano/cip509/utils/cip134/uri_set.rs
@@ -10,7 +10,7 @@ use c509_certificate::{
 };
 use der_parser::der::parse_der_sequence;
 use tracing::debug;
-use x509_cert::der::{oid::db::rfc5912::ID_CE_SUBJECT_ALT_NAME, Decode};
+use x509_cert::der::oid::db::rfc5912::ID_CE_SUBJECT_ALT_NAME;
 
 use crate::{
     cardano::cip509::{
@@ -81,8 +81,6 @@ fn extract_x509_uris(certificates: &[X509DerCert]) -> Result<UrisMap> {
         let X509DerCert::X509Cert(cert) = cert else {
             continue;
         };
-        let cert = x509_cert::Certificate::from_der(cert)
-            .with_context(|| "Failed to decode X509 certificate from DER")?;
         // Find the "subject alternative name" extension.
         let Some(extension) = cert
             .tbs_certificate


### PR DESCRIPTION
# Description

- Store x509 certificates (`Cip509RbacMetadata::x509_certs`) in the decoded format.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
