### PR TITLE
feat(rust/signed-doc): Improve `catalyst-signed-doc` crate API.

### DIFF
--- a/rust/signed_doc/Cargo.toml
+++ b/rust/signed_doc/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-catalyst-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250122-00" }
+catalyst-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250124-00" }
 anyhow = "1.0.95"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.134"

--- a/rust/signed_doc/src/metadata/document_ref.rs
+++ b/rust/signed_doc/src/metadata/document_ref.rs
@@ -9,6 +9,7 @@ pub struct DocumentRef {
     /// Reference to the Document Id
     pub id: UuidV7,
     /// Reference to the Document Ver, if not specified the latest document is meant
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ver: Option<UuidV7>,
 }
 

--- a/rust/signed_doc/src/metadata/document_ref.rs
+++ b/rust/signed_doc/src/metadata/document_ref.rs
@@ -5,34 +5,24 @@ use super::{decode_cbor_uuid, encode_cbor_uuid, UuidV7};
 
 /// Reference to a Document.
 #[derive(Copy, Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
-#[serde(untagged)]
-pub enum DocumentRef {
-    /// Reference to the latest document
-    Latest {
-        /// Document ID UUID
-        id: UuidV7,
-    },
-    /// Reference to the specific document version
-    WithVer {
-        /// Document ID UUID,
-        id: UuidV7,
-        /// Document Ver UUID
-        ver: UuidV7,
-    },
+pub struct DocumentRef {
+    /// Reference to the Document Id
+    pub id: UuidV7,
+    /// Reference to the Document Ver, if not specified the latest document is meant
+    pub ver: Option<UuidV7>,
 }
 
 impl TryFrom<DocumentRef> for Value {
     type Error = anyhow::Error;
 
     fn try_from(value: DocumentRef) -> Result<Self, Self::Error> {
-        match value {
-            DocumentRef::Latest { id } => encode_cbor_uuid(id),
-            DocumentRef::WithVer { id, ver } => {
-                Ok(Value::Array(vec![
-                    encode_cbor_uuid(id)?,
-                    encode_cbor_uuid(ver)?,
-                ]))
-            },
+        if let Some(ver) = value.ver {
+            Ok(Value::Array(vec![
+                encode_cbor_uuid(value.id)?,
+                encode_cbor_uuid(ver)?,
+            ]))
+        } else {
+            encode_cbor_uuid(value.id)
         }
     }
 }
@@ -43,7 +33,7 @@ impl TryFrom<&Value> for DocumentRef {
     #[allow(clippy::indexing_slicing)]
     fn try_from(val: &Value) -> anyhow::Result<DocumentRef> {
         if let Ok(id) = decode_cbor_uuid(val.clone()) {
-            Ok(DocumentRef::Latest { id })
+            Ok(DocumentRef { id, ver: None })
         } else {
             let Some(array) = val.as_array() else {
                 anyhow::bail!("Document Reference must be either a single UUID or an array of two");
@@ -58,7 +48,7 @@ impl TryFrom<&Value> for DocumentRef {
                 ver >= id,
                 "Document Reference Version can never be smaller than its ID"
             );
-            Ok(DocumentRef::WithVer { id, ver })
+            Ok(DocumentRef { id, ver: Some(ver) })
         }
     }
 }

--- a/rust/signed_doc/src/metadata/extra_fields.rs
+++ b/rust/signed_doc/src/metadata/extra_fields.rs
@@ -31,31 +31,31 @@ const CATEGORY_ID_KEY: &str = "category_id";
 pub struct ExtraFields {
     /// Reference to the latest document.
     #[serde(rename = "ref", skip_serializing_if = "Option::is_none")]
-    pub(super) doc_ref: Option<DocumentRef>,
+    doc_ref: Option<DocumentRef>,
     /// Reference to the document template.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(super) template: Option<DocumentRef>,
+    template: Option<DocumentRef>,
     /// Reference to the document reply.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(super) reply: Option<DocumentRef>,
+    reply: Option<DocumentRef>,
     /// Reference to the document section.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(super) section: Option<String>,
+    section: Option<String>,
     /// Reference to the document collaborators. Collaborator type is TBD.
     #[serde(default = "Vec::new", skip_serializing_if = "Vec::is_empty")]
-    pub(super) collabs: Vec<String>,
+    collabs: Vec<String>,
     /// Unique identifier for the brand that is running the voting.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(super) brand_id: Option<UuidV4>,
+    brand_id: Option<UuidV4>,
     /// Unique identifier for the campaign of voting.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(super) campaign_id: Option<UuidV4>,
+    campaign_id: Option<UuidV4>,
     /// Unique identifier for the election.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(super) election_id: Option<UuidV4>,
+    election_id: Option<UuidV4>,
     /// Unique identifier for the voting category as a collection of proposals.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(super) category_id: Option<UuidV4>,
+    category_id: Option<UuidV4>,
 }
 
 impl ExtraFields {

--- a/rust/signed_doc/src/metadata/extra_fields.rs
+++ b/rust/signed_doc/src/metadata/extra_fields.rs
@@ -59,6 +59,60 @@ pub struct ExtraFields {
 }
 
 impl ExtraFields {
+    /// Return `ref` field.
+    #[must_use]
+    pub fn doc_ref(&self) -> Option<DocumentRef> {
+        self.doc_ref
+    }
+
+    /// Return `template` field.
+    #[must_use]
+    pub fn template(&self) -> Option<DocumentRef> {
+        self.template
+    }
+
+    /// Return `reply` field.
+    #[must_use]
+    pub fn reply(&self) -> Option<DocumentRef> {
+        self.reply
+    }
+
+    /// Return `section` field.
+    #[must_use]
+    pub fn section(&self) -> Option<&String> {
+        self.section.as_ref()
+    }
+
+    /// Return `collabs` field.
+    #[must_use]
+    pub fn collabs(&self) -> &Vec<String> {
+        &self.collabs
+    }
+
+    /// Return `brand_id` field.
+    #[must_use]
+    pub fn brand_id(&self) -> Option<UuidV4> {
+        self.brand_id
+    }
+
+    /// Return `campaign_id` field.
+    #[must_use]
+    pub fn campaign_id(&self) -> Option<UuidV4> {
+        self.campaign_id
+    }
+
+    /// Return `election_id` field.
+    #[must_use]
+    pub fn election_id(&self) -> Option<UuidV4> {
+        self.election_id
+    }
+
+    /// Return `category_id` field.
+    #[must_use]
+    pub fn category_id(&self) -> Option<UuidV4> {
+        self.category_id
+    }
+
     /// Fill the COSE header `ExtraFields` data into the header builder.
     pub(super) fn fill_cose_header_fields(
         &self, mut builder: coset::HeaderBuilder,

--- a/rust/signed_doc/src/metadata/mod.rs
+++ b/rust/signed_doc/src/metadata/mod.rs
@@ -12,7 +12,7 @@ mod extra_fields;
 
 use algorithm::Algorithm;
 use anyhow::anyhow;
-pub use catalyst_types::uuid::{CborContext, V4 as UuidV4, V7 as UuidV7};
+pub use catalyst_types::uuid::{CborContext, UuidV4, UuidV7};
 pub use content_encoding::ContentEncoding;
 pub use content_type::ContentType;
 use coset::{iana::CoapContentFormat, CborSerializable};


### PR DESCRIPTION
# Description

- Add public getters for `ExtraField` structure.
- Simplify `DocumentRef` structure.

## Related Issue(s)

Needed for https://github.com/input-output-hk/catalyst-voices/issues/1539