### PR TITLE
feat(rust/cardano-blockchain-types): Fix comments

### DIFF
--- a/rust/cardano-blockchain-types/src/metadata/cip36/key_registration.rs
+++ b/rust/cardano-blockchain-types/src/metadata/cip36/key_registration.rs
@@ -47,7 +47,6 @@ pub(crate) struct Cip36KeyRegistration {
     /// None if it is not set.
     pub payment_addr: Option<ShelleyAddress>,
     /// Nonce (nonce that has been slot corrected).
-    /// Field 4 in the CIP-36 61284 Spec.
     /// None if it is not set.
     pub nonce: Option<u64>,
     /// Registration Purpose (Always 0 for Catalyst).
@@ -55,6 +54,7 @@ pub(crate) struct Cip36KeyRegistration {
     /// Default to 0.
     pub purpose: u64,
     /// Raw nonce (nonce that has not had slot correction applied).
+    /// Field 4 in the CIP-36 61284 Spec.
     /// None if it is not set.
     pub raw_nonce: Option<u64>,
     /// Is payment address payable? (not a script)

--- a/rust/cardano-blockchain-types/src/metadata/cip36/mod.rs
+++ b/rust/cardano-blockchain-types/src/metadata/cip36/mod.rs
@@ -229,8 +229,8 @@ impl Cip36 {
     /// Get the `is_cip36` flag from the registration.
     /// True if it is CIP-36 format, false if CIP-15 format.
     #[must_use]
-    pub fn is_cip36(&self) -> Option<bool> {
-        self.key_registration.is_cip36
+    pub fn is_cip36(&self) -> bool {
+        self.key_registration.is_cip36.unwrap_or_default()
     }
 
     /// Get the voting public keys from the registration.
@@ -271,8 +271,8 @@ impl Cip36 {
 
     /// Is the payment address in the registration payable?
     #[must_use]
-    pub fn is_payable(&self) -> Option<bool> {
-        self.key_registration.is_payable
+    pub fn is_payable(&self) -> bool {
+        self.key_registration.is_payable.unwrap_or_default()
     }
 
     /// Get the signature from the registration witness.

--- a/rust/cardano-blockchain-types/src/metadata/cip36/mod.rs
+++ b/rust/cardano-blockchain-types/src/metadata/cip36/mod.rs
@@ -229,8 +229,8 @@ impl Cip36 {
     /// Get the `is_cip36` flag from the registration.
     /// True if it is CIP-36 format, false if CIP-15 format.
     #[must_use]
-    pub fn is_cip36(&self) -> bool {
-        self.key_registration.is_cip36.unwrap_or_default()
+    pub fn is_cip36(&self) -> Option<bool> {
+        self.key_registration.is_cip36
     }
 
     /// Get the voting public keys from the registration.
@@ -271,8 +271,8 @@ impl Cip36 {
 
     /// Is the payment address in the registration payable?
     #[must_use]
-    pub fn is_payable(&self) -> bool {
-        self.key_registration.is_payable.unwrap_or_default()
+    pub fn is_payable(&self) -> Option<bool> {
+        self.key_registration.is_payable
     }
 
     /// Get the signature from the registration witness.


### PR DESCRIPTION
# Description

Fix doc comments for the `Cip36KeyRegistration` fields