### PR TITLE
fix(rust/catalyst-types): IdUri::is_id take self by reference

### DIFF
--- a/rust/catalyst-types/src/id_uri/mod.rs
+++ b/rust/catalyst-types/src/id_uri/mod.rs
@@ -138,9 +138,9 @@ impl IdUri {
         Self { id: true, ..self }
     }
 
-    /// Was `IdUri` formatted as a id when it was parsed.
+    /// Was `IdUri` formatted as an id when it was parsed.
     #[must_use]
-    pub fn is_id(self) -> bool {
+    pub fn is_id(&self) -> bool {
         self.id
     }
 


### PR DESCRIPTION
# Description

- Update `IdUri::is_id` method signature (`&self` instead of `self`).
