### PR TITLE
feat(rust/cbork): Add report_duplicated_key and report_missing_keys functions to the cbork-utils crate

### DIFF
--- a/rust/cbork-utils/Cargo.toml
+++ b/rust/cbork-utils/Cargo.toml
@@ -13,6 +13,8 @@ workspace = true
 [dependencies]
 minicbor = { version = "0.25.1", features = ["std"] }
 
+catalyst-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250124-00" }
+
 [dev-dependencies]
 proptest = { version = "1.5.0" }
 # Potentially it could be replaced with using `proptest::property_test` attribute macro,


### PR DESCRIPTION
# Description

- Add `report_duplicated_key` and `report_missing_keys` functions to the `cbork-utils` crate.

## Description of Changes

It is rather common pattern in the `Decode` trait implementation to check for report duplicated keys and check presence of the required ones. For example [in CIP-36 decoding](https://github.com/input-output-hk/catalyst-libs/blob/main/rust/cardano-blockchain-types/src/metadata/cip36/key_registration.rs#L146) and [CIP-509 decoding](https://github.com/input-output-hk/catalyst-libs/blob/main/rust/rbac-registration/src/utils/decode_helper.rs#L9). I'm not sure if `cbork-utils` is the best place for these functions, but it would be nice to reuse them instead of having several almost identical implementations.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
