### PR TITLE
chore(rust/cbork): Update 'cbork-cddl-parser' dependency to use revision instead of tag

### DIFF
--- a/rust/cbork/Cargo.toml
+++ b/rust/cbork/Cargo.toml
@@ -15,10 +15,10 @@ workspace = true
 [dependencies]
 # Always used a versioned dependency, so that changes to dependent libraries do not cause cascading 
 # breakage inside the repo.
-cbork-cddl-parser = {version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "v0.0.3" }
+cbork-cddl-parser = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", rev = "r20250204-00" }
 # Only use this for testing - do not change dependency to this in checked in code.
 #cbork-cddl-parser = { path = "../cbork-cddl-parser", version = "0.1.0" }
-clap = { version = "4.5.19",  features = ["derive", "env"] }
+clap = { version = "4.5.19", features = ["derive", "env"] }
 anyhow = "1.0.89"
 console = "0.15.8"
 

--- a/rust/cbork/src/cli.rs
+++ b/rust/cbork/src/cli.rs
@@ -2,7 +2,7 @@
 
 use std::{path::PathBuf, process::exit};
 
-use cbork_cddl_parser::{parse_cddl, Extension};
+use cbork_cddl_parser::{validate_cddl, Extension};
 use clap::Parser;
 use console::{style, Emoji};
 
@@ -33,7 +33,7 @@ impl Cli {
 /// Check the CDDL file, return any errors
 fn check_file(file_path: &PathBuf) -> anyhow::Result<()> {
     let mut content = std::fs::read_to_string(file_path)?;
-    parse_cddl(&mut content, &Extension::CDDLParser)?;
+    validate_cddl(&mut content, &Extension::CDDL)?;
     Ok(())
 }
 


### PR DESCRIPTION
# Description

- Update the 'cbork-cddl-parser' dependency of the `cbork` crate to use revision instead of tag.

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
