### PR TITLE
feat(rust/rbac-registration): Use TransactionHash type

### DIFF
--- a/rust/catalyst-types/src/id_uri/mod.rs
+++ b/rust/catalyst-types/src/id_uri/mod.rs
@@ -714,4 +714,14 @@ mod tests {
         let encoded_vk = base64_url::encode(vk.as_bytes());
         assert_eq!(encoded_vk, "1234");
     }
+
+    #[test]
+    fn fixme_remove() {
+        // example: Some("cardano/FftxFnOrj2qmTuB2oZG2v0YEWJfKvQ9Gg8AgNAhDsKE".into()),
+        let id: IdUri = "cardano/FftxFnOrj2qmTuB2oZG2v0YEWJfKvQ9Gg8AgNAhDsKE"
+            .parse()
+            .unwrap();
+        println!("{:?}", id.role0_pk.as_bytes());
+        todo!();
+    }
 }

--- a/rust/catalyst-types/src/id_uri/mod.rs
+++ b/rust/catalyst-types/src/id_uri/mod.rs
@@ -714,14 +714,4 @@ mod tests {
         let encoded_vk = base64_url::encode(vk.as_bytes());
         assert_eq!(encoded_vk, "1234");
     }
-
-    #[test]
-    fn fixme_remove() {
-        // example: Some("cardano/FftxFnOrj2qmTuB2oZG2v0YEWJfKvQ9Gg8AgNAhDsKE".into()),
-        let id: IdUri = "cardano/FftxFnOrj2qmTuB2oZG2v0YEWJfKvQ9Gg8AgNAhDsKE"
-            .parse()
-            .unwrap();
-        println!("{:?}", id.role0_pk.as_bytes());
-        todo!();
-    }
 }

--- a/rust/rbac-registration/Cargo.toml
+++ b/rust/rbac-registration/Cargo.toml
@@ -32,6 +32,6 @@ uuid = "1.11.0"
 
 c509-certificate = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "v0.0.3" }
 pallas = { version = "0.30.1", git = "https://github.com/input-output-hk/catalyst-pallas.git", rev = "9b5183c8b90b90fe2cc319d986e933e9518957b3" }
-cbork-utils = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250127-00" }
-cardano-blockchain-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250127-00" }
-catalyst-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250127-00" }
+cbork-utils = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250212-00" }
+cardano-blockchain-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250214-00" }
+catalyst-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250212-00" }

--- a/rust/rbac-registration/src/cardano/cip509/cip509.rs
+++ b/rust/rbac-registration/src/cardano/cip509/cip509.rs
@@ -5,10 +5,11 @@
 use std::{borrow::Cow, collections::HashMap};
 
 use anyhow::{anyhow, Context};
-use cardano_blockchain_types::{MetadatumLabel, MultiEraBlock, TxnIndex};
+use cardano_blockchain_types::{MetadatumLabel, MultiEraBlock, TransactionHash, TxnIndex};
 use catalyst_types::{
     cbor_utils::{report_duplicated_key, report_missing_keys},
     hashes::{Blake2b256Hash, BLAKE_2B256_SIZE},
+    id_uri::IdUri,
     problem_report::ProblemReport,
     uuid::UuidV4,
 };
@@ -59,7 +60,7 @@ pub struct Cip509 {
     /// An optional hash of the previous transaction.
     ///
     /// The hash must always be present except for the first registration transaction.
-    prv_tx_id: Option<Blake2b256Hash>,
+    prv_tx_id: Option<TransactionHash>,
     /// Metadata.
     ///
     /// This field encoded in chunks. See [`X509Chunks`] for more details.
@@ -72,10 +73,14 @@ pub struct Cip509 {
     /// constructors.
     payment_history: PaymentHistory,
     /// A hash of the transaction from which this registration is extracted.
-    txn_hash: Blake2b256Hash,
+    txn_hash: TransactionHash,
     /// A point (slot) and a transaction index identifying the block and the transaction
     /// that this `Cip509` was extracted from.
     origin: PointTxnIdx,
+    /// A catalyst ID.
+    ///
+    /// This field is only present in role 0 registrations.
+    catalyst_id: Option<IdUri>,
     /// A report potentially containing all the issues occurred during `Cip509` decoding
     /// and validation.
     ///
@@ -139,7 +144,7 @@ impl Cip509 {
             payment_history,
             report: &mut report,
         };
-        let cip509 =
+        let mut cip509 =
             Cip509::decode(&mut decoder, &mut decode_context).context("Failed to decode Cip509")?;
 
         // Perform the validation.
@@ -156,7 +161,7 @@ impl Cip509 {
             validate_stake_public_key(txn, cip509.certificate_uris(), &cip509.report);
         }
         if let Some(metadata) = &cip509.metadata {
-            validate_role_data(metadata, &cip509.report);
+            cip509.catalyst_id = validate_role_data(metadata, &cip509.report);
         }
 
         Ok(Some(cip509))
@@ -210,7 +215,7 @@ impl Cip509 {
 
     /// Returns a hash of the previous transaction.
     #[must_use]
-    pub fn previous_transaction(&self) -> Option<Blake2b256Hash> {
+    pub fn previous_transaction(&self) -> Option<TransactionHash> {
         self.prv_tx_id
     }
 
@@ -228,7 +233,7 @@ impl Cip509 {
 
     /// Returns a hash of the transaction where this data is originating from.
     #[must_use]
-    pub fn txn_hash(&self) -> Blake2b256Hash {
+    pub fn txn_hash(&self) -> TransactionHash {
         self.txn_hash
     }
 
@@ -242,6 +247,12 @@ impl Cip509 {
     #[must_use]
     pub fn txn_inputs_hash(&self) -> Option<&TxInputHash> {
         self.txn_inputs_hash.as_ref()
+    }
+
+    /// Returns a Catalyst ID of this registration if role 0 is present.
+    #[must_use]
+    pub fn catalyst_id(&self) -> Option<&IdUri> {
+        self.catalyst_id.as_ref()
     }
 
     /// Returns `Cip509` fields consuming the structure if it was successfully decoded and
@@ -370,9 +381,10 @@ impl Decode<'_, DecodeContext<'_, '_>> for Cip509 {
                 .missing_field("metadata (10, 11 or 12 chunks)", context);
         }
 
-        let txn_hash = MultiEraTx::Conway(Box::new(Cow::Borrowed(decode_context.txn)))
-            .hash()
-            .into();
+        let txn_hash = Blake2b256Hash::from(
+            MultiEraTx::Conway(Box::new(Cow::Borrowed(decode_context.txn))).hash(),
+        )
+        .into();
         Ok(Self {
             purpose,
             txn_inputs_hash,
@@ -382,6 +394,7 @@ impl Decode<'_, DecodeContext<'_, '_>> for Cip509 {
             payment_history: HashMap::new(),
             txn_hash,
             origin: decode_context.origin.clone(),
+            catalyst_id: None,
             report: decode_context.report.clone(),
         })
     }
@@ -501,7 +514,7 @@ fn decode_input_hash(
 /// Decodes previous transaction id.
 fn decode_previous_transaction_id(
     d: &mut Decoder, context: &str, report: &ProblemReport,
-) -> Result<Option<Blake2b256Hash>, ()> {
+) -> Result<Option<TransactionHash>, ()> {
     let bytes = match decode_bytes(d, "Cip509 previous transaction id") {
         Ok(v) => v,
         Err(e) => {
@@ -515,7 +528,7 @@ fn decode_previous_transaction_id(
 
     let len = bytes.len();
     if let Ok(v) = Blake2b256Hash::try_from(bytes) {
-        Ok(Some(v))
+        Ok(Some(v.into()))
     } else {
         report.invalid_value(
             "previous transaction hash",

--- a/rust/rbac-registration/src/cardano/cip509/validation.rs
+++ b/rust/rbac-registration/src/cardano/cip509/validation.rs
@@ -352,6 +352,7 @@ fn c509_cert_key(cert: &C509, context: &str, report: &ProblemReport) -> Option<V
 fn verifying_key(
     extended_public_key: &[u8], context: &str, report: &ProblemReport,
 ) -> Option<VerifyingKey> {
+    /// An extender public key length in bytes.
     const EXTENDED_PUBLIC_KEY_LENGTH: usize = 64;
 
     if extended_public_key.len() != EXTENDED_PUBLIC_KEY_LENGTH {

--- a/rust/rbac-registration/src/registration/cardano/mod.rs
+++ b/rust/rbac-registration/src/registration/cardano/mod.rs
@@ -4,7 +4,8 @@ use std::{collections::HashMap, sync::Arc};
 
 use anyhow::bail;
 use c509_certificate::c509::C509;
-use catalyst_types::{hashes::Blake2b256Hash, uuid::UuidV4};
+use cardano_blockchain_types::TransactionHash;
+use catalyst_types::uuid::UuidV4;
 use ed25519_dalek::VerifyingKey;
 use tracing::{error, warn};
 use x509_cert::certificate::Certificate as X509Certificate;
@@ -57,7 +58,7 @@ impl RegistrationChain {
 
     /// Get the current transaction ID hash.
     #[must_use]
-    pub fn current_tx_id_hash(&self) -> Blake2b256Hash {
+    pub fn current_tx_id_hash(&self) -> TransactionHash {
         self.inner.current_tx_id_hash
     }
 
@@ -108,7 +109,7 @@ impl RegistrationChain {
 #[derive(Debug, Clone)]
 struct RegistrationChainInner {
     /// The current transaction ID hash (32 bytes)
-    current_tx_id_hash: Blake2b256Hash,
+    current_tx_id_hash: TransactionHash,
     /// List of purpose for this registration chain
     purpose: Vec<UuidV4>,
 

--- a/rust/rbac-registration/src/utils/test.rs
+++ b/rust/rbac-registration/src/utils/test.rs
@@ -2,8 +2,8 @@
 
 // cspell: words stake_test1urs8t0ssa3w9wh90ld5tprp3gurxd487rth2qlqk6ernjqcef4ugr
 
-use cardano_blockchain_types::{MultiEraBlock, Network, Point, Slot, TxnIndex};
-use catalyst_types::{hashes::Blake2b256Hash, uuid::UuidV4};
+use cardano_blockchain_types::{MultiEraBlock, Network, Point, Slot, TransactionHash, TxnIndex};
+use catalyst_types::uuid::UuidV4;
 use uuid::Uuid;
 
 use crate::cardano::cip509::{Cip509, RoleNumber};
@@ -20,9 +20,9 @@ pub struct BlockTestData {
     /// Transaction index.
     pub txn_index: TxnIndex,
     /// Transaction hash.
-    pub txn_hash: Blake2b256Hash,
+    pub txn_hash: TransactionHash,
     /// Previous hash.
-    pub prv_hash: Option<Blake2b256Hash>,
+    pub prv_hash: Option<TransactionHash>,
     /// Purpose.
     pub purpose: UuidV4,
     /// Stake address.


### PR DESCRIPTION
# Description

- Use the `TransactionHash` type in the `rbac-registration` crate.
- Store `IdUri` in `Cip509`.

## Related Pull Requests

https://github.com/input-output-hk/catalyst-voices/pull/1367/

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
