### PR TITLE
fix(rust/catalyst-types): Add validation during deserialising and instantiation of the `UuidV4`, `UuidV7`

### DIFF
--- a/rust/catalyst-types/Cargo.toml
+++ b/rust/catalyst-types/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 name = "catalyst_types"
 
 [dependencies]
+anyhow = "1.0.95"
 blake2b_simd = "1.0.2"
 displaydoc = "0.2.5"
 ed25519-dalek = "2.1.1"

--- a/rust/catalyst-types/Cargo.toml
+++ b/rust/catalyst-types/Cargo.toml
@@ -16,7 +16,6 @@ workspace = true
 name = "catalyst_types"
 
 [dependencies]
-anyhow = "1.0.95"
 blake2b_simd = "1.0.2"
 displaydoc = "0.2.5"
 ed25519-dalek = "2.1.1"

--- a/rust/catalyst-types/src/uuid/mod.rs
+++ b/rust/catalyst-types/src/uuid/mod.rs
@@ -14,6 +14,19 @@ pub const INVALID_UUID: uuid::Uuid = uuid::Uuid::from_bytes([0x00; 16]);
 #[allow(dead_code)]
 const UUID_CBOR_TAG: u64 = 37;
 
+/// Uuid validation errors, which could occur during decoding or converting to
+/// `UuidV4` or `UuidV7` types.
+#[derive(Debug, Clone, thiserror::Error)]
+#[allow(clippy::module_name_repetitions)]
+pub enum UuidError {
+    /// `UUIDv4` invalid error
+    #[error("'{0}' is not a valid UUIDv4")]
+    InvalidUuidV4(uuid::Uuid),
+    /// `UUIDv7` invalid error
+    #[error("'{0}' is not a valid UUIDv7")]
+    InvalidUuidV7(uuid::Uuid),
+}
+
 /// Context for `CBOR` encoding and decoding
 pub enum CborContext {
     /// Untagged bytes

--- a/rust/catalyst-types/src/uuid/mod.rs
+++ b/rust/catalyst-types/src/uuid/mod.rs
@@ -103,12 +103,32 @@ mod tests {
     }
 
     #[test]
+    fn test_cbor_uuid_v4_invalid_decoding() {
+        let uuid = V7::new();
+        let mut bytes = Vec::new();
+        minicbor::encode_with(uuid, &mut bytes, &mut CborContext::Untagged).unwrap();
+        assert!(
+            minicbor::decode_with::<_, V4>(bytes.as_slice(), &mut CborContext::Untagged).is_err()
+        );
+    }
+
+    #[test]
     fn test_cbor_uuid_v7_roundtrip() {
         let uuid = V7::new();
         let mut bytes = Vec::new();
         minicbor::encode_with(uuid, &mut bytes, &mut CborContext::Untagged).unwrap();
         let decoded = minicbor::decode_with(bytes.as_slice(), &mut CborContext::Untagged).unwrap();
         assert_eq!(uuid, decoded);
+    }
+
+    #[test]
+    fn test_cbor_uuid_v7_invalid_decoding() {
+        let uuid = V7::new();
+        let mut bytes = Vec::new();
+        minicbor::encode_with(uuid, &mut bytes, &mut CborContext::Untagged).unwrap();
+        assert!(
+            minicbor::decode_with::<_, V7>(bytes.as_slice(), &mut CborContext::Untagged).is_err()
+        );
     }
 
     #[test]

--- a/rust/catalyst-types/src/uuid/mod.rs
+++ b/rust/catalyst-types/src/uuid/mod.rs
@@ -82,7 +82,7 @@ mod tests {
 
     #[test]
     fn test_cbor_uuid_v4_roundtrip() {
-        let uuid: V4 = uuid::Uuid::new_v4().into();
+        let uuid = V4::new();
         let mut bytes = Vec::new();
         minicbor::encode_with(uuid, &mut bytes, &mut CborContext::Untagged).unwrap();
         let decoded = minicbor::decode_with(bytes.as_slice(), &mut CborContext::Untagged).unwrap();
@@ -91,7 +91,7 @@ mod tests {
 
     #[test]
     fn test_cbor_uuid_v7_roundtrip() {
-        let uuid: V7 = uuid::Uuid::now_v7().into();
+        let uuid = V7::new();
         let mut bytes = Vec::new();
         minicbor::encode_with(uuid, &mut bytes, &mut CborContext::Untagged).unwrap();
         let decoded = minicbor::decode_with(bytes.as_slice(), &mut CborContext::Untagged).unwrap();
@@ -100,7 +100,7 @@ mod tests {
 
     #[test]
     fn test_tagged_cbor_uuid_v4_roundtrip() {
-        let uuid: V4 = uuid::Uuid::new_v4().into();
+        let uuid = V4::new();
         let mut bytes = Vec::new();
         minicbor::encode_with(uuid, &mut bytes, &mut CborContext::Tagged).unwrap();
         let decoded = minicbor::decode_with(bytes.as_slice(), &mut CborContext::Tagged).unwrap();
@@ -109,7 +109,7 @@ mod tests {
 
     #[test]
     fn test_tagged_cbor_uuid_v7_roundtrip() {
-        let uuid: V7 = uuid::Uuid::now_v7().into();
+        let uuid = V7::new();
         let mut bytes = Vec::new();
         minicbor::encode_with(uuid, &mut bytes, &mut CborContext::Tagged).unwrap();
         let decoded = minicbor::decode_with(bytes.as_slice(), &mut CborContext::Tagged).unwrap();
@@ -118,7 +118,7 @@ mod tests {
 
     #[test]
     fn test_optional_cbor_uuid_v4_roundtrip() {
-        let uuid: V4 = uuid::Uuid::new_v4().into();
+        let uuid = V4::new();
 
         let mut bytes = Vec::new();
         minicbor::encode_with(uuid, &mut bytes, &mut CborContext::Untagged).unwrap();
@@ -133,7 +133,7 @@ mod tests {
 
     #[test]
     fn test_optional_cbor_uuid_v7_roundtrip() {
-        let uuid: V7 = uuid::Uuid::now_v7().into();
+        let uuid = V7::new();
 
         let mut bytes = Vec::new();
         minicbor::encode_with(uuid, &mut bytes, &mut CborContext::Untagged).unwrap();

--- a/rust/catalyst-types/src/uuid/mod.rs
+++ b/rust/catalyst-types/src/uuid/mod.rs
@@ -104,9 +104,9 @@ mod tests {
 
     #[test]
     fn test_cbor_uuid_v4_invalid_decoding() {
-        let uuid = V7::new();
+        let uuid_v7 = V7::new();
         let mut bytes = Vec::new();
-        minicbor::encode_with(uuid, &mut bytes, &mut CborContext::Untagged).unwrap();
+        minicbor::encode_with(uuid_v7, &mut bytes, &mut CborContext::Untagged).unwrap();
         assert!(
             minicbor::decode_with::<_, V4>(bytes.as_slice(), &mut CborContext::Untagged).is_err()
         );
@@ -123,9 +123,9 @@ mod tests {
 
     #[test]
     fn test_cbor_uuid_v7_invalid_decoding() {
-        let uuid = V7::new();
+        let uuid_v4 = V4::new();
         let mut bytes = Vec::new();
-        minicbor::encode_with(uuid, &mut bytes, &mut CborContext::Untagged).unwrap();
+        minicbor::encode_with(uuid_v4, &mut bytes, &mut CborContext::Untagged).unwrap();
         assert!(
             minicbor::decode_with::<_, V7>(bytes.as_slice(), &mut CborContext::Untagged).is_err()
         );

--- a/rust/catalyst-types/src/uuid/uuid_v4.rs
+++ b/rust/catalyst-types/src/uuid/uuid_v4.rs
@@ -6,47 +6,60 @@ use minicbor::{Decode, Decoder, Encode};
 use super::{decode_cbor_uuid, encode_cbor_uuid, CborContext, INVALID_UUID};
 
 /// Type representing a `UUIDv4`.
-#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
-#[serde(from = "uuid::Uuid")]
-#[serde(into = "uuid::Uuid")]
-pub struct UuidV4 {
-    /// UUID
-    uuid: uuid::Uuid,
-}
+#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, serde::Serialize)]
+pub struct UuidV4(uuid::Uuid);
 
 impl UuidV4 {
     /// Version for `UUIDv4`.
     const UUID_VERSION_NUMBER: usize = 4;
 
+    /// Generates a random `UUIDv4`.
+    #[must_use]
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self(uuid::Uuid::new_v4())
+    }
+
     /// Generates a zeroed out `UUIDv4` that can never be valid.
     #[must_use]
     pub fn invalid() -> Self {
-        Self { uuid: INVALID_UUID }
+        Self(INVALID_UUID)
     }
 
     /// Check if this is a valid `UUIDv4`.
     #[must_use]
     pub fn is_valid(&self) -> bool {
-        self.uuid != INVALID_UUID && self.uuid.get_version_num() == Self::UUID_VERSION_NUMBER
+        is_valid(&self.uuid())
     }
 
     /// Returns the `uuid::Uuid` type.
     #[must_use]
     pub fn uuid(&self) -> uuid::Uuid {
-        self.uuid
+        self.0
     }
+}
+
+/// Check if this is a valid `UUIDv4`.
+fn is_valid(uuid: &uuid::Uuid) -> bool {
+    uuid != &INVALID_UUID && uuid.get_version_num() == UuidV4::UUID_VERSION_NUMBER
 }
 
 impl Display for UuidV4 {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(f, "{}", self.uuid)
+        write!(f, "{}", self.0)
     }
 }
 
 impl Decode<'_, CborContext> for UuidV4 {
     fn decode(d: &mut Decoder<'_>, ctx: &mut CborContext) -> Result<Self, minicbor::decode::Error> {
         let uuid = decode_cbor_uuid(d, ctx)?;
-        Ok(Self { uuid })
+        if is_valid(&uuid) {
+            Ok(Self(uuid))
+        } else {
+            Err(minicbor::decode::Error::message(format!(
+                "'{uuid}' is not a valid UUIDv4"
+            )))
+        }
     }
 }
 
@@ -59,11 +72,12 @@ impl Encode<CborContext> for UuidV4 {
 }
 
 /// Returns a `UUIDv4` from `uuid::Uuid`.
-///
-/// NOTE: This does not guarantee that the `UUID` is valid.
-impl From<uuid::Uuid> for UuidV4 {
-    fn from(uuid: uuid::Uuid) -> Self {
-        Self { uuid }
+impl TryFrom<uuid::Uuid> for UuidV4 {
+    type Error = anyhow::Error;
+
+    fn try_from(uuid: uuid::Uuid) -> Result<Self, Self::Error> {
+        anyhow::ensure!(is_valid(&uuid), "'{uuid}' is not a valid UUIDv4");
+        Ok(Self(uuid))
     }
 }
 
@@ -72,7 +86,21 @@ impl From<uuid::Uuid> for UuidV4 {
 /// NOTE: This does not guarantee that the `UUID` is valid.
 impl From<UuidV4> for uuid::Uuid {
     fn from(value: UuidV4) -> Self {
-        value.uuid
+        value.0
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for UuidV4 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where D: serde::Deserializer<'de> {
+        let uuid = uuid::Uuid::deserialize(deserializer)?;
+        if is_valid(&uuid) {
+            Ok(Self(uuid))
+        } else {
+            Err(serde::de::Error::custom(format!(
+                "'{uuid}' is not a valid UUIDv4"
+            )))
+        }
     }
 }
 
@@ -95,15 +123,17 @@ mod tests {
 
     #[test]
     fn test_valid_uuid() {
-        let valid_uuid = UuidV4::from(Uuid::new_v4());
+        let valid_uuid = UuidV4::try_from(Uuid::new_v4()).unwrap();
+        assert!(valid_uuid.is_valid(), "Valid UUID should be valid");
+
+        let valid_uuid = UuidV4::new();
         assert!(valid_uuid.is_valid(), "Valid UUID should be valid");
     }
 
     #[test]
     fn test_invalid_version_uuid() {
-        let invalid_version_uuid = UuidV4::from(Uuid::from_u128(0));
         assert!(
-            !invalid_version_uuid.is_valid(),
+            UuidV4::try_from(INVALID_UUID).is_err(),
             "Zero UUID should not be valid"
         );
     }

--- a/rust/catalyst-types/src/uuid/uuid_v7.rs
+++ b/rust/catalyst-types/src/uuid/uuid_v7.rs
@@ -6,47 +6,54 @@ use minicbor::{Decode, Decoder, Encode};
 use super::{decode_cbor_uuid, encode_cbor_uuid, CborContext, INVALID_UUID};
 
 /// Type representing a `UUIDv7`.
-#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
-#[serde(from = "uuid::Uuid")]
-#[serde(into = "uuid::Uuid")]
-pub struct UuidV7 {
-    /// UUID
-    uuid: uuid::Uuid,
-}
+#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, serde::Serialize)]
+pub struct UuidV7(uuid::Uuid);
 
 impl UuidV7 {
     /// Version for `UUIDv7`.
     const UUID_VERSION_NUMBER: usize = 7;
 
+    /// Generates a random `UUIDv4`.
+    #[must_use]
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self(uuid::Uuid::now_v7())
+    }
+
     /// Generates a zeroed out `UUIDv7` that can never be valid.
     #[must_use]
     pub fn invalid() -> Self {
-        Self { uuid: INVALID_UUID }
+        Self(INVALID_UUID)
     }
 
     /// Check if this is a valid `UUIDv7`.
     #[must_use]
     pub fn is_valid(&self) -> bool {
-        self.uuid != INVALID_UUID && self.uuid.get_version_num() == Self::UUID_VERSION_NUMBER
+        is_valid(&self.0)
     }
 
     /// Returns the `uuid::Uuid` type.
     #[must_use]
     pub fn uuid(&self) -> uuid::Uuid {
-        self.uuid
+        self.0
     }
+}
+
+/// Check if this is a valid `UUIDv7`.
+fn is_valid(uuid: &uuid::Uuid) -> bool {
+    uuid != &INVALID_UUID && uuid.get_version_num() == UuidV7::UUID_VERSION_NUMBER
 }
 
 impl Display for UuidV7 {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(f, "{}", self.uuid)
+        write!(f, "{}", self.0)
     }
 }
 
 impl Decode<'_, CborContext> for UuidV7 {
     fn decode(d: &mut Decoder<'_>, ctx: &mut CborContext) -> Result<Self, minicbor::decode::Error> {
         let uuid = decode_cbor_uuid(d, ctx)?;
-        Ok(Self { uuid })
+        Ok(Self(uuid))
     }
 }
 
@@ -59,11 +66,12 @@ impl Encode<CborContext> for UuidV7 {
 }
 
 /// Returns a `UUIDv7` from `uuid::Uuid`.
-///
-/// NOTE: This does not guarantee that the `UUID` is valid.
-impl From<uuid::Uuid> for UuidV7 {
-    fn from(uuid: uuid::Uuid) -> Self {
-        Self { uuid }
+impl TryFrom<uuid::Uuid> for UuidV7 {
+    type Error = anyhow::Error;
+
+    fn try_from(uuid: uuid::Uuid) -> Result<Self, Self::Error> {
+        anyhow::ensure!(is_valid(&uuid), "'{uuid}' is not a valid UUIDv7");
+        Ok(Self(uuid))
     }
 }
 
@@ -72,7 +80,21 @@ impl From<uuid::Uuid> for UuidV7 {
 /// NOTE: This does not guarantee that the `UUID` is valid.
 impl From<UuidV7> for uuid::Uuid {
     fn from(value: UuidV7) -> Self {
-        value.uuid
+        value.0
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for UuidV7 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where D: serde::Deserializer<'de> {
+        let uuid = uuid::Uuid::deserialize(deserializer)?;
+        if is_valid(&uuid) {
+            Ok(Self(uuid))
+        } else {
+            Err(serde::de::Error::custom(format!(
+                "'{uuid}' is not a valid UUIDv4"
+            )))
+        }
     }
 }
 
@@ -95,16 +117,17 @@ mod tests {
 
     #[test]
     fn test_valid_uuid() {
-        let valid_uuid =
-            UuidV7::from(Uuid::try_parse("017f22e3-79b0-7cc7-98cf-e0bbf8a1c5f1").unwrap());
+        let valid_uuid = UuidV7::try_from(Uuid::now_v7()).unwrap();
+        assert!(valid_uuid.is_valid(), "Valid UUID should be valid");
+
+        let valid_uuid = UuidV7::new();
         assert!(valid_uuid.is_valid(), "Valid UUID should be valid");
     }
 
     #[test]
     fn test_invalid_version_uuid() {
-        let invalid_version_uuid = UuidV7::from(Uuid::from_u128(0));
         assert!(
-            !invalid_version_uuid.is_valid(),
+            UuidV7::try_from(INVALID_UUID).is_err(),
             "Zero UUID should not be valid"
         );
     }


### PR DESCRIPTION
# Description

Updated validation of the `UuidV4` and `UuidV7` types during deserialisation and instantiation.

# Related PR
Needed for https://github.com/input-output-hk/catalyst-libs/pull/155
