### PR TITLE
feat(rust/catalyst-types): `uuid::Uuid` public import

### DIFF
--- a/rust/catalyst-types/src/uuid/mod.rs
+++ b/rust/catalyst-types/src/uuid/mod.rs
@@ -1,5 +1,6 @@
 //! `UUID` types.
 
+pub use uuid::Uuid;
 #[allow(clippy::module_name_repetitions)]
 pub use uuid_v4::UuidV4;
 #[allow(clippy::module_name_repetitions)]


### PR DESCRIPTION
# Description

Make a `uuid::Uuid` dependency import `pub`, so it could be possible to reuse `uuid::Uuid` on the clients code without explicit adding a `uuid` dependency.