### PR TITLE
feat(): Bump `catalyst-ci`

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,7 +1,7 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/mdlint:v3.2.27 AS mdlint-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cspell:v3.2.27 AS cspell-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/mdlint:v3.3.0 AS mdlint-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cspell:v3.3.0 AS cspell-ci
 
 
 FROM debian:stable-slim

--- a/docs/Earthfile
+++ b/docs/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.2.27 AS docs-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.3.0 AS docs-ci
 
 
 IMPORT .. AS repo

--- a/docs/src/architecture/08_concepts/catalyst_voting/cddl/Earthfile
+++ b/docs/src/architecture/08_concepts/catalyst_voting/cddl/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:v3.2.27 AS cddl-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:v3.3.0 AS cddl-ci
 
 check-cddl:
     FROM cddl-ci+cddl-base

--- a/docs/src/architecture/08_concepts/immutable_ledger/cddl/Earthfile
+++ b/docs/src/architecture/08_concepts/immutable_ledger/cddl/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:v3.2.27 AS cddl-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:v3.3.0 AS cddl-ci
 
 check-cddl:
     FROM cddl-ci+cddl-base

--- a/docs/src/architecture/08_concepts/signed_doc/cddl/Earthfile
+++ b/docs/src/architecture/08_concepts/signed_doc/cddl/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:v3.2.27 AS cddl-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:v3.3.0 AS cddl-ci
 
 check-cddl:
     FROM cddl-ci+cddl-base

--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.2.37 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.3.0 AS rust-ci
 
 COPY_SRC:
     FUNCTION

--- a/rust/c509-certificate/Earthfile
+++ b/rust/c509-certificate/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust::v3.2.27 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust::v3.3.0 AS rust-ci
 
 
 IMPORT .. AS rust-local

--- a/rust/signed_doc/Cargo.toml
+++ b/rust/signed_doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catalyst-signed-doc"
-version = "0.0.3"
+version = "0.0.4"
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
# Description

Bumped a `catalyst-ci` version to the `3.3.0` which enforces to use a rustc `1.85`