### PR TITLE
fix(rust/catalyst-types): Add serde::Serialize to UUID types

### DIFF
--- a/rust/catalyst-types/src/uuid/uuid_v4.rs
+++ b/rust/catalyst-types/src/uuid/uuid_v4.rs
@@ -4,8 +4,9 @@ use std::fmt::{Display, Formatter};
 use super::{decode_cbor_uuid, INVALID_UUID};
 
 /// Type representing a `UUIDv4`.
-#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, serde::Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
 #[serde(from = "uuid::Uuid")]
+#[serde(into = "uuid::Uuid")]
 pub struct UuidV4 {
     /// UUID
     uuid: uuid::Uuid,
@@ -66,6 +67,15 @@ impl TryFrom<&coset::cbor::Value> for UuidV4 {
 impl From<uuid::Uuid> for UuidV4 {
     fn from(uuid: uuid::Uuid) -> Self {
         Self { uuid }
+    }
+}
+
+/// Returns a `uuid::Uuid` from `UUIDv4`.
+///
+/// NOTE: This does not guarantee that the `UUID` is valid.
+impl From<UuidV4> for uuid::Uuid {
+    fn from(value: UuidV4) -> Self {
+        value.uuid
     }
 }
 

--- a/rust/catalyst-types/src/uuid/uuid_v7.rs
+++ b/rust/catalyst-types/src/uuid/uuid_v7.rs
@@ -4,8 +4,9 @@ use std::fmt::{Display, Formatter};
 use super::{decode_cbor_uuid, INVALID_UUID};
 
 /// Type representing a `UUIDv7`.
-#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, serde::Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
 #[serde(from = "uuid::Uuid")]
+#[serde(into = "uuid::Uuid")]
 pub struct UuidV7 {
     /// UUID
     uuid: uuid::Uuid,
@@ -66,6 +67,15 @@ impl TryFrom<&coset::cbor::Value> for UuidV7 {
 impl From<uuid::Uuid> for UuidV7 {
     fn from(uuid: uuid::Uuid) -> Self {
         Self { uuid }
+    }
+}
+
+/// Returns a `uuid::Uuid` from `UUIDv7`.
+///
+/// NOTE: This does not guarantee that the `UUID` is valid.
+impl From<UuidV7> for uuid::Uuid {
+    fn from(value: UuidV7) -> Self {
+        value.uuid
     }
 }
 


### PR DESCRIPTION
# Description

Derive `serde::Serialize` for `UUIDV4` and `UUIDV7`.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
