### PR TITLE
chore(general): Update pallas version

### DIFF
--- a/rust/cardano-blockchain-types/Cargo.toml
+++ b/rust/cardano-blockchain-types/Cargo.toml
@@ -20,8 +20,8 @@ workspace = true
 [dependencies]
 pallas = "0.32.0"
 # pallas-hardano = { version = "0.30.1", git = "https://github.com/input-output-hk/catalyst-pallas.git", rev = "9b5183c8b90b90fe2cc319d986e933e9518957b3" }
-cbork-utils = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", branch = "update-pallas-version" }
-catalyst-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", branch = "update-pallas-version" }
+cbork-utils = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250218-00" }
+catalyst-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250218-00" }
 
 ouroboros = "0.18.4"
 tracing = "0.1.41"

--- a/rust/cardano-blockchain-types/Cargo.toml
+++ b/rust/cardano-blockchain-types/Cargo.toml
@@ -18,10 +18,10 @@ crate-type = ["cdylib", "rlib"]
 workspace = true
 
 [dependencies]
-pallas = { version = "0.30.1", git = "https://github.com/input-output-hk/catalyst-pallas.git", rev = "9b5183c8b90b90fe2cc319d986e933e9518957b3" }
+pallas = "0.32.0"
 # pallas-hardano = { version = "0.30.1", git = "https://github.com/input-output-hk/catalyst-pallas.git", rev = "9b5183c8b90b90fe2cc319d986e933e9518957b3" }
-cbork-utils = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250212-00" }
-catalyst-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250212-00" }
+cbork-utils = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", branch = "update-pallas-version" }
+catalyst-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", branch = "update-pallas-version" }
 
 ouroboros = "0.18.4"
 tracing = "0.1.41"

--- a/rust/cardano-blockchain-types/Cargo.toml
+++ b/rust/cardano-blockchain-types/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cardano-blockchain-types"
 description = "Common Cardano Blockchain data types for use in both applications and crates"
 keywords = ["cardano", "catalyst", ]
-version = "0.0.1"
+version = "0.0.2"
 authors = [
     "Steven Johnson <steven.johnson@iohk.io>"
 ]

--- a/rust/cardano-chain-follower/Cargo.toml
+++ b/rust/cardano-chain-follower/Cargo.toml
@@ -19,8 +19,8 @@ mithril-client = { version = "0.10.4", default-features = false, features = [
     "full",
     "num-integer-backend",
 ] }
-cardano-blockchain-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", branch = "update-pallas-version" }
-catalyst-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", branch = "update-pallas-version" }
+cardano-blockchain-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250218-00" }
+catalyst-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250218-00" }
 
 thiserror = "1.0.69"
 tokio = { version = "1.42.0", features = [
@@ -63,7 +63,7 @@ test-log = { version = "0.2.16", default-features = false, features = [
     "trace",
 ] }
 clap = "4.5.23"
-# rbac-registration = { version = "0.0.2", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "v0.0.8" }
+# rbac-registration = { version = "0.0.2", git = "https://github.com/input-output-hk/catalyst-libs.git", "tag = "r20250218-00" }
 
 # Note, these features are for support of features exposed by dependencies.
 [features]

--- a/rust/cardano-chain-follower/Cargo.toml
+++ b/rust/cardano-chain-follower/Cargo.toml
@@ -11,16 +11,16 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-pallas = { version = "0.30.1", git = "https://github.com/input-output-hk/catalyst-pallas.git", rev = "9b5183c8b90b90fe2cc319d986e933e9518957b3" }
-pallas-hardano = { version = "0.30.1", git = "https://github.com/input-output-hk/catalyst-pallas.git", rev = "9b5183c8b90b90fe2cc319d986e933e9518957b3" }
-pallas-crypto = { version = "0.30.1", git = "https://github.com/input-output-hk/catalyst-pallas.git", rev = "9b5183c8b90b90fe2cc319d986e933e9518957b3" }
+pallas = "0.32.0"
+pallas-hardano = "0.32.0"
+pallas-crypto = "0.32.0"
 
 mithril-client = { version = "0.10.4", default-features = false, features = [
     "full",
     "num-integer-backend",
 ] }
-cardano-blockchain-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250214-00" }
-catalyst-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250212-00" }
+cardano-blockchain-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", branch = "update-pallas-version" }
+catalyst-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", branch = "update-pallas-version" }
 
 thiserror = "1.0.69"
 tokio = { version = "1.42.0", features = [

--- a/rust/cardano-chain-follower/Cargo.toml
+++ b/rust/cardano-chain-follower/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cardano-chain-follower"
-version = "0.0.6"
+version = "0.0.7"
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/rust/cardano-chain-follower/Cargo.toml
+++ b/rust/cardano-chain-follower/Cargo.toml
@@ -63,7 +63,7 @@ test-log = { version = "0.2.16", default-features = false, features = [
     "trace",
 ] }
 clap = "4.5.23"
-# rbac-registration = { version = "0.0.2", git = "https://github.com/input-output-hk/catalyst-libs.git", "tag = "r20250218-00" }
+# rbac-registration = { version = "0.0.2", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250218-00" }
 
 # Note, these features are for support of features exposed by dependencies.
 [features]

--- a/rust/catalyst-types/Cargo.toml
+++ b/rust/catalyst-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catalyst-types"
-version = "0.0.1"
+version = "0.0.2"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/rust/catalyst-types/Cargo.toml
+++ b/rust/catalyst-types/Cargo.toml
@@ -24,7 +24,7 @@ hex = "0.4.3"
 minicbor = { version = "0.25.1", features = ["std"] }
 num-traits = "0.2.19"
 orx-concurrent-vec = { version = "3.2.0", features = ["serde"] }
-pallas-crypto = { version = "0.30.1", git = "https://github.com/input-output-hk/catalyst-pallas.git", rev = "9b5183c8b90b90fe2cc319d986e933e9518957b3" }
+pallas-crypto = "0.32.0"
 serde = { version = "1.0.217", features = ["derive", "rc"] }
 thiserror = "2.0.11"
 base64-url = "3.0.0"

--- a/rust/rbac-registration/Cargo.toml
+++ b/rust/rbac-registration/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rbac-registration"
 description = "Role Based Access Control Registration"
 keywords = ["cardano", "catalyst", "rbac registration"]
-version = "0.0.2"
+version = "0.0.3"
 authors = [
     "Arissara Chotivichit <arissara.chotivichit@iohk.io>"
 ]

--- a/rust/rbac-registration/Cargo.toml
+++ b/rust/rbac-registration/Cargo.toml
@@ -29,9 +29,9 @@ der-parser = "9.0.0"
 tracing = "0.1.40"
 ed25519-dalek = "2.1.1"
 uuid = "1.11.0"
+pallas = "0.32.0"
 
-c509-certificate = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "v0.0.3" }
-pallas = { version = "0.30.1", git = "https://github.com/input-output-hk/catalyst-pallas.git", rev = "9b5183c8b90b90fe2cc319d986e933e9518957b3" }
-cbork-utils = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250212-00" }
-cardano-blockchain-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250214-00" }
-catalyst-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250212-00" }
+c509-certificate = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", branch = "update-pallas-version" }
+cbork-utils = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", branch = "update-pallas-version" }
+cardano-blockchain-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", branch = "update-pallas-version" }
+catalyst-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", branch = "update-pallas-version" }

--- a/rust/rbac-registration/Cargo.toml
+++ b/rust/rbac-registration/Cargo.toml
@@ -31,7 +31,7 @@ ed25519-dalek = "2.1.1"
 uuid = "1.11.0"
 pallas = "0.32.0"
 
-c509-certificate = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", branch = "update-pallas-version" }
-cbork-utils = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", branch = "update-pallas-version" }
-cardano-blockchain-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", branch = "update-pallas-version" }
-catalyst-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", branch = "update-pallas-version" }
+c509-certificate = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250218-00" }
+cbork-utils = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250218-00" }
+cardano-blockchain-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250218-00" }
+catalyst-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250218-00" }

--- a/rust/signed_doc/Cargo.toml
+++ b/rust/signed_doc/Cargo.toml
@@ -11,8 +11,8 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-rbac-registration = { version = "0.0.2", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250217-00" }
-catalyst-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250212-00" }
+rbac-registration = { version = "0.0.2", git = "https://github.com/input-output-hk/catalyst-libs.git", branch = "update-pallas-version" }
+catalyst-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", branch = "update-pallas-version" }
 anyhow = "1.0.95"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.134"

--- a/rust/signed_doc/Cargo.toml
+++ b/rust/signed_doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catalyst-signed-doc"
-version = "0.0.1"
+version = "0.0.2"
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/rust/signed_doc/Cargo.toml
+++ b/rust/signed_doc/Cargo.toml
@@ -11,8 +11,8 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-rbac-registration = { version = "0.0.2", git = "https://github.com/input-output-hk/catalyst-libs.git", branch = "update-pallas-version" }
-catalyst-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", branch = "update-pallas-version" }
+rbac-registration = { version = "0.0.2", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250218-00" }
+catalyst-types = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250218-00" }
 anyhow = "1.0.95"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.134"


### PR DESCRIPTION
# Description

- Use the upstream latest (0.32.0) `pallas` version instead of our fork.
- Bump `cardano-blockchain-types`, `cardano-chain-follower`, `catalyst-types`, `rbac-registration` and `catalyst-signed-doc` versions.

## Description of Changes

I have just checked and both libs and `catalyst-voices` are ok with using the latest version. There are a very few minor changes (in `catalyst-voices`) required.

The `r20250218-00` tag that is used in this pull request isn't published yet, so build will fail, but I have checked everything using a branch as a dependency and everything was ok.

## Related Pull Requests

https://github.com/input-output-hk/catalyst-voices/pull/1367

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
