### PR TITLE
feat(rust/cardano-blockchain-types): Add `Network` variants index

### DIFF
--- a/rust/cardano-blockchain-types/src/network.rs
+++ b/rust/cardano-blockchain-types/src/network.rs
@@ -37,13 +37,15 @@ pub(crate) const ENVVAR_MITHRIL_EXE_NAME: &str = "MITHRIL_EXE_NAME";
     strum::Display,
 )]
 #[strum(ascii_case_insensitive)]
+#[strum(serialize_all = "snake_case")]
+#[repr(usize)]
 pub enum Network {
     /// Cardano mainnet network.
-    Mainnet,
+    Mainnet = 0,
     /// Cardano pre-production network.
-    Preprod,
+    Preprod = 1,
     /// Cardano preview network.
-    Preview,
+    Preview = 2,
 }
 
 // Mainnet Defaults.
@@ -224,6 +226,7 @@ mod tests {
 
     use anyhow::Ok;
     use chrono::{TimeZone, Utc};
+    use strum::VariantNames;
 
     use super::*;
 
@@ -246,6 +249,23 @@ mod tests {
         assert_eq!(preview, Network::Preview);
 
         Ok(())
+    }
+
+    #[test]
+    fn test_variant_to_usize() {
+        assert_eq!(Network::Mainnet as usize, 0);
+        assert_eq!(Network::Preprod as usize, 1);
+        assert_eq!(Network::Preview as usize, 2);
+    }
+
+    #[test]
+    fn test_variant_to_string() {
+        assert_eq!(Network::Mainnet.to_string(), "mainnet");
+        assert_eq!(Network::Preprod.to_string(), "preprod");
+        assert_eq!(Network::Preview.to_string(), "preview");
+
+        let expected_names = ["mainnet", "preprod", "preview"];
+        assert_eq!(Network::VARIANTS, expected_names);
     }
 
     #[test]


### PR DESCRIPTION
# Description

- Added indexes to `Network` variants.
- Added `snake_case` when converting variant to string.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
