### PR TITLE
fix(rust/cardano-blockchain-types): CIP36 payment address type

### DIFF
--- a/rust/cardano-blockchain-types/src/metadata/cip36/key_registration.rs
+++ b/rust/cardano-blockchain-types/src/metadata/cip36/key_registration.rs
@@ -62,7 +62,9 @@ pub(crate) struct Cip36KeyRegistration {
     pub is_payable: Option<bool>,
 }
 
-/// Header type of address that are consider as payable.
+/// Header type of Shelley address that are consider as payable.
+/// Payable if payment part is a `PaymentKeyHash`
+/// <https://cips.cardano.org/cip/CIP-19>
 const VALID_PAYABLE_HEADER: [u8; 4] = [0, 2, 4, 6];
 
 /// Enum of CIP36 registration (61284) with its associated unsigned integer key.
@@ -117,7 +119,7 @@ impl Decode<'_, ProblemReport> for Cip36KeyRegistration {
                         let address = decode_payment_addr(d, err_report)?;
                         cip36_key_registration.is_payable = address
                             .as_ref()
-                            .map(|addr| !VALID_PAYABLE_HEADER.contains(&addr.typeid()))
+                            .map(|addr| VALID_PAYABLE_HEADER.contains(&addr.typeid()))
                             .or(None);
                         cip36_key_registration.payment_addr = address;
                     },

--- a/rust/cardano-blockchain-types/src/metadata/cip36/mod.rs
+++ b/rust/cardano-blockchain-types/src/metadata/cip36/mod.rs
@@ -10,7 +10,7 @@ use catalyst_types::problem_report::ProblemReport;
 use ed25519_dalek::VerifyingKey;
 use key_registration::Cip36KeyRegistration;
 use minicbor::{Decode, Decoder};
-use pallas::ledger::addresses::ShelleyAddress;
+use pallas::ledger::addresses::Address;
 use registration_witness::Cip36RegistrationWitness;
 use voting_pk::VotingPubKey;
 
@@ -247,7 +247,7 @@ impl Cip36 {
 
     /// Get the payment address from the registration.
     #[must_use]
-    pub fn payment_address(&self) -> Option<&ShelleyAddress> {
+    pub fn payment_address(&self) -> Option<&Address> {
         self.key_registration.payment_addr.as_ref()
     }
 

--- a/rust/cardano-blockchain-types/src/metadata/cip36/validation.rs
+++ b/rust/cardano-blockchain-types/src/metadata/cip36/validation.rs
@@ -74,7 +74,16 @@ impl Cip36 {
             return;
         };
         // Extract the network tag and validate
-        let network_tag = address.network();
+        let Some(network_tag) = address.network() else {
+            // Byron address don't have network tag
+            self.err_report.missing_field(
+                "Network tag",
+                "Validate CIP36 payment address network, network tag not found",
+            );
+            self.is_valid_payment_address_network = false;
+            return;
+        };
+
         let valid = match self.network {
             Network::Mainnet => network_tag.value() == 1,
             Network::Preprod | Network::Preview => network_tag.value() == 0,
@@ -164,12 +173,9 @@ mod tests {
         // cSpell:disable
         let addr = Address::from_bech32("addr_test1qprhw4s70k0vzyhvxp6h97hvrtlkrlcvlmtgmaxdtjz87xrjkctk27ypuv9dzlzxusqse89naweygpjn5dxnygvus05sdq9h07").expect("Failed to create address");
         // cSpell:enable
-        let Address::Shelley(shelley_addr) = addr else {
-            panic!("Invalid address type")
-        };
         let mut cip36 = create_cip36();
         cip36.key_registration = Cip36KeyRegistration {
-            payment_addr: Some(shelley_addr),
+            payment_addr: Some(addr),
             ..Default::default()
         };
         cip36.validate_payment_address_network();
@@ -183,13 +189,10 @@ mod tests {
         // cSpell:disable
         let addr = Address::from_bech32("addr_test1qprhw4s70k0vzyhvxp6h97hvrtlkrlcvlmtgmaxdtjz87xrjkctk27ypuv9dzlzxusqse89naweygpjn5dxnygvus05sdq9h07").expect("Failed to create address");
         // cSpell:enable
-        let Address::Shelley(shelley_addr) = addr else {
-            panic!("Invalid address type")
-        };
         let mut cip36 = create_cip36();
         cip36.network = Network::Mainnet;
         cip36.key_registration = Cip36KeyRegistration {
-            payment_addr: Some(shelley_addr),
+            payment_addr: Some(addr),
             ..Default::default()
         };
         cip36.validate_payment_address_network();


### PR DESCRIPTION
# Description

Changing the CIP36 payment address type from `ShelleyAddress` to `Address`
This change will make a stake address a valid payment address, but is not payable.
Shelley address is not payable if the payment part is script.


## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
