### PR TITLE
feat(rust): Replace `base64-url` with `base64`

### DIFF
--- a/rust/catalyst-types/Cargo.toml
+++ b/rust/catalyst-types/Cargo.toml
@@ -27,7 +27,7 @@ orx-concurrent-vec = { version = "3.2.0", features = ["serde"] }
 pallas-crypto = { version = "0.30.1", git = "https://github.com/input-output-hk/catalyst-pallas.git", rev = "9b5183c8b90b90fe2cc319d986e933e9518957b3" }
 serde = { version = "1.0.217", features = ["derive", "rc"] }
 thiserror = "2.0.11"
-base64-url = "3.0.0"
+base64 = "0.22.1"
 uuid = { version = "1.12.0", features = ["v4", "v7", "serde"] }
 chrono = "0.4.39"
 fmmap = { version = "0.4.0", features = ["sync", "tokio"] }

--- a/rust/catalyst-types/src/id_uri/errors.rs
+++ b/rust/catalyst-types/src/id_uri/errors.rs
@@ -21,7 +21,7 @@ pub enum IdUriError {
     /// Role 0 Key in path is invalid
     InvalidRole0Key,
     /// Role 0 Key in path is not encoded correctly
-    InvalidRole0KeyEncoding(#[from] base64_url::base64::DecodeError),
+    InvalidRole0KeyEncoding(#[from] base64::DecodeError),
     /// Role Index is invalid
     InvalidRole,
     /// Role Index is not encoded correctly

--- a/rust/signed_doc/Cargo.toml
+++ b/rust/signed_doc/Cargo.toml
@@ -28,7 +28,7 @@ jsonpath-rust = "0.7.5"
 futures = "0.3.31"
 
 [dev-dependencies]
-base64-url = "3.0.0"
+base64 = "0.22.1"
 rand = "0.8.5"
 tokio = { version = "1.42.0", features = [ "macros" ] }
 

--- a/rust/signed_doc/src/lib.rs
+++ b/rust/signed_doc/src/lib.rs
@@ -278,6 +278,7 @@ impl TryFrom<CatalystSignedDocument> for Vec<u8> {
 mod tests {
     use std::str::FromStr;
 
+    use base64::Engine;
     use ed25519_dalek::{SigningKey, VerifyingKey};
     use metadata::{ContentEncoding, ContentType};
     use rand::rngs::OsRng;
@@ -357,7 +358,7 @@ mod tests {
 
         let kid_str = format!(
             "id.catalyst://cardano/{}/0/0",
-            base64_url::encode(pk.as_bytes())
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(pk.as_bytes())
         );
 
         let kid = IdUri::from_str(&kid_str).unwrap();


### PR DESCRIPTION
# Description

Replace `base64-url` which is simply just a wrapper over `base64` crate https://github.com/magiclen/base64-url/blob/7bcd29e6b1c21bc4b2592d40d9b493ab4ff3fad4/Cargo.toml#L16.
Simplify our dependency tree.