### PR TITLE
fix(rust/signed-doc): Fix `ExtraFields::from_protected_header` error return

### DIFF
--- a/rust/signed_doc/src/metadata/extra_fields.rs
+++ b/rust/signed_doc/src/metadata/extra_fields.rs
@@ -1,6 +1,5 @@
 //! Catalyst Signed Document Extra Fields.
 
-use anyhow::bail;
 use catalyst_types::{problem_report::ProblemReport, uuid::UuidV4};
 use coset::{cbor::Value, Label, ProtectedHeader};
 
@@ -160,12 +159,14 @@ impl ExtraFields {
     }
 
     /// Converting COSE Protected Header to `ExtraFields`.
+    /// Return `None` if it fails during
     #[allow(clippy::too_many_lines)]
     pub(crate) fn from_protected_header(
         protected: &ProtectedHeader, error_report: &ProblemReport,
-    ) -> anyhow::Result<Self> {
+    ) -> Option<Self> {
         /// Context for error messages.
         const CONTEXT: &str = "COSE ProtectedHeader to ExtraFields";
+        let mut valid = false;
 
         let mut extra = ExtraFields::default();
 
@@ -177,6 +178,7 @@ impl ExtraFields {
                     extra.doc_ref = Some(doc_ref);
                 },
                 Err(e) => {
+                    valid = false;
                     error_report.conversion_error(
                         "CBOR COSE protected header doc ref",
                         &format!("{cbor_doc_ref:?}"),
@@ -195,6 +197,7 @@ impl ExtraFields {
                     extra.template = Some(doc_template);
                 },
                 Err(e) => {
+                    valid = false;
                     error_report.conversion_error(
                         "CBOR COSE protected header document template",
                         &format!("{cbor_doc_template:?}"),
@@ -213,6 +216,7 @@ impl ExtraFields {
                     extra.reply = Some(doc_reply);
                 },
                 Err(e) => {
+                    valid = false;
                     error_report.conversion_error(
                         "CBOR COSE protected header document reply",
                         &format!("{cbor_doc_reply:?}"),
@@ -231,6 +235,7 @@ impl ExtraFields {
                     extra.section = Some(doc_section);
                 },
                 Err(e) => {
+                    valid = false;
                     error_report.conversion_error(
                         "COSE protected header document section",
                         &format!("{cbor_doc_section:?}"),
@@ -253,6 +258,7 @@ impl ExtraFields {
                                 c.push(collaborator);
                             },
                             Err(e) => {
+                                valid = false;
                                 error_report.conversion_error(
                                     &format!("COSE protected header collaborator index {ids}"),
                                     &format!("{collaborator:?}"),
@@ -265,6 +271,7 @@ impl ExtraFields {
                     extra.collabs = c;
                 },
                 Err(e) => {
+                    valid = false;
                     error_report.conversion_error(
                         "CBOR COSE protected header collaborators",
                         &format!("{cbor_doc_collabs:?}"),
@@ -283,6 +290,7 @@ impl ExtraFields {
                     extra.brand_id = Some(brand_id);
                 },
                 Err(e) => {
+                    valid = false;
                     error_report.conversion_error(
                         "CBOR COSE protected header brand ID",
                         &format!("{cbor_doc_brand_id:?}"),
@@ -301,6 +309,7 @@ impl ExtraFields {
                     extra.campaign_id = Some(campaign_id);
                 },
                 Err(e) => {
+                    valid = false;
                     error_report.conversion_error(
                         "CBOR COSE protected header campaign ID",
                         &format!("{cbor_doc_campaign_id:?}"),
@@ -319,6 +328,7 @@ impl ExtraFields {
                     extra.election_id = Some(election_id);
                 },
                 Err(e) => {
+                    valid = false;
                     error_report.conversion_error(
                         "CBOR COSE protected header election ID",
                         &format!("{cbor_doc_election_id:?}"),
@@ -337,6 +347,7 @@ impl ExtraFields {
                     extra.category_id = Some(category_id);
                 },
                 Err(e) => {
+                    valid = false;
                     error_report.conversion_error(
                         "CBOR COSE protected header category ID",
                         &format!("{cbor_doc_category_id:?}"),
@@ -347,10 +358,7 @@ impl ExtraFields {
             }
         }
 
-        if error_report.is_problematic() {
-            bail!("Failed to convert COSE ProtectedHeader to ExtraFields");
-        }
-        Ok(extra)
+        valid.then_some(extra)
     }
 }
 

--- a/rust/signed_doc/src/metadata/extra_fields.rs
+++ b/rust/signed_doc/src/metadata/extra_fields.rs
@@ -166,7 +166,7 @@ impl ExtraFields {
     ) -> Option<Self> {
         /// Context for error messages.
         const CONTEXT: &str = "COSE ProtectedHeader to ExtraFields";
-        let mut valid = false;
+        let mut valid = true;
 
         let mut extra = ExtraFields::default();
 

--- a/rust/signed_doc/src/metadata/mod.rs
+++ b/rust/signed_doc/src/metadata/mod.rs
@@ -220,18 +220,7 @@ impl Metadata {
             error_report.missing_field("ver", "Missing ver field in COSE protected header");
         }
 
-        let extra = ExtraFields::from_protected_header(protected, error_report).map_or_else(
-            |e| {
-                error_report.conversion_error(
-                    "COSE protected header",
-                    &format!("{protected:?}"),
-                    &format!("Expected ExtraField: {e}"),
-                    &format!("{CONTEXT}, ExtraFields"),
-                );
-                None
-            },
-            Some,
-        );
+        let extra = ExtraFields::from_protected_header(protected, error_report);
 
         match (content_type, content_encoding, id, doc_type, ver, extra) {
             (


### PR DESCRIPTION
# Description

Updated `ExtraFields::from_protected_header` to return `Option<Self>` instead of unused `Result`.
Fixed issue with returning an invalid result when `error_report` argument passed with already predefined some error reports inside it.