### PR TITLE
chore(rust/rbac-registration): bump cardano-blockchain-types

### DIFF
--- a/rust/rbac-registration/Cargo.toml
+++ b/rust/rbac-registration/Cargo.toml
@@ -33,5 +33,5 @@ uuid = "1.11.0"
 c509-certificate = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "v0.0.3" }
 pallas = { version = "0.30.1", git = "https://github.com/input-output-hk/catalyst-pallas.git", rev = "9b5183c8b90b90fe2cc319d986e933e9518957b3" }
 cbork-utils = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250127-00" }
-cardano-blockchain-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250127-00" }
+cardano-blockchain-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250214-00" }
 catalyst-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250127-00" }


### PR DESCRIPTION
# Description

Bump tag for cardano-blockchain-types in rbac-registration
