### PR TITLE
fix(rust/rbac-registration): Store role data in BTreeMap isnstead of HashMap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,11 @@ name: CI
 on:
   push:
     branches: [main]
+    tags: ["**"]
   pull_request:
     types:
       - synchronize
       - ready_for_review
-    
 
 permissions:
   id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
       - synchronize
       - ready_for_review
 
+
 permissions:
   id-token: write
   contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   push:
     branches: [main]
-    tags: ["**"]
   pull_request:
     types:
       - synchronize

--- a/rust/rbac-registration/src/cardano/cip509/rbac/metadata.rs
+++ b/rust/rbac-registration/src/cardano/cip509/rbac/metadata.rs
@@ -1,6 +1,6 @@
 //! Cip509 RBAC metadata.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use catalyst_types::{cbor_utils::report_duplicated_key, problem_report::ProblemReport};
 use cbork_utils::decode_helper::{
@@ -46,7 +46,7 @@ pub struct Cip509RbacMetadata {
     /// A potentially empty list of revoked certificates.
     pub revocation_list: Vec<CertKeyHash>,
     /// A potentially empty role data.
-    pub role_data: HashMap<RoleNumber, RoleData>,
+    pub role_data: BTreeMap<RoleNumber, RoleData>,
     /// Optional map of purpose key data.
     /// Empty map if no purpose key data is present.
     pub purpose_key_data: HashMap<u16, Vec<u8>>,
@@ -85,7 +85,7 @@ impl Decode<'_, DecodeContext<'_, '_>> for Cip509RbacMetadata {
         let mut c509_certs = Vec::new();
         let mut pub_keys = Vec::new();
         let mut revocation_list = Vec::new();
-        let mut role_data = HashMap::new();
+        let mut role_data = BTreeMap::new();
         let mut purpose_key_data = HashMap::new();
 
         for index in 0..map_len {
@@ -273,7 +273,7 @@ fn report_duplicated_roles(data: &[CborRoleData], context: &str, report: &Proble
 /// Decodes and converts a role data.
 fn decode_role_data(
     d: &mut Decoder, context: &str, decode_context: &mut DecodeContext,
-) -> Option<HashMap<RoleNumber, RoleData>> {
+) -> Option<BTreeMap<RoleNumber, RoleData>> {
     let roles = decode_array(d, "Cip509RbacMetadata role set", decode_context.report)?;
     report_duplicated_roles(&roles, context, decode_context.report);
     let roles = roles

--- a/rust/rbac-registration/src/cardano/cip509/types/role_number.rs
+++ b/rust/rbac-registration/src/cardano/cip509/types/role_number.rs
@@ -1,7 +1,7 @@
 //! A role number for `RoleData` in RBAC metadata.
 
 /// A role number for `RoleData` in `Cip509RbacMetadata`.
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Hash)]
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash)]
 pub struct RoleNumber(u8);
 
 impl RoleNumber {

--- a/rust/rbac-registration/src/registration/cardano/mod.rs
+++ b/rust/rbac-registration/src/registration/cardano/mod.rs
@@ -1,6 +1,9 @@
 //! Chain of Cardano registration data
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Arc,
+};
 
 use anyhow::bail;
 use c509_certificate::c509::C509;
@@ -94,7 +97,7 @@ impl RegistrationChain {
 
     /// Get the map of role number to point, transaction index, and role data.
     #[must_use]
-    pub fn role_data(&self) -> &HashMap<RoleNumber, (PointTxnIdx, RoleData)> {
+    pub fn role_data(&self) -> &BTreeMap<RoleNumber, (PointTxnIdx, RoleData)> {
         &self.inner.role_data
     }
 
@@ -127,7 +130,7 @@ struct RegistrationChainInner {
 
     // Role
     /// Map of role number to point, transaction index, and role data.
-    role_data: HashMap<RoleNumber, (PointTxnIdx, RoleData)>,
+    role_data: BTreeMap<RoleNumber, (PointTxnIdx, RoleData)>,
     /// Map of tracked payment key to its history.
     payment_history: PaymentHistory,
 }
@@ -364,8 +367,8 @@ fn revocations_list(
 
 /// Process the role data for chain root.
 fn chain_root_role_data(
-    role_data: HashMap<RoleNumber, RoleData>, point_tx_idx: &PointTxnIdx,
-) -> HashMap<RoleNumber, (PointTxnIdx, RoleData)> {
+    role_data: BTreeMap<RoleNumber, RoleData>, point_tx_idx: &PointTxnIdx,
+) -> BTreeMap<RoleNumber, (PointTxnIdx, RoleData)> {
     role_data
         .into_iter()
         .map(|(number, data)| (number, (point_tx_idx.clone(), data)))
@@ -374,7 +377,7 @@ fn chain_root_role_data(
 
 /// Update the role data in the registration chain.
 fn update_role_data(
-    inner: &mut RegistrationChainInner, role_set: HashMap<RoleNumber, RoleData>,
+    inner: &mut RegistrationChainInner, role_set: BTreeMap<RoleNumber, RoleData>,
     point_tx_idx: &PointTxnIdx,
 ) {
     for (number, mut data) in role_set {


### PR DESCRIPTION
# Description

- Store role data in `BTreeMap` instead of `HashMap`.

## Description of Changes

Sometimes we need to access the latest role data and it is impossible (or rather very inefficient and inconvenient) with `HashMap`.

## Related Pull Requests

https://github.com/input-output-hk/catalyst-voices/pull/1941
