### PR TITLE
chore(general): Enable arithmetic_side_effects Clippy lint

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,7 +10,7 @@ members = [
     "cbork-cddl-parser",
     "cbork-utils",
     "catalyst-voting",
-    "catalyst-types", 
+    "catalyst-types",
     "immutable-ledger",
     "vote-tx-v1",
     "vote-tx-v2",
@@ -60,3 +60,4 @@ string_slice = "deny"
 unchecked_duration_subtraction = "deny"
 unreachable = "deny"
 missing_docs_in_private_items = "deny"
+arithmetic_side_effects = "deny"

--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.2.27 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.2.28 AS rust-ci
 
 COPY_SRC:
     FUNCTION

--- a/rust/c509-certificate/src/attributes/mod.rs
+++ b/rust/c509-certificate/src/attributes/mod.rs
@@ -62,7 +62,12 @@ impl Encode<()> for Attributes {
             ));
         }
         // The attribute type should be included in array too
-        encode_array_len(e, "Attributes", self.0.len() as u64 * 2)?;
+        let Some(len) = (self.0.len() as u64).checked_mul(2) else {
+            return Err(minicbor::encode::Error::message(
+                "Attributes length overflow",
+            ));
+        };
+        encode_array_len(e, "Attributes", len)?;
         for attribute in &self.0 {
             attribute.encode(e, ctx)?;
         }

--- a/rust/c509-certificate/src/attributes/mod.rs
+++ b/rust/c509-certificate/src/attributes/mod.rs
@@ -62,11 +62,9 @@ impl Encode<()> for Attributes {
             ));
         }
         // The attribute type should be included in array too
-        let Some(len) = (self.0.len() as u64).checked_mul(2) else {
-            return Err(minicbor::encode::Error::message(
-                "Attributes length overflow",
-            ));
-        };
+        let len = (self.0.len() as u64)
+            .checked_mul(2)
+            .ok_or_else(|| minicbor::encode::Error::message("Attributes length overflow"))?;
         encode_array_len(e, "Attributes", len)?;
         for attribute in &self.0 {
             attribute.encode(e, ctx)?;

--- a/rust/c509-certificate/src/extensions/extension/mod.rs
+++ b/rust/c509-certificate/src/extensions/extension/mod.rs
@@ -110,7 +110,11 @@ impl Encode<()> for Extension {
         {
             // Determine encoded OID value based on critical flag
             let encoded_oid = if self.critical {
-                -mapped_oid
+                mapped_oid.checked_neg().ok_or_else(|| {
+                    minicbor::encode::Error::message(format!(
+                        "Invalid OID value (will overflow during negation): {mapped_oid}"
+                    ))
+                })?
             } else {
                 mapped_oid
             };

--- a/rust/c509-certificate/src/general_names/mod.rs
+++ b/rust/c509-certificate/src/general_names/mod.rs
@@ -59,11 +59,9 @@ impl Encode<()> for GeneralNames {
             ));
         }
         // The general name type should be included in array too
-        let Some(len) = (self.0.len() as u64).checked_mul(2) else {
-            return Err(minicbor::encode::Error::message(
-                "General Names length overflow",
-            ));
-        };
+        let len = (self.0.len() as u64)
+            .checked_mul(2)
+            .ok_or_else(|| minicbor::encode::Error::message("General Names length overflow"))?;
         encode_array_len(e, "General Names", len)?;
         for gn in &self.0 {
             gn.encode(e, ctx)?;

--- a/rust/c509-certificate/src/general_names/mod.rs
+++ b/rust/c509-certificate/src/general_names/mod.rs
@@ -59,7 +59,12 @@ impl Encode<()> for GeneralNames {
             ));
         }
         // The general name type should be included in array too
-        encode_array_len(e, "General Names", self.0.len() as u64 * 2)?;
+        let Some(len) = (self.0.len() as u64).checked_mul(2) else {
+            return Err(minicbor::encode::Error::message(
+                "General Names length overflow",
+            ));
+        };
+        encode_array_len(e, "General Names", len)?;
         for gn in &self.0 {
             gn.encode(e, ctx)?;
         }

--- a/rust/c509-certificate/src/name/mod.rs
+++ b/rust/c509-certificate/src/name/mod.rs
@@ -106,11 +106,9 @@ impl Encode<()> for NameValue {
 
                         encode_cn_value(e, cn_value)?;
                     } else {
-                        let Some(len) = (attrs.len() as u64).checked_mul(2) else {
-                            return Err(minicbor::encode::Error::message(
-                                "Attribute length overflow",
-                            ));
-                        };
+                        let len = (attrs.len() as u64).checked_mul(2).ok_or_else(|| {
+                            minicbor::encode::Error::message("Attribute length overflow")
+                        })?;
                         encode_array_len(e, "Attributes", len)?;
                         for attribute in attrs {
                             attribute.encode(e, ctx)?;
@@ -118,11 +116,9 @@ impl Encode<()> for NameValue {
                     }
                 } else {
                     // If is okay if the attributes is empty
-                    let Some(len) = (attrs.len() as u64).checked_mul(2) else {
-                        return Err(minicbor::encode::Error::message(
-                            "Attribute length overflow",
-                        ));
-                    };
+                    let len = (attrs.len() as u64).checked_mul(2).ok_or_else(|| {
+                        minicbor::encode::Error::message("Attribute length overflow")
+                    })?;
                     encode_array_len(e, "Attributes", len)?;
                     for attribute in attrs {
                         attribute.encode(e, ctx)?;

--- a/rust/c509-certificate/src/name/mod.rs
+++ b/rust/c509-certificate/src/name/mod.rs
@@ -106,14 +106,24 @@ impl Encode<()> for NameValue {
 
                         encode_cn_value(e, cn_value)?;
                     } else {
-                        encode_array_len(e, "Attributes", attrs.len() as u64 * 2)?;
+                        let Some(len) = (attrs.len() as u64).checked_mul(2) else {
+                            return Err(minicbor::encode::Error::message(
+                                "Attribute length overflow",
+                            ));
+                        };
+                        encode_array_len(e, "Attributes", len)?;
                         for attribute in attrs {
                             attribute.encode(e, ctx)?;
                         }
                     }
                 } else {
                     // If is okay if the attributes is empty
-                    encode_array_len(e, "Attributes", attrs.len() as u64 * 2)?;
+                    let Some(len) = (attrs.len() as u64).checked_mul(2) else {
+                        return Err(minicbor::encode::Error::message(
+                            "Attribute length overflow",
+                        ));
+                    };
+                    encode_array_len(e, "Attributes", len)?;
                     for attribute in attrs {
                         attribute.encode(e, ctx)?;
                     }

--- a/rust/cardano-blockchain-types/src/auxdata/scripts.rs
+++ b/rust/cardano-blockchain-types/src/auxdata/scripts.rs
@@ -100,7 +100,7 @@ impl TryFrom<u64> for ScriptType {
         match value {
             0 => Err(anyhow!("Invalid script type: {}", value)),
             1 => Ok(Self::Native),
-            _ => Ok(Self::Plutus(value - 1)),
+            _ => Ok(Self::Plutus(value.saturating_sub(1))),
         }
     }
 }

--- a/rust/cardano-blockchain-types/src/fork.rs
+++ b/rust/cardano-blockchain-types/src/fork.rs
@@ -71,7 +71,7 @@ impl fmt::Display for Fork {
             0 => write!(f, "IMMUTABLE"),
             1 => write!(f, "BACKFILL"),
             // For live forks: 2 maps to LIVE:1, 3 maps to LIVE:2 etc.
-            2..=u64::MAX => write!(f, "LIVE:{}", self.0 - 1),
+            2..=u64::MAX => write!(f, "LIVE:{}", self.0.saturating_sub(1)),
         }
     }
 }

--- a/rust/cardano-blockchain-types/src/metadata/cip36/key_registration.rs
+++ b/rust/cardano-blockchain-types/src/metadata/cip36/key_registration.rs
@@ -150,7 +150,11 @@ fn check_is_key_exist(
     if found_keys.contains(key) {
         err_report.duplicate_field(
             format!("{key:?}").as_str(),
-            format!("Redundant key found in item {} in RBAC map", index + 1).as_str(),
+            format!(
+                "Redundant key found in item {} in RBAC map",
+                index.saturating_add(1)
+            )
+            .as_str(),
             format!("CIP36 Key Registration {key:?}").as_str(),
         );
         return true;

--- a/rust/cardano-blockchain-types/src/metadata/cip36/key_registration.rs
+++ b/rust/cardano-blockchain-types/src/metadata/cip36/key_registration.rs
@@ -146,10 +146,6 @@ impl Decode<'_, ProblemReport> for Cip36KeyRegistration {
         Ok(cip36_key_registration)
     }
 }
-                "Redundant key found in item {} in RBAC map",
-                index.saturating_add(1)
-            )
-            .as_str(),
 
 /// Helper function for decoding the voting key.
 ///

--- a/rust/cardano-blockchain-types/src/multi_era_block_data.rs
+++ b/rust/cardano-blockchain-types/src/multi_era_block_data.rs
@@ -487,8 +487,10 @@ pub(crate) mod tests {
             let pallas_block =
                 pallas::ledger::traverse::MultiEraBlock::decode(test_block.raw.as_slice())?;
 
-            let previous_point =
-                Point::new((pallas_block.slot() - 1).into(), vec![0; 32].try_into()?);
+            let previous_point = Point::new(
+                (pallas_block.slot().checked_sub(1).unwrap()).into(),
+                vec![0; 32].try_into()?,
+            );
 
             let block = MultiEraBlock::new(
                 Network::Preprod,
@@ -511,7 +513,7 @@ pub(crate) mod tests {
                 pallas::ledger::traverse::MultiEraBlock::decode(test_block.raw.as_slice())?;
 
             let previous_point = Point::new(
-                (pallas_block.slot() - 1).into(),
+                (pallas_block.slot().checked_sub(1).unwrap()).into(),
                 pallas_block
                     .header()
                     .previous_hash()
@@ -540,7 +542,7 @@ pub(crate) mod tests {
                 let prev_point = pallas::ledger::traverse::MultiEraBlock::decode(block.as_slice())
                     .map(|block| {
                         Point::new(
-                            (block.slot() - 1).into(),
+                            (block.slot().saturating_sub(1)).into(),
                             block
                                 .header()
                                 .previous_hash()

--- a/rust/cardano-blockchain-types/src/network.rs
+++ b/rust/cardano-blockchain-types/src/network.rs
@@ -190,23 +190,23 @@ impl Network {
 
         let (elapsed_slots, era_known_slot) = if time < shelley_start_time {
             // Byron era
-            let time_diff = time - byron_start_time;
-            (
-                time_diff.num_seconds() / i64::from(genesis.byron_slot_length),
-                genesis.byron_known_slot,
-            )
+            let time_diff = time.signed_duration_since(byron_start_time);
+            let elapsed_slots = time_diff
+                .num_seconds()
+                .checked_div(i64::from(genesis.byron_slot_length))?;
+            (elapsed_slots, genesis.byron_known_slot)
         } else {
             // Shelley era
-            let time_diff = time - shelley_start_time;
-            (
-                time_diff.num_seconds() / i64::from(genesis.shelley_slot_length),
-                genesis.shelley_known_slot,
-            )
+            let time_diff = time.signed_duration_since(shelley_start_time);
+            let elapsed_slots = time_diff
+                .num_seconds()
+                .checked_div(i64::from(genesis.shelley_slot_length))?;
+            (elapsed_slots, genesis.shelley_known_slot)
         };
 
         let era_known_slot = i64::try_from(era_known_slot).ok()?;
-
-        Some(Slot::from_saturating(elapsed_slots + era_known_slot))
+        let slot = elapsed_slots.checked_add(era_known_slot)?;
+        Some(Slot::from_saturating(slot))
     }
 }
 

--- a/rust/cardano-chain-follower/examples/follow_chains.rs
+++ b/rust/cardano-chain-follower/examples/follow_chains.rs
@@ -97,8 +97,8 @@ async fn start_sync_for(network: &Network, matches: ArgMatches) -> Result<(), Bo
 
     if let Some(chunk_size) = matches.get_one::<u16>("mithril-sync-chunk-size") {
         let chunk_size = (*chunk_size as usize)
-            .checked_mul(1024)
-            .and_then(|v| v.checked_mul(1024))
+            // 1024 * 1024
+            .checked_mul(1_048_576)
             .ok_or("Chunk size overflow")?;
         dl_config = dl_config.with_chunk_size(chunk_size);
     }

--- a/rust/cardano-chain-follower/examples/follow_chains.rs
+++ b/rust/cardano-chain-follower/examples/follow_chains.rs
@@ -96,7 +96,11 @@ async fn start_sync_for(network: &Network, matches: ArgMatches) -> Result<(), Bo
     let mithril_dl_workers = format!("{}", dl_config.workers);
 
     if let Some(chunk_size) = matches.get_one::<u16>("mithril-sync-chunk-size") {
-        dl_config = dl_config.with_chunk_size(*chunk_size as usize * 1024 * 1024);
+        let chunk_size = (*chunk_size as usize)
+            .checked_mul(1024)
+            .and_then(|v| v.checked_mul(1024))
+            .ok_or("Chunk size overflow")?;
+        dl_config = dl_config.with_chunk_size(chunk_size);
     }
     let mithril_dl_chunk_size = format!("{} MBytes", dl_config.chunk_size / (1024 * 1024));
 
@@ -176,7 +180,7 @@ async fn follow_for(network: Network, matches: ArgMatches) {
     let mut largest_aux_size: usize = 0;
 
     while let Some(chain_update) = follower.next().await {
-        updates += 1;
+        updates = updates.saturating_add(1);
 
         if chain_update.tip {
             reached_tip = true;
@@ -196,7 +200,7 @@ async fn follow_for(network: Network, matches: ArgMatches) {
                 info!(
                     chain = network.to_string(),
                     "Chain Update {}:{}",
-                    updates - 1,
+                    updates.saturating_sub(1),
                     last_update
                 );
             }

--- a/rust/cardano-chain-follower/src/chain_sync.rs
+++ b/rust/cardano-chain-follower/src/chain_sync.rs
@@ -193,6 +193,7 @@ async fn process_rollback(
     let head_slot = previous_point.slot_or_default();
     debug!("Head slot: {head_slot:?}");
     debug!("Rollback slot: {rollback_slot:?}");
+    // It is ok because slot implement saturating subtraction.
     #[allow(clippy::arithmetic_side_effects)]
     let slot_rollback_size = head_slot - rollback_slot;
 

--- a/rust/cardano-chain-follower/src/chain_sync.rs
+++ b/rust/cardano-chain-follower/src/chain_sync.rs
@@ -63,7 +63,7 @@ async fn retry_connect(
                 match peer {
                     Ok(peer) => return Ok(peer),
                     Err(err) => {
-                        retries -= 1;
+                        retries = retries.saturating_sub(1);
                         if retries == 0 {
                             return Err(err);
                         }
@@ -72,7 +72,7 @@ async fn retry_connect(
                 }
             },
             Err(error) => {
-                retries -= 1;
+                retries = retries.saturating_sub(1);
                 if retries == 0 {
                     return Err(pallas::network::facades::Error::ConnectFailure(
                         tokio::io::Error::new(
@@ -193,6 +193,7 @@ async fn process_rollback(
     let head_slot = previous_point.slot_or_default();
     debug!("Head slot: {head_slot:?}");
     debug!("Rollback slot: {rollback_slot:?}");
+    #[allow(clippy::arithmetic_side_effects)]
     let slot_rollback_size = head_slot - rollback_slot;
 
     // We actually do the work here...

--- a/rust/cardano-chain-follower/src/follow.rs
+++ b/rust/cardano-chain-follower/src/follow.rs
@@ -374,7 +374,7 @@ mod tests {
             .expect("cannot decode block");
 
         let previous_point = Point::new(
-            (pallas_block.slot() - 1).into(),
+            (pallas_block.slot().checked_sub(1).unwrap()).into(),
             pallas_block
                 .header()
                 .previous_hash()

--- a/rust/cardano-chain-follower/src/mithril_snapshot_iterator.rs
+++ b/rust/cardano-chain-follower/src/mithril_snapshot_iterator.rs
@@ -56,6 +56,7 @@ pub(crate) fn probe_point(point: &Point, distance: u64) -> Point {
     const STEP_BACK_ORIGIN: u64 = 0;
     // Now that we have the tip, step back about 4 block intervals from tip, and do a fuzzy
     // iteration to find the exact two blocks at the end of the immutable chain.
+    #[allow(clippy::arithmetic_side_effects)]
     let step_back_search = point.slot_or_default() - distance.into();
 
     // We stepped back to the origin, so just return Origin
@@ -143,7 +144,7 @@ impl MithrilSnapshotIterator {
                 return iterator;
             }
 
-            backwards_search *= 2;
+            backwards_search = backwards_search.saturating_mul(2);
         }
     }
 

--- a/rust/cardano-chain-follower/src/mithril_snapshot_iterator.rs
+++ b/rust/cardano-chain-follower/src/mithril_snapshot_iterator.rs
@@ -56,6 +56,7 @@ pub(crate) fn probe_point(point: &Point, distance: u64) -> Point {
     const STEP_BACK_ORIGIN: u64 = 0;
     // Now that we have the tip, step back about 4 block intervals from tip, and do a fuzzy
     // iteration to find the exact two blocks at the end of the immutable chain.
+    // It is ok because slot implement saturating subtraction.
     #[allow(clippy::arithmetic_side_effects)]
     let step_back_search = point.slot_or_default() - distance.into();
 

--- a/rust/cardano-chain-follower/src/mithril_turbo_downloader.rs
+++ b/rust/cardano-chain-follower/src/mithril_turbo_downloader.rs
@@ -359,7 +359,9 @@ impl SnapshotDownloader for MithrilTurboDownloader {
             self.inner.cfg.chain,
             Some(self.inner.ext_size.load(Ordering::SeqCst)),
             self.inner.dedup_size.load(Ordering::SeqCst),
-            tot_files - (chg_files + new_files),
+            tot_files
+                .saturating_sub(chg_files)
+                .saturating_sub(new_files),
             chg_files,
             new_files,
         );

--- a/rust/cardano-chain-follower/src/stats/mod.rs
+++ b/rust/cardano-chain-follower/src/stats/mod.rs
@@ -153,9 +153,9 @@ pub(crate) fn stats_invalid_block(chain: Network, immutable: bool) {
     };
 
     if immutable {
-        chain_stats.mithril.invalid_blocks = chain_stats.mithril.invalid_blocks.saturating_sub(1);
+        chain_stats.mithril.invalid_blocks = chain_stats.mithril.invalid_blocks.saturating_add(1);
     } else {
-        chain_stats.live.invalid_blocks = chain_stats.live.invalid_blocks.saturating_sub(1);
+        chain_stats.live.invalid_blocks = chain_stats.live.invalid_blocks.saturating_add(1);
     }
 }
 

--- a/rust/cardano-chain-follower/src/stats/rollback.rs
+++ b/rust/cardano-chain-follower/src/stats/rollback.rs
@@ -135,7 +135,7 @@ pub(crate) fn rollback(chain: Network, rollback: RollbackType, depth: u64) {
         None => Rollback { depth, count: 0 },
     };
 
-    value.count += 1;
+    value.count = value.count.saturating_add(1);
 
     let _unused = rollbacks.insert(depth, value);
 }

--- a/rust/catalyst-types/src/cbor_utils.rs
+++ b/rust/catalyst-types/src/cbor_utils.rs
@@ -13,11 +13,7 @@ pub fn report_duplicated_key<T: Debug + PartialEq>(
     if found_keys.contains(key) {
         report.duplicate_field(
             format!("{key:?}").as_str(),
-            format!("Redundant key found in item {}", index + 1).as_str(),
-                "Redundant key found in item {} in RBAC map",
-                index.saturating_add(1)
-            )
-            .as_str(),
+            format!("Redundant key found in item {}", index.saturating_add(1)).as_str(),
             context,
         );
         return true;

--- a/rust/catalyst-types/src/id_uri/mod.rs
+++ b/rust/catalyst-types/src/id_uri/mod.rs
@@ -414,8 +414,12 @@ impl IdUri {
     pub fn is_nonce_in_range(&self, past: Duration, future: Duration) -> bool {
         if let Some(nonce) = self.nonce {
             let now = Utc::now();
-            let start_time = now - past;
-            let end_time = now + future;
+            let Some(start_time) = now.checked_sub_signed(past) else {
+                return false;
+            };
+            let Some(end_time) = now.checked_add_signed(future) else {
+                return false;
+            };
             (start_time..=end_time).contains(&nonce)
         } else {
             // No nonce defined, so we say that this fails.

--- a/rust/catalyst-types/src/mmap_file.rs
+++ b/rust/catalyst-types/src/mmap_file.rs
@@ -82,8 +82,8 @@ impl MemMapFileStat {
     /// Update the global stats when a file is created.
     fn update_create_stat(size: u64) {
         if let Ok(mut stat) = MEMMAP_FILE_STATS.write() {
-            stat.file_count += 1;
-            stat.total_size += size;
+            stat.file_count = stat.file_count.saturating_add(1);
+            stat.total_size = stat.total_size.saturating_add(size);
         } else {
             error!(
                 "RwLock write poisoned, failed to update created memory-mapped file statistics."
@@ -94,8 +94,8 @@ impl MemMapFileStat {
     /// Update the global stats when a file is dropped.
     fn update_drop_stat(size: u64) {
         if let Ok(mut stat) = MEMMAP_FILE_STATS.write() {
-            stat.drop_count += 1;
-            stat.drop_size += size;
+            stat.drop_count = stat.drop_count.saturating_add(1);
+            stat.drop_size = stat.drop_size.saturating_add(size);
         } else {
             error!(
                 "RwLock write poisoned, failed to update dropped memory-mapped file statistics."
@@ -106,7 +106,7 @@ impl MemMapFileStat {
     /// Update the global error count when an error occurs.
     fn update_err_stat() {
         if let Ok(mut stat) = MEMMAP_FILE_STATS.write() {
-            stat.error_count += 1;
+            stat.error_count = stat.error_count.saturating_add(1);
         } else {
             error!("RwLock write poisoned, failed to update error memory-mapped file statistics.");
         }

--- a/rust/catalyst-voting/src/lib.rs
+++ b/rust/catalyst-voting/src/lib.rs
@@ -1,5 +1,7 @@
 //! Voting primitives which are used among Catalyst ecosystem.
 
+#![allow(clippy::arithmetic_side_effects)]
+
 pub mod crypto;
 mod utils;
 pub mod vote_protocol;

--- a/rust/clippy.toml
+++ b/rust/clippy.toml
@@ -1,3 +1,4 @@
 allow-unwrap-in-tests = true
 allow-expect-in-tests = true
 allow-panic-in-tests = true
+arithmetic-side-effects-allowed = ["num_bigint::BigInt"]

--- a/rust/rbac-registration/src/utils/decode_helper.rs
+++ b/rust/rbac-registration/src/utils/decode_helper.rs
@@ -12,7 +12,11 @@ pub fn report_duplicated_key<T: Debug + PartialEq>(
     if found_keys.contains(key) {
         report.duplicate_field(
             format!("{key:?}").as_str(),
-            format!("Redundant key found in item {} in RBAC map", index + 1).as_str(),
+            format!(
+                "Redundant key found in item {} in RBAC map",
+                index.saturating_add(1)
+            )
+            .as_str(),
             context,
         );
         return true;

--- a/rust/vote-tx-v1/src/decoding.rs
+++ b/rust/vote-tx-v1/src/decoding.rs
@@ -247,7 +247,7 @@ mod tests {
         let mut reader = bytes.as_slice();
 
         let size = read_be_u32(&mut reader).unwrap();
-        assert_eq!(size as usize, bytes.len() - 4);
+        assert_eq!(size as usize, bytes.len().checked_sub(4).unwrap());
 
         let padding_tag = read_be_u8(&mut reader).unwrap();
         assert_eq!(padding_tag, PADDING_TAG);
@@ -324,7 +324,7 @@ mod tests {
         let mut reader = bytes.as_slice();
 
         let size = read_be_u32(&mut reader).unwrap();
-        assert_eq!(size as usize, bytes.len() - 4);
+        assert_eq!(size as usize, bytes.len().checked_sub(4).unwrap());
 
         let padding_tag = read_be_u8(&mut reader).unwrap();
         assert_eq!(padding_tag, PADDING_TAG);


### PR DESCRIPTION
# Description

- Enable the `arithmetic_side_effects` Clippy lint and fix the generated warnings.

## Related Issue(s)

Related to https://github.com/input-output-hk/catalyst-voices/issues/1467.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
