### PR TITLE
feat(rust/signed-doc): add binary compilation

### DIFF
--- a/rust/signed_doc/Cargo.toml
+++ b/rust/signed_doc/Cargo.toml
@@ -22,7 +22,13 @@ ed25519-dalek = { version = "2.1.1", features = ["pem", "rand_core"] }
 uuid = { version = "1.11.0", features = ["v4", "v7", "serde"] }
 hex = "0.4.3"
 strum = { version = "0.26.3", features = ["derive"] }
+clap = { version = "4.5.23",  features = ["derive", "env"] }
+
 
 [dev-dependencies]
-clap = { version = "4.5.23",  features = ["derive", "env"] }
 rand = "0.8.5"
+
+
+[[bin]]
+name = "signed-docs"
+path = "examples/mk_signed_doc.rs"


### PR DESCRIPTION
The following produces an ELF binary in the target after a release build.