### PR TITLE
feat(rust/catalyst-types): Implement Debug for ProblemReport

### DIFF
--- a/rust/catalyst-types/Cargo.toml
+++ b/rust/catalyst-types/Cargo.toml
@@ -23,7 +23,7 @@ fluent-uri = "0.3.2"
 hex = "0.4.3"
 minicbor = { version = "0.25.1", features = ["std"] }
 num-traits = "0.2.19"
-orx-concurrent-vec = "3.1.0"
+orx-concurrent-vec = { version = "3.2.0", features = ["serde"] }
 pallas-crypto = { version = "0.30.1", git = "https://github.com/input-output-hk/catalyst-pallas.git", rev = "9b5183c8b90b90fe2cc319d986e933e9518957b3" }
 serde = { version = "1.0.217", features = ["derive", "rc"] }
 thiserror = "2.0.9"

--- a/rust/catalyst-types/src/problem_report.rs
+++ b/rust/catalyst-types/src/problem_report.rs
@@ -7,10 +7,10 @@
 use std::sync::Arc;
 
 use orx_concurrent_vec::ConcurrentVec;
-use serde::{ser::SerializeSeq, Serialize};
+use serde::Serialize;
 
 /// The kind of problem being reported
-#[derive(Serialize, Clone)]
+#[derive(Debug, Serialize, Clone)]
 #[serde(tag = "type")]
 enum Kind {
     /// Expected and Required field is missing
@@ -73,7 +73,7 @@ enum Kind {
 }
 
 /// Problem Report Entry
-#[derive(Serialize, Clone)]
+#[derive(Debug, Serialize, Clone)]
 struct Entry {
     /// The kind of problem we are recording.
     kind: Kind,
@@ -82,22 +82,11 @@ struct Entry {
 }
 
 /// The Problem Report list
-#[derive(Clone)]
+#[derive(Debug, Clone, Serialize)]
 struct Report(ConcurrentVec<Entry>);
 
-impl Serialize for Report {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where S: serde::Serializer {
-        let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
-        for e in self.0.iter_cloned() {
-            seq.serialize_element(&e)?;
-        }
-        seq.end()
-    }
-}
-
 /// An inner state of the report.
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 struct State {
     /// What context does the whole report have
     context: String,
@@ -108,7 +97,7 @@ struct State {
 /// Problem Report.
 ///
 /// This structure allows making a cheap copies that share the same state.
-#[derive(Clone, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ProblemReport(Arc<State>);
 
 impl ProblemReport {


### PR DESCRIPTION
# Description

- Implement the `Debug` trait for `ProblemReport`
- Simplify the serialization implementation by using the feature of the `orx-concurrent-vec` crate.

## Description of Changes

This is a part of changes from the https://github.com/input-output-hk/catalyst-libs/pull/127/ pull request that is unrelated to the `rbac-registration` crate.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
