### PR TITLE
feat(rust): Remove unneeded patch of `orx-pseudo-default`

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -61,7 +61,3 @@ unchecked_duration_subtraction = "deny"
 unreachable = "deny"
 missing_docs_in_private_items = "deny"
 arithmetic_side_effects = "deny"
-
-# https://github.com/orxfun/orx-pseudo-default/issues/11
-[patch.crates-io]
-orx-pseudo-default = { git = "https://github.com/orxfun/orx-pseudo-default?rev=1.4.0", tag = "1.4.0" }


### PR DESCRIPTION
# Description

Removed unneeded patch of `orx-pseudo-default` as https://github.com/orxfun/orx-pseudo-default/issues/11 resolved