### PR TITLE
feat(docs): Update Catalyst Signed Document specification.

### DIFF
--- a/docs/src/architecture/08_concepts/catalyst_docs/comment.md
+++ b/docs/src/architecture/08_concepts/catalyst_docs/comment.md
@@ -47,17 +47,21 @@ A list of used [Catalyst Signed Document protected header fields](./../signed_do
   ```
 
 * [`ref`](./../signed_doc/meta.md#ref-document-reference).
-  Reference to a related [Proposal Document].
-* [`template`](./../signed_doc/meta.md#ref-document-reference) must be equal to `0b8424d4-ebfd-46e3-9577-1775a69d290c` value,
-  [comment template type](#comment-template).
+  Reference to a related [Proposal Document],
+  which [`type`](./../signed_doc/spec.md#type) must be equal to
+  [proposal document `type`][Proposal Document] field value.
 
-  ```CDDL
-  "template" => 37(h'0b8424d4ebfd46e395771775a69d290c')
-  ```
+* [`template`](./../signed_doc/meta.md#ref-document-reference).
+  A reference to the comment template document,
+  which [`type`](./../signed_doc/spec.md#type) must be equal to
+  [comment template `type`](#comment-template) field value.
 
 * [`reply`](./../signed_doc/meta.md#reply-reply-reference) (optional).
-  A reference to another comment,
+  A reference to another comment document,
   where the comment is in reply to the referenced comment.
+  The [`type`](./../signed_doc/spec.md#type) of the replied document
+  must be equal to comment document `type` field value.
+
   Comments may only reply to a single other comment document.
   The referenced `comment` must be for the same proposal [`id`](./../signed_doc/spec.md#id),
   but can be for a different proposal [`ver`](./../signed_doc/spec.md#ver).

--- a/docs/src/architecture/08_concepts/catalyst_docs/comment.md
+++ b/docs/src/architecture/08_concepts/catalyst_docs/comment.md
@@ -43,7 +43,7 @@ A list of used [Catalyst Signed Document protected header fields](./../signed_do
   [Catalyst Signed Document content] must be [Brotli] compressed.
 
   ```CDDL
-  "content-type" => "br"
+  "content-encoding" => "br"
   ```
 
 * [`ref`](./../signed_doc/meta.md#ref-document-reference).
@@ -103,7 +103,7 @@ A list of used [Catalyst Signed Document protected header fields](./../signed_do
   [Catalyst Signed Document content] must be [Brotli] compressed.
 
   ```CDDL
-  "content-type" => "br"
+  "content-encoding" => "br"
   ```
 
 #### Content format

--- a/docs/src/architecture/08_concepts/catalyst_docs/comment.md
+++ b/docs/src/architecture/08_concepts/catalyst_docs/comment.md
@@ -61,7 +61,6 @@ A list of used [Catalyst Signed Document protected header fields](./../signed_do
   where the comment is in reply to the referenced comment.
   The [`type`](./../signed_doc/spec.md#type) of the replied document
   must be equal to comment document `type` field value.
-
   Comments may only reply to a single other comment document.
   The referenced `comment` must be for the same proposal [`id`](./../signed_doc/spec.md#id),
   but can be for a different proposal [`ver`](./../signed_doc/spec.md#ver).

--- a/docs/src/architecture/08_concepts/catalyst_docs/proposal.md
+++ b/docs/src/architecture/08_concepts/catalyst_docs/proposal.md
@@ -47,7 +47,7 @@ A list of used [Catalyst Signed Document protected header fields](./../signed_do
   [Catalyst Signed Document content] must be [Brotli] compressed.
 
   ```CDDL
-  "content-type" => "br"
+  "content-encoding" => "br"
   ```
 
 * [`template`](./../signed_doc/meta.md#ref-document-reference).
@@ -94,7 +94,7 @@ A list of used [Catalyst Signed Document protected header fields](./../signed_do
   [Catalyst Signed Document content] must be [Brotli] compressed.
 
   ```CDDL
-  "content-type" => "br"
+  "content-encoding" => "br"
   ```
 
 #### Content format

--- a/docs/src/architecture/08_concepts/catalyst_docs/proposal.md
+++ b/docs/src/architecture/08_concepts/catalyst_docs/proposal.md
@@ -60,7 +60,6 @@ A list of used [Catalyst Signed Document protected header fields](./../signed_do
   which [`type`](./../signed_doc/spec.md#type) must be equal to
   `48c20109-362a-4d32-9bba-e0a9cf8b45be` value.
 
-
 #### Content format
 
 TODO

--- a/docs/src/architecture/08_concepts/catalyst_docs/proposal.md
+++ b/docs/src/architecture/08_concepts/catalyst_docs/proposal.md
@@ -50,12 +50,16 @@ A list of used [Catalyst Signed Document protected header fields](./../signed_do
   "content-type" => "br"
   ```
 
-* [`template`](./../signed_doc/meta.md#ref-document-reference) must be equal to `0ce8ab38-9258-4fbc-a62e-7faa6e58318f` value,
-  [proposal template type](#proposal-template).
+* [`template`](./../signed_doc/meta.md#ref-document-reference).
+  A reference to the proposal template document,
+  which [`type`](./../signed_doc/spec.md#type) must be equal to
+  [proposal template `type`](#proposal-template) field value.
 
-  ```CDDL
-  "template" => 37(h'0ce8ab3892584fbca62e7faa6e58318f')
-  ```
+* [`category_id`](./../signed_doc/meta.md#category_id) (optional).
+  A reference to the category document,
+  which [`type`](./../signed_doc/spec.md#type) must be equal to
+  `48c20109-362a-4d32-9bba-e0a9cf8b45be` value.
+
 
 #### Content format
 

--- a/docs/src/architecture/08_concepts/catalyst_docs/review.md
+++ b/docs/src/architecture/08_concepts/catalyst_docs/review.md
@@ -47,7 +47,7 @@ A list of used [Catalyst Signed Document protected header fields](./../signed_do
   ```
 
 * [`template`](./../signed_doc/meta.md#ref-document-reference).
-  A reference to the comment template document,
+  A reference to the review template document,
   which [`type`](./../signed_doc/spec.md#type) must be equal to
   [review template `type`](#review-template) field value.
 

--- a/docs/src/architecture/08_concepts/catalyst_docs/review.md
+++ b/docs/src/architecture/08_concepts/catalyst_docs/review.md
@@ -43,7 +43,7 @@ A list of used [Catalyst Signed Document protected header fields](./../signed_do
   [Catalyst Signed Document content] must be [Brotli] compressed.
 
   ```CDDL
-  "content-type" => "br"
+  "content-encoding" => "br"
   ```
 
 * [`template`](./../signed_doc/meta.md#ref-document-reference).
@@ -85,7 +85,7 @@ A list of used [Catalyst Signed Document protected header fields](./../signed_do
   [Catalyst Signed Document content] must be [Brotli] compressed.
 
   ```CDDL
-  "content-type" => "br"
+  "content-encoding" => "br"
   ```
 
 #### Content format

--- a/docs/src/architecture/08_concepts/catalyst_docs/review.md
+++ b/docs/src/architecture/08_concepts/catalyst_docs/review.md
@@ -46,12 +46,10 @@ A list of used [Catalyst Signed Document protected header fields](./../signed_do
   "content-type" => "br"
   ```
 
-* [`template`](./../signed_doc/meta.md#ref-document-reference) must be equal to `ebe5d0bf-5d86-4577-af4d-008fddbe2edc` value,
-  [review template type](#review-template).
-
-  ```CDDL
-  "template" => 37(h'ebe5d0bf5d864577af4d008fddbe2edc')
-  ```
+* [`template`](./../signed_doc/meta.md#ref-document-reference).
+  A reference to the comment template document,
+  which [`type`](./../signed_doc/spec.md#type) must be equal to
+  [review template `type`](#review-template) field value.
 
 #### Content format
 

--- a/docs/src/architecture/08_concepts/signed_doc/meta.md
+++ b/docs/src/architecture/08_concepts/signed_doc/meta.md
@@ -115,4 +115,5 @@ e.g. "Development & Infrastructure", "Products & Integrations".
 
 [UUID]: https://www.rfc-editor.org/rfc/rfc9562.html
 [CBOR]: https://datatracker.ietf.org/doc/rfc8949/
+[JSON]: https://datatracker.ietf.org/doc/html/rfc7159
 [JSON Path]: https://datatracker.ietf.org/doc/html/rfc9535


### PR DESCRIPTION
# Description

- Fixed the part of specifying `template` fields for proposal, comment and review documents.
- Improved description of the comment's `ref`, `reply` fields.
- Added a new `category_id` field for the proposal document.