### PR TITLE
feat(rust/catalyst-types): Add report_duplicated_key and report_missing_keys functions to catalyst-types

### DIFF
--- a/rust/catalyst-types/src/cbor_utils.rs
+++ b/rust/catalyst-types/src/cbor_utils.rs
@@ -13,7 +13,7 @@ pub fn report_duplicated_key<T: Debug + PartialEq>(
     if found_keys.contains(key) {
         report.duplicate_field(
             format!("{key:?}").as_str(),
-            format!("Redundant key found in item {} in RBAC map", index + 1).as_str(),
+            format!("Redundant key found in item {}, index + 1).as_str(),
             context,
         );
         return true;

--- a/rust/catalyst-types/src/cbor_utils.rs
+++ b/rust/catalyst-types/src/cbor_utils.rs
@@ -13,7 +13,7 @@ pub fn report_duplicated_key<T: Debug + PartialEq>(
     if found_keys.contains(key) {
         report.duplicate_field(
             format!("{key:?}").as_str(),
-            format!("Redundant key found in item {} in RBAC map", index + 1).as_str(),
+            format!("Redundant key found in item {}", index + 1).as_str(),
             context,
         );
         return true;

--- a/rust/catalyst-types/src/cbor_utils.rs
+++ b/rust/catalyst-types/src/cbor_utils.rs
@@ -13,7 +13,7 @@ pub fn report_duplicated_key<T: Debug + PartialEq>(
     if found_keys.contains(key) {
         report.duplicate_field(
             format!("{key:?}").as_str(),
-            format!("Redundant key found in item {}, index + 1).as_str(),
+            format!("Redundant key found in item {} in RBAC map", index + 1).as_str(),
             context,
         );
         return true;

--- a/rust/catalyst-types/src/cbor_utils.rs
+++ b/rust/catalyst-types/src/cbor_utils.rs
@@ -1,0 +1,34 @@
+//! CBOR utilities that are highly tied to Catalyst types, so they don't belong to the
+//! `cbork-utils` crate.
+
+use std::fmt::Debug;
+
+use crate::problem_report::ProblemReport;
+
+/// Adds a "duplicated field" entry to the report and returns true if the field is already
+/// present in the given found keys list.
+pub fn report_duplicated_key<T: Debug + PartialEq>(
+    found_keys: &[T], key: &T, index: u64, context: &str, report: &ProblemReport,
+) -> bool {
+    if found_keys.contains(key) {
+        report.duplicate_field(
+            format!("{key:?}").as_str(),
+            format!("Redundant key found in item {} in RBAC map", index + 1).as_str(),
+            context,
+        );
+        return true;
+    }
+    false
+}
+
+/// Adds a "missing field" entry to the report for every required key that isn't present
+/// in the found keys list.
+pub fn report_missing_keys<T: Debug + PartialEq>(
+    found_keys: &[T], required_keys: &[T], context: &str, report: &ProblemReport,
+) {
+    for key in required_keys {
+        if !found_keys.contains(key) {
+            report.missing_field(&format!("{key:?}"), context);
+        }
+    }
+}

--- a/rust/catalyst-types/src/lib.rs
+++ b/rust/catalyst-types/src/lib.rs
@@ -1,5 +1,6 @@
 //! Catalyst Generic Types
 
+pub mod cbor_utils;
 pub mod conversion;
 pub mod hashes;
 pub mod id_uri;

--- a/rust/cbork-utils/Cargo.toml
+++ b/rust/cbork-utils/Cargo.toml
@@ -14,7 +14,4 @@ workspace = true
 minicbor = { version = "0.25.1", features = ["std"] }
 
 [dev-dependencies]
-proptest = { version = "1.5.0" }
-# Potentially it could be replaced with using `proptest::property_test` attribute macro,
-# after this PR will be merged https://github.com/proptest-rs/proptest/pull/523
-test-strategy = "0.4.0"
+proptest = { version = "1.6.0", features = ["attr-macro"] }

--- a/rust/cbork-utils/src/decode_helper.rs
+++ b/rust/cbork-utils/src/decode_helper.rs
@@ -95,11 +95,11 @@ pub fn decode_any<'d>(d: &mut Decoder<'d>, from: &str) -> Result<&'d [u8], decod
 #[cfg(test)]
 mod tests {
     use minicbor::Encoder;
-    use test_strategy::proptest;
+    use proptest::property_test;
 
     use super::*;
 
-    #[proptest]
+    #[property_test]
     fn test_decode_any_bytes(random_bytes: Vec<u8>) {
         let mut buf = Vec::new();
         let mut e = Encoder::new(&mut buf);
@@ -112,7 +112,7 @@ mod tests {
         assert_eq!(result, random_bytes);
     }
 
-    #[proptest]
+    #[property_test]
     fn test_decode_any_string(random_string: String) {
         let mut buf = Vec::new();
         let mut e = Encoder::new(&mut buf);
@@ -126,7 +126,7 @@ mod tests {
         assert_eq!(result, random_string);
     }
 
-    #[proptest]
+    #[property_test]
     fn test_decode_any_array(random_array: Vec<u8>) {
         // The array should contain a supported type
         let mut buf = Vec::new();
@@ -143,7 +143,7 @@ mod tests {
         assert_eq!(result, random_array.len() as u64);
     }
 
-    #[proptest]
+    #[property_test]
     fn test_decode_any_u32(random_u32: u32) {
         let mut buf = Vec::new();
         let mut e = Encoder::new(&mut buf);
@@ -157,7 +157,7 @@ mod tests {
         assert_eq!(result, random_u32);
     }
 
-    #[proptest]
+    #[property_test]
     fn test_decode_any_i32(random_i32: i32) {
         let mut buf = Vec::new();
         let mut e = Encoder::new(&mut buf);


### PR DESCRIPTION
# Description

Add `report_duplicated_key` and `report_missing_keys` functions to the `catalyst-types` crate.

## Related Pull Requests

https://github.com/input-output-hk/catalyst-libs/pull/178

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
