### PR TITLE
fix(rust/cardano-blockchain-types): Expose function in `txn_index`

### DIFF
--- a/rust/cardano-blockchain-types/src/txn_index.rs
+++ b/rust/cardano-blockchain-types/src/txn_index.rs
@@ -8,7 +8,7 @@ pub struct TxnIndex(u16);
 
 impl TxnIndex {
     /// Convert an `<T>` to transaction index (saturate if out of range).
-    pub(crate) fn from_saturating<
+    pub fn from_saturating<
         T: Copy
             + TryInto<u16>
             + std::ops::Sub<Output = T>


### PR DESCRIPTION
Make `from_saturating` in `TxnIndex` public