### PR TITLE
feat(rust/rbac-registration): Store and update certificate URIs in the registration chain

### DIFF
--- a/rust/rbac-registration/src/cardano/cip509/utils/cip134/uri.rs
+++ b/rust/rbac-registration/src/cardano/cip509/utils/cip134/uri.rs
@@ -13,7 +13,7 @@ use pallas::ledger::addresses::Address;
 /// See the [proposal] for more details.
 ///
 /// [proposal]: https://github.com/cardano-foundation/CIPs/pull/888
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 #[allow(clippy::module_name_repetitions)]
 pub struct Cip0134Uri {
     /// A URI string.


### PR DESCRIPTION
# Description

- Store and update certificate URIs in the `RegistrationChain` structure.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
