### PR TITLE
fix(rust/catalyst-types): Implement Display for hash wrappers

### DIFF
--- a/rust/catalyst-types/src/hash_wrapper.rs
+++ b/rust/catalyst-types/src/hash_wrapper.rs
@@ -136,7 +136,7 @@ mod tests {
     #[test]
     fn display() {
         let hash = H1::new(&[1, 2, 3, 4, 5]);
-        let display = format!("{}", hash);
+        let display = format!("{hash}");
         let expected = "0x2a6ad53c3c6986406e1d6c7cfd06b69a";
         assert_eq!(expected, display);
     }

--- a/rust/catalyst-types/src/hash_wrapper.rs
+++ b/rust/catalyst-types/src/hash_wrapper.rs
@@ -33,6 +33,12 @@ macro_rules! define_hashes {
                 }
             }
 
+            impl std::fmt::Display for $name {
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    f.write_str(&format!("0x{}", self.0))
+                }
+            }
+
             impl From<$name> for Vec<u8> {
                 fn from(value: $name) -> Self {
                     value.0.into()
@@ -123,5 +129,15 @@ mod tests {
 
         let from_vec = H1::try_from(v).unwrap();
         assert_eq!(hash, from_vec);
+    }
+
+    // The display implementation is used to get user-friendly representation and must be
+    // equal to `hex::encode(<underlying bytes>)`.
+    #[test]
+    fn display() {
+        let hash = H1::new(&[1, 2, 3, 4, 5]);
+        let display = format!("{}", hash);
+        let expected = "0x2a6ad53c3c6986406e1d6c7cfd06b69a";
+        assert_eq!(expected, display);
     }
 }


### PR DESCRIPTION
# Description

- Implement the `Display` trait for types generated by the `define_hashes!` macro.

## Description of Changes

`Blake2bHash` implements `Display`, so it makes sense to implement this trait for derived types too. Also it is often used to print a user-friendly hash representation.

## Related Pull Requests

https://github.com/input-output-hk/catalyst-voices/pull/1367/

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
