### PR TITLE
fix(rust/cardano-blockchain-types): Introduce 'TxnOutputOffset' type

### DIFF
--- a/rust/cardano-blockchain-types/Cargo.toml
+++ b/rust/cardano-blockchain-types/Cargo.toml
@@ -20,8 +20,8 @@ workspace = true
 [dependencies]
 pallas = { version = "0.30.1", git = "https://github.com/input-output-hk/catalyst-pallas.git", rev = "9b5183c8b90b90fe2cc319d986e933e9518957b3" }
 # pallas-hardano = { version = "0.30.1", git = "https://github.com/input-output-hk/catalyst-pallas.git", rev = "9b5183c8b90b90fe2cc319d986e933e9518957b3" }
-cbork-utils = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250128-01" }
-catalyst-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250128-01" }
+cbork-utils = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250212-00" }
+catalyst-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250212-00" }
 
 ouroboros = "0.18.4"
 tracing = "0.1.41"

--- a/rust/cardano-blockchain-types/src/hashes.rs
+++ b/rust/cardano-blockchain-types/src/hashes.rs
@@ -9,5 +9,5 @@ define_hashes!(
     /// A transaction hash - Blake2b-256 hash of a transaction.
     (TransactionHash, Blake2b256Hash),
     /// A public key hash - raw Blake2b-224 hash of an Ed25519 public key (has no discriminator, just the hash).
-    (PubKeyHash, Blake2b224Hash)
+    (PubKeyHash, Blake2b224Hash),
 );

--- a/rust/cardano-blockchain-types/src/lib.rs
+++ b/rust/cardano-blockchain-types/src/lib.rs
@@ -10,6 +10,7 @@ mod network;
 mod point;
 mod slot;
 mod txn_index;
+mod txn_output_offset;
 mod txn_witness;
 
 pub use auxdata::{
@@ -29,4 +30,5 @@ pub use network::Network;
 pub use point::Point;
 pub use slot::Slot;
 pub use txn_index::TxnIndex;
+pub use txn_output_offset::TxnOutputOffset;
 pub use txn_witness::{TxnWitness, VKeyHash};

--- a/rust/cardano-blockchain-types/src/multi_era_block_data.rs
+++ b/rust/cardano-blockchain-types/src/multi_era_block_data.rs
@@ -294,6 +294,7 @@ impl MultiEraBlock {
     }
 
     /// Returns a slot of the block.
+    #[must_use]
     pub fn slot(&self) -> Slot {
         self.decode().slot().into()
     }

--- a/rust/cardano-blockchain-types/src/multi_era_block_data.rs
+++ b/rust/cardano-blockchain-types/src/multi_era_block_data.rs
@@ -24,6 +24,7 @@ use crate::{
     point::Point,
     txn_index::TxnIndex,
     txn_witness::{TxnWitness, VKeyHash},
+    Slot,
 };
 
 /// Self-referencing CBOR encoded data of a multi-era block.
@@ -278,10 +279,23 @@ impl MultiEraBlock {
         self.decode().txs()
     }
 
+    /// Returns an iterator over `(TxnIndex, MultiEraTx)` pair.
+    pub fn enumerate_txs(&self) -> impl Iterator<Item = (TxnIndex, MultiEraTx)> {
+        self.txs()
+            .into_iter()
+            .enumerate()
+            .map(|(i, t)| (i.into(), t))
+    }
+
     /// Get the auxiliary data of the block.
     #[must_use]
     pub fn aux_data(&self) -> &BlockAuxData {
         &self.inner.aux_data
+    }
+
+    /// Returns a slot of the block.
+    pub fn slot(&self) -> Slot {
+        self.decode().slot().into()
     }
 }
 

--- a/rust/cardano-blockchain-types/src/slot.rs
+++ b/rust/cardano-blockchain-types/src/slot.rs
@@ -1,18 +1,14 @@
 //! Block Slot
 
-use std::{
-    cmp::Ordering,
-    ops::{MulAssign, Sub},
-};
+use std::ops::{MulAssign, Sub};
 
 use catalyst_types::conversion::from_saturating;
 use num_bigint::{BigInt, Sign};
 use serde::Serialize;
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default, Serialize)]
-
 /// Slot on the blockchain, typically one slot equals one second. However chain
 /// parameters can alter how long a slot is.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize)]
 pub struct Slot(u64);
 
 impl Slot {
@@ -42,12 +38,6 @@ impl From<Slot> for u64 {
 impl MulAssign<u64> for Slot {
     fn mul_assign(&mut self, rhs: u64) {
         self.0 = self.0.saturating_mul(rhs);
-    }
-}
-
-impl PartialOrd for Slot {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.0.partial_cmp(&other.0)
     }
 }
 

--- a/rust/cardano-blockchain-types/src/txn_output_offset.rs
+++ b/rust/cardano-blockchain-types/src/txn_output_offset.rs
@@ -1,10 +1,9 @@
-//! Transaction Index
+//! A transaction output offset inside the transaction.
 use catalyst_types::conversion::from_saturating;
 
-/// Transaction index within a block
-/// See: <https://github.com/IntersectMBO/cardano-ledger/blob/78b32d585fd4a0340fb2b184959fb0d46f32c8d2/eras/conway/impl/cddl-files/conway.cddl#L20C1-L20C33>
+/// A transaction output offset inside the transaction.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct TxnIndex(u16);
+pub struct TxnOutputOffset(u16);
 
 impl<
         T: Copy
@@ -12,21 +11,21 @@ impl<
             + std::ops::Sub<Output = T>
             + PartialOrd<T>
             + num_traits::identities::Zero,
-    > From<T> for TxnIndex
+    > From<T> for TxnOutputOffset
 {
     fn from(value: T) -> Self {
         Self(from_saturating(value))
     }
 }
 
-impl From<TxnIndex> for i16 {
-    fn from(val: TxnIndex) -> Self {
+impl From<TxnOutputOffset> for i16 {
+    fn from(val: TxnOutputOffset) -> Self {
         i16::try_from(val.0).unwrap_or(i16::MAX)
     }
 }
 
-impl From<TxnIndex> for usize {
-    fn from(value: TxnIndex) -> Self {
+impl From<TxnOutputOffset> for usize {
+    fn from(value: TxnOutputOffset) -> Self {
         value.0.into()
     }
 }
@@ -35,55 +34,53 @@ impl From<TxnIndex> for usize {
 mod tests {
     use super::*;
 
-    // Test for `From<T>` conversion to `TxnIndex`
     #[test]
     fn test_from_u8_to_txn_index() {
-        let txn_index: TxnIndex = 100u8.into(); // u8 is a valid type for conversion
+        let txn_index: TxnOutputOffset = 100u8.into(); // u8 is a valid type for conversion
         assert_eq!(txn_index.0, 100);
     }
 
     #[test]
     fn test_from_u16_to_txn_index() {
-        let txn_index: TxnIndex = 500u16.into(); // u16 is valid and within range for `TxnIndex`
+        let txn_index: TxnOutputOffset = 500u16.into(); // u16 is valid and within range for `TxnOutputOffset`
         assert_eq!(txn_index.0, 500);
     }
 
     #[test]
     fn test_from_i32_to_txn_index() {
-        let txn_index: TxnIndex = 1234i32.into(); // i32 can be converted into `TxnIndex`
+        let txn_index: TxnOutputOffset = 1234i32.into(); // i32 can be converted into `TxnOutputOffset`
         assert_eq!(txn_index.0, 1234);
     }
 
     #[test]
     fn test_from_u32_to_txn_index() {
-        let txn_index: TxnIndex = 500_000u32.into(); // u32 is larger but should be saturated to `u16::MAX`
+        let txn_index: TxnOutputOffset = 500_000u32.into(); // u32 is larger but should be saturated to `u16::MAX`
         assert_eq!(txn_index.0, u16::MAX);
     }
 
     #[test]
     fn test_from_large_i32_to_txn_index() {
-        let txn_index: TxnIndex = 70000i32.into(); // i32 too large for u16, should saturate to `u16::MAX`
+        let txn_index: TxnOutputOffset = 70000i32.into(); // i32 too large for u16, should saturate to `u16::MAX`
         assert_eq!(txn_index.0, u16::MAX);
     }
 
-    // Test for `From<TxnIndex>` conversion to `i16`
     #[test]
     fn test_txn_index_to_i16_within_range() {
-        let txn_index = TxnIndex(100);
+        let txn_index = TxnOutputOffset(100);
         let result: i16 = txn_index.into(); // Should successfully convert to i16
         assert_eq!(result, 100);
     }
 
     #[test]
     fn test_txn_index_to_i16_with_saturation() {
-        let txn_index = TxnIndex(u16::MAX); // u16::MAX = 65535, which is too large for i16
+        let txn_index = TxnOutputOffset(u16::MAX); // u16::MAX = 65535, which is too large for i16
         let result: i16 = txn_index.into(); // Should saturate to i16::MAX
         assert_eq!(result, i16::MAX);
     }
 
     #[test]
     fn test_txn_index_to_i16_with_zero() {
-        let txn_index = TxnIndex(0); // Should be able to convert to i16 without issue
+        let txn_index = TxnOutputOffset(0); // Should be able to convert to i16 without issue
         let result: i16 = txn_index.into();
         assert_eq!(result, 0);
     }


### PR DESCRIPTION
# Description

- Introduce `TxnOutputOffset` type.
- Update `cbork-utils` and `catalyst-types` versions.
- Add `slot` and `enumerate_txs` methods to `MultiEraBlock`.

## Related Pull Requests

https://github.com/input-output-hk/catalyst-voices/pull/1367/

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
