### PR TITLE
feat(rust/catalyst-types): Add the 'rc' serde feature to catalyst-types in order to be able to serialize ProblemReport

### DIFF
--- a/rust/catalyst-types/Cargo.toml
+++ b/rust/catalyst-types/Cargo.toml
@@ -25,7 +25,7 @@ minicbor = { version = "0.25.1", features = ["std"] }
 num-traits = "0.2.19"
 orx-concurrent-vec = "3.1.0"
 pallas-crypto = { version = "0.30.1", git = "https://github.com/input-output-hk/catalyst-pallas.git", rev = "9b5183c8b90b90fe2cc319d986e933e9518957b3" }
-serde = { version = "1.0.217", features = ["derive"] }
+serde = { version = "1.0.217", features = ["derive", "rc"] }
 thiserror = "2.0.9"
 base64-url = "3.0.0"
 uuid = { version = "1.11.0", features = ["v4", "v7", "serde"] }
@@ -36,3 +36,4 @@ tracing = "0.1.41"
 [dev-dependencies]
 ed25519-dalek = { version = "2.1.1", features = ["rand_core"] }
 rand = "0.8.5"
+serde_json = "1"

--- a/rust/catalyst-types/src/problem_report.rs
+++ b/rust/catalyst-types/src/problem_report.rs
@@ -469,4 +469,14 @@ mod tests {
         // The original report must have the same (problematic) state.
         assert!(original.is_problematic());
     }
+
+    #[test]
+    fn serialize() {
+        let report = ProblemReport::new("top level context");
+        report.invalid_value("field name", "found", "constraint", "context");
+
+        let serialized = serde_json::to_string(&report).unwrap();
+        let expected = r#"{"context":"top level context","report":[{"kind":{"type":"InvalidValue","field":"field name","value":"found","constraint":"constraint"},"context":"context"}]}"#;
+        assert_eq!(serialized, expected);
+    }
 }


### PR DESCRIPTION
# Description

- Added `rc` to the list of serde features for the `catalyst-types` crate.
- Added a test for `ProblemReport` serialization.

## Description of Changes

Serde provides `Serialize`/`Deserialize` implementations for `Rc<T>` and `Arc<T>` but it is hidden under the `rc` [feature](https://serde.rs/feature-flags.html#rc).

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
