### PR TITLE
fix(rust/rbac-registration): RBAC reg chain with historical data

### DIFF
--- a/rust/rbac-registration/src/cardano/cip509/mod.rs
+++ b/rust/rbac-registration/src/cardano/cip509/mod.rs
@@ -6,8 +6,8 @@ pub use cip509::Cip509;
 #[allow(clippy::module_name_repetitions)]
 pub use rbac::{C509Cert, Cip509RbacMetadata, SimplePublicKeyType, X509DerCert};
 pub use types::{
-    CertKeyHash, KeyLocalRef, LocalRefInt, Payment, PaymentHistory, PointTxnIdx, RoleData,
-    RoleNumber, TxInputHash, ValidationSignature,
+    CertKeyHash, KeyLocalRef, LocalRefInt, Payment, PaymentHistory, PointData, PointTxnIdx,
+    RoleData, RoleNumber, TxInputHash, ValidationSignature,
 };
 pub use utils::Cip0134UriSet;
 

--- a/rust/rbac-registration/src/cardano/cip509/types/mod.rs
+++ b/rust/rbac-registration/src/cardano/cip509/types/mod.rs
@@ -3,6 +3,7 @@
 pub use cert_key_hash::CertKeyHash;
 pub use key_local_ref::{KeyLocalRef, LocalRefInt};
 pub use payment_history::{Payment, PaymentHistory};
+pub use point_data::PointData;
 pub use point_tx_idx::PointTxnIdx;
 pub use role_data::RoleData;
 pub use role_number::RoleNumber;
@@ -12,6 +13,7 @@ pub use validation_signature::ValidationSignature;
 mod cert_key_hash;
 mod key_local_ref;
 mod payment_history;
+mod point_data;
 mod point_tx_idx;
 mod role_data;
 mod role_number;

--- a/rust/rbac-registration/src/cardano/cip509/types/point_data.rs
+++ b/rust/rbac-registration/src/cardano/cip509/types/point_data.rs
@@ -1,0 +1,40 @@
+//! Point and transaction index with its associated data.
+
+use cardano_blockchain_types::{Point, TxnIndex};
+
+use super::PointTxnIdx;
+
+/// Point + transaction index with data.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PointData<T> {
+    /// Point and transaction index.
+    point_txn_index: PointTxnIdx,
+    /// Data associated to the point and transaction index.
+    data: T,
+}
+
+impl<T> PointData<T> {
+    /// Creates an instance of point and transaction index with data.
+    #[must_use]
+    pub fn new(point_txn_index: PointTxnIdx, data: T) -> Self {
+        Self {
+            point_txn_index,
+            data,
+        }
+    }
+
+    /// Get a reference to the data.
+    pub fn data(&self) -> &T {
+        &self.data
+    }
+
+    /// Get the point.
+    pub fn point(&self) -> &Point {
+        self.point_txn_index.point()
+    }
+
+    /// Get the transaction index.
+    pub fn txn_index(&self) -> TxnIndex {
+        self.point_txn_index.txn_index()
+    }
+}

--- a/rust/rbac-registration/src/registration/cardano/mod.rs
+++ b/rust/rbac-registration/src/registration/cardano/mod.rs
@@ -430,12 +430,12 @@ fn update_role_data(
 
         // If there is new role encryption key, use it, else use the old one
         if data.encryption_key().is_none() {
-            let signing_key = inner
+            let encryption_key = inner
                 .role_data
                 .get(&number)
                 .and_then(|pd| pd.data().encryption_key())
                 .cloned();
-            data.set_encryption_key(signing_key);
+            data.set_encryption_key(encryption_key);
         }
 
         // Map of role number to point and role data

--- a/rust/rbac-registration/src/registration/cardano/mod.rs
+++ b/rust/rbac-registration/src/registration/cardano/mod.rs
@@ -11,7 +11,7 @@ use tracing::{error, warn};
 use x509_cert::certificate::Certificate as X509Certificate;
 
 use crate::cardano::cip509::{
-    C509Cert, CertKeyHash, Cip0134UriSet, Cip509, PaymentHistory, PointTxnIdx, RoleData,
+    C509Cert, CertKeyHash, Cip0134UriSet, Cip509, PaymentHistory, PointData, PointTxnIdx, RoleData,
     RoleNumber, SimplePublicKeyType, X509DerCert,
 };
 
@@ -68,34 +68,44 @@ impl RegistrationChain {
         &self.inner.purpose
     }
 
-    /// Get the map of index in array to point, transaction index, and x509 certificate.
+    /// Get the map of index in array to list of point + transaction index, and x509
+    /// certificate.
     #[must_use]
-    pub fn x509_certs(&self) -> &HashMap<usize, (PointTxnIdx, X509Certificate)> {
+    pub fn x509_certs(&self) -> &HashMap<usize, Vec<PointData<Option<X509Certificate>>>> {
         &self.inner.x509_certs
     }
 
-    /// Get the map of index in array to point, transaction index, and c509 certificate.
+    /// Get the map of index in array to list of point + transaction index, and c509
+    /// certificate.
     #[must_use]
-    pub fn c509_certs(&self) -> &HashMap<usize, (PointTxnIdx, C509)> {
+    pub fn c509_certs(&self) -> &HashMap<usize, Vec<PointData<Option<C509>>>> {
         &self.inner.c509_certs
     }
 
-    /// Get the map of index in array to point, transaction index, and public key.
+    /// Get the map of index in array to list of point + transaction index, and public
+    /// key.
     #[must_use]
-    pub fn simple_keys(&self) -> &HashMap<usize, (PointTxnIdx, VerifyingKey)> {
+    pub fn simple_keys(&self) -> &HashMap<usize, Vec<PointData<Option<VerifyingKey>>>> {
         &self.inner.simple_keys
     }
 
-    /// Get a list of revocations.
+    /// Get a list of point + transaction index and revocation.
     #[must_use]
-    pub fn revocations(&self) -> &[(PointTxnIdx, CertKeyHash)] {
+    pub fn revocations(&self) -> &[PointData<CertKeyHash>] {
         &self.inner.revocations
     }
 
-    /// Get the map of role number to point, transaction index, and role data.
+    /// Get the map of latest update role number to point + transaction index, and role
+    /// data.
     #[must_use]
-    pub fn role_data(&self) -> &HashMap<RoleNumber, (PointTxnIdx, RoleData)> {
+    pub fn role_data(&self) -> &HashMap<RoleNumber, PointData<RoleData>> {
         &self.inner.role_data
+    }
+
+    /// Get the map of role number to list of point + transaction index, and role data.
+    #[must_use]
+    pub fn all_role_data(&self) -> &HashMap<RoleNumber, Vec<PointData<RoleData>>> {
+        &self.inner.all_role_data
     }
 
     /// Get the map of tracked payment keys to its history.
@@ -114,20 +124,26 @@ struct RegistrationChainInner {
     purpose: Vec<UuidV4>,
 
     // RBAC
-    /// Map of index in array to point, transaction index, and x509 certificate.
-    x509_certs: HashMap<usize, (PointTxnIdx, X509Certificate)>,
-    /// Map of index in array to point, transaction index, and c509 certificate.
-    c509_certs: HashMap<usize, (PointTxnIdx, C509)>,
+    /// Map of index in array to list of point + transaction index, and optional x509
+    /// certificate. If X509 is None, it means the certificate is deleted.
+    x509_certs: HashMap<usize, Vec<PointData<Option<X509Certificate>>>>,
+    /// Map of index in array to list of point + transaction index, and optional c509
+    /// certificate. If C509 is None, it means the certificate is deleted.
+    c509_certs: HashMap<usize, Vec<PointData<Option<C509>>>>,
     /// A set of URIs contained in both x509 and c509 certificates.
     certificate_uris: Cip0134UriSet,
-    /// Map of index in array to point, transaction index, and public key.
-    simple_keys: HashMap<usize, (PointTxnIdx, VerifyingKey)>,
-    /// List of point, transaction index, and certificate key hash.
-    revocations: Vec<(PointTxnIdx, CertKeyHash)>,
+    /// Map of index in array to list of point + transaction index, and public key.
+    /// If key is None, it means the key is deleted.
+    simple_keys: HashMap<usize, Vec<PointData<Option<VerifyingKey>>>>,
+    /// List of point + transaction index, and certificate key hash.
+    revocations: Vec<PointData<CertKeyHash>>,
 
     // Role
-    /// Map of role number to point, transaction index, and role data.
-    role_data: HashMap<RoleNumber, (PointTxnIdx, RoleData)>,
+    /// Map of role number to list point + transaction index, and role data.
+    /// Cannot use the latest one since role data can be partially updated.
+    all_role_data: HashMap<RoleNumber, Vec<PointData<RoleData>>>,
+    /// The latest update of role data associated to the role number.
+    role_data: HashMap<RoleNumber, PointData<RoleData>>,
     /// Map of tracked payment key to its history.
     payment_history: PaymentHistory,
 }
@@ -165,11 +181,22 @@ impl RegistrationChainInner {
 
         let purpose = vec![purpose];
         let certificate_uris = registration.certificate_uris;
-        let x509_certs = chain_root_x509_certs(registration.x509_certs, &point_tx_idx);
-        let c509_certs = chain_root_c509_certs(registration.c509_certs, &point_tx_idx);
-        let simple_keys = chain_root_public_keys(registration.pub_keys, &point_tx_idx);
+        let mut x509_certs = HashMap::new();
+        update_x509_certs(&mut x509_certs, registration.x509_certs, &point_tx_idx);
+        let mut c509_certs = HashMap::new();
+        update_c509_certs(&mut c509_certs, registration.c509_certs, &point_tx_idx);
+        let mut simple_keys = HashMap::new();
+        update_public_keys(&mut simple_keys, registration.pub_keys, &point_tx_idx);
         let revocations = revocations_list(registration.revocation_list, &point_tx_idx);
-        let role_data = chain_root_role_data(registration.role_data, &point_tx_idx);
+
+        // Role data
+        let mut all_role_data = HashMap::new();
+        let mut role_data = HashMap::new();
+        for (number, data) in registration.role_data {
+            let point_data = PointData::new(point_tx_idx.clone(), data);
+            all_role_data.insert(number, vec![point_data.clone()]);
+            role_data.insert(number, point_data);
+        }
 
         Ok(Self {
             current_tx_id_hash,
@@ -179,6 +206,7 @@ impl RegistrationChainInner {
             certificate_uris,
             simple_keys,
             revocations,
+            all_role_data,
             role_data,
             payment_history,
         })
@@ -227,9 +255,21 @@ impl RegistrationChainInner {
 
         new_inner.certificate_uris = new_inner.certificate_uris.update(&registration);
         new_inner.payment_history.extend(payment_history);
-        update_x509_certs(&mut new_inner, registration.x509_certs, &point_tx_idx);
-        update_c509_certs(&mut new_inner, registration.c509_certs, &point_tx_idx);
-        update_public_keys(&mut new_inner, registration.pub_keys, &point_tx_idx);
+        update_x509_certs(
+            &mut new_inner.x509_certs,
+            registration.x509_certs,
+            &point_tx_idx,
+        );
+        update_c509_certs(
+            &mut new_inner.c509_certs,
+            registration.c509_certs,
+            &point_tx_idx,
+        );
+        update_public_keys(
+            &mut new_inner.simple_keys,
+            registration.pub_keys,
+            &point_tx_idx,
+        );
 
         let revocations = revocations_list(registration.revocation_list, &point_tx_idx);
         // Revocation list should be appended
@@ -241,118 +281,113 @@ impl RegistrationChainInner {
     }
 }
 
-/// Process x509 certificate for chain root.
-fn chain_root_x509_certs(
-    x509_certs: Vec<X509DerCert>, point_tx_idx: &PointTxnIdx,
-) -> HashMap<usize, (PointTxnIdx, X509Certificate)> {
-    x509_certs
-        .into_iter()
-        .enumerate()
-        .filter_map(|(index, cert)| {
-            if let X509DerCert::X509Cert(cert) = cert {
-                Some((index, (point_tx_idx.clone(), *cert)))
-            } else {
-                None
-            }
-        })
-        .collect()
-}
-
 /// Update x509 certificates in the registration chain.
 fn update_x509_certs(
-    new_inner: &mut RegistrationChainInner, x509_certs: Vec<X509DerCert>,
-    point_tx_idx: &PointTxnIdx,
+    x509_cert_map: &mut HashMap<usize, Vec<PointData<Option<X509Certificate>>>>,
+    x509_certs: Vec<X509DerCert>, point_tx_idx: &PointTxnIdx,
 ) {
     for (idx, cert) in x509_certs.into_iter().enumerate() {
         match cert {
-            // Unchanged to that index, so continue
-            X509DerCert::Undefined => continue,
-            // Delete the certificate
+            // Unchanged to that index
+            X509DerCert::Undefined => {
+                if let Some(cert_vec) = x509_cert_map.get_mut(&idx) {
+                    // Get the previous (last) one since the certificate is unchanged
+                    if let Some(last_cert) = cert_vec.last() {
+                        cert_vec.push(PointData::new(
+                            point_tx_idx.clone(),
+                            last_cert.data().clone(),
+                        ));
+                    }
+                }
+            },
+            // Delete the certificate, set to none
             X509DerCert::Deleted => {
-                new_inner.x509_certs.remove(&idx);
+                x509_cert_map
+                    .entry(idx)
+                    .or_default()
+                    .push(PointData::new(point_tx_idx.clone(), None));
             },
             // Add the new certificate
             X509DerCert::X509Cert(cert) => {
-                new_inner
-                    .x509_certs
-                    .insert(idx, (point_tx_idx.clone(), *cert));
+                x509_cert_map
+                    .entry(idx)
+                    .or_default()
+                    .push(PointData::new(point_tx_idx.clone(), Some(*cert)));
             },
         }
     }
-}
-
-/// Process c509 certificates for chain root.
-fn chain_root_c509_certs(
-    c509_certs: Vec<C509Cert>, point_tx_idx: &PointTxnIdx,
-) -> HashMap<usize, (PointTxnIdx, C509)> {
-    let mut map = HashMap::new();
-    for (idx, cert) in c509_certs.into_iter().enumerate() {
-        if let C509Cert::C509Certificate(cert) = cert {
-            // Chain root, expect only the certificate not undefined or delete
-            map.insert(idx, (point_tx_idx.clone(), *cert));
-        }
-    }
-    map
 }
 
 /// Update c509 certificates in the registration chain.
 fn update_c509_certs(
-    new_inner: &mut RegistrationChainInner, c509_certs: Vec<C509Cert>, point_tx_idx: &PointTxnIdx,
+    c509_cert_map: &mut HashMap<usize, Vec<PointData<Option<C509>>>>, c509_certs: Vec<C509Cert>,
+    point_tx_idx: &PointTxnIdx,
 ) {
     for (idx, cert) in c509_certs.into_iter().enumerate() {
         match cert {
-            // Unchanged to that index, so continue
-            C509Cert::Undefined => continue,
-            // Delete the certificate
+            // Unchanged to that index
+            C509Cert::Undefined => {
+                if let Some(cert_vec) = c509_cert_map.get_mut(&idx) {
+                    // Get the previous (last) one since the certificate is unchanged
+                    if let Some(last_cert) = cert_vec.last() {
+                        cert_vec.push(PointData::new(
+                            point_tx_idx.clone(),
+                            last_cert.data().clone(),
+                        ));
+                    }
+                }
+            },
+            // Delete the certificate, set to none
             C509Cert::Deleted => {
-                new_inner.c509_certs.remove(&idx);
+                c509_cert_map
+                    .entry(idx)
+                    .or_default()
+                    .push(PointData::new(point_tx_idx.clone(), None));
             },
             // Certificate reference
             C509Cert::C509CertInMetadatumReference(_) => {
                 warn!("Unsupported C509CertInMetadatumReference");
             },
             // Add the new certificate
-            C509Cert::C509Certificate(c509) => {
-                new_inner
-                    .c509_certs
-                    .insert(idx, (point_tx_idx.clone(), *c509));
+            C509Cert::C509Certificate(cert) => {
+                c509_cert_map
+                    .entry(idx)
+                    .or_default()
+                    .push(PointData::new(point_tx_idx.clone(), Some(*cert)));
             },
         }
     }
-}
-
-/// Process public keys for chain root.
-fn chain_root_public_keys(
-    pub_keys: Vec<SimplePublicKeyType>, point_tx_idx: &PointTxnIdx,
-) -> HashMap<usize, (PointTxnIdx, VerifyingKey)> {
-    let mut map = HashMap::new();
-    for (idx, key) in pub_keys.into_iter().enumerate() {
-        // Chain root, expect only the public key not undefined or delete
-        if let SimplePublicKeyType::Ed25519(key) = key {
-            map.insert(idx, (point_tx_idx.clone(), key));
-        }
-    }
-    map
 }
 
 /// Update public keys in the registration chain.
 fn update_public_keys(
-    new_inner: &mut RegistrationChainInner, pub_keys: Vec<SimplePublicKeyType>,
-    point_tx_idx: &PointTxnIdx,
+    pub_key_map: &mut HashMap<usize, Vec<PointData<Option<VerifyingKey>>>>,
+    pub_keys: Vec<SimplePublicKeyType>, point_tx_idx: &PointTxnIdx,
 ) {
     for (idx, cert) in pub_keys.into_iter().enumerate() {
         match cert {
-            // Unchanged to that index, so continue
-            SimplePublicKeyType::Undefined => continue,
-            // Delete the public key
+            // Unchanged to that index
+            SimplePublicKeyType::Undefined => {
+                if let Some(key_vec) = pub_key_map.get_mut(&idx) {
+                    // Get the previous (last) one since the certificate is unchanged
+                    if let Some(last_key) = key_vec.last() {
+                        key_vec.push(PointData::new(point_tx_idx.clone(), *last_key.data()));
+                    }
+                }
+            },
+            // Delete the certificate, set to none
             SimplePublicKeyType::Deleted => {
-                new_inner.simple_keys.remove(&idx);
+                pub_key_map
+                    .entry(idx)
+                    .or_default()
+                    .push(PointData::new(point_tx_idx.clone(), None));
             },
             // Add the new public key
             SimplePublicKeyType::Ed25519(key) => {
-                new_inner
-                    .simple_keys
-                    .insert(idx, (point_tx_idx.clone(), key));
+                pub_key_map
+                    .entry(idx)
+                    .or_default()
+                    .push(PointData::new(point_tx_idx.clone(), Some(key)));
             },
         }
     }
@@ -361,22 +396,13 @@ fn update_public_keys(
 /// Process the revocation list.
 fn revocations_list(
     revocation_list: Vec<CertKeyHash>, point_tx_idx: &PointTxnIdx,
-) -> Vec<(PointTxnIdx, CertKeyHash)> {
+) -> Vec<PointData<CertKeyHash>> {
     let mut revocations = Vec::new();
     for item in revocation_list {
-        revocations.push((point_tx_idx.clone(), item.clone()));
+        let point_data = PointData::new(point_tx_idx.clone(), item.clone());
+        revocations.push(point_data);
     }
     revocations
-}
-
-/// Process the role data for chain root.
-fn chain_root_role_data(
-    role_data: HashMap<RoleNumber, RoleData>, point_tx_idx: &PointTxnIdx,
-) -> HashMap<RoleNumber, (PointTxnIdx, RoleData)> {
-    role_data
-        .into_iter()
-        .map(|(number, data)| (number, (point_tx_idx.clone(), data)))
-        .collect()
 }
 
 /// Update the role data in the registration chain.
@@ -385,12 +411,19 @@ fn update_role_data(
     point_tx_idx: &PointTxnIdx,
 ) {
     for (number, mut data) in role_set {
+        // Update the record of role data first
+        inner
+            .all_role_data
+            .entry(number)
+            .or_default()
+            .push(PointData::new(point_tx_idx.clone(), data.clone()));
+
         // If there is new role singing key, use it, else use the old one
         if data.signing_key().is_none() {
             let signing_key = inner
                 .role_data
                 .get(&number)
-                .and_then(|(_, d)| d.signing_key())
+                .and_then(|pd| pd.data().signing_key())
                 .cloned();
             data.set_signing_key(signing_key);
         }
@@ -400,14 +433,16 @@ fn update_role_data(
             let signing_key = inner
                 .role_data
                 .get(&number)
-                .and_then(|(_, d)| d.encryption_key())
+                .and_then(|pd| pd.data().encryption_key())
                 .cloned();
             data.set_encryption_key(signing_key);
         }
 
         // Map of role number to point and role data
         // Note that new role data will overwrite the old one
-        inner.role_data.insert(number, (point_tx_idx.clone(), data));
+        inner
+            .role_data
+            .insert(number, PointData::new(point_tx_idx.clone(), data));
     }
 }
 
@@ -428,7 +463,7 @@ mod test {
         let chain = RegistrationChain::new(registration).unwrap();
         assert_eq!(chain.purpose(), &[data.purpose]);
         assert_eq!(1, chain.x509_certs().len());
-        let origin = &chain.x509_certs().get(&0).unwrap().0;
+        let origin = &chain.x509_certs().get(&0).unwrap().first().unwrap();
         assert_eq!(origin.point().slot_or_default(), data.slot);
         assert_eq!(origin.txn_index(), data.txn_index);
 
@@ -458,5 +493,25 @@ mod test {
         // Current tx hash should be equal to the hash from block 4.
         assert_eq!(update.current_tx_id_hash(), data.txn_hash);
         assert!(update.role_data().contains_key(&data.role));
+        // There is only 1 update to role 0 data
+        assert_eq!(
+            update
+                .all_role_data()
+                .get(&RoleNumber::ROLE_0)
+                .unwrap()
+                .len(),
+            1
+        );
+        // There is only 1 update to role 4 data
+        assert_eq!(
+            update
+                .all_role_data()
+                .get(&RoleNumber::from(4))
+                .unwrap()
+                .len(),
+            1
+        );
+        // x509 certificates update on 2 index
+        assert_eq!(update.x509_certs().len(), 2);
     }
 }


### PR DESCRIPTION
# Description

Modify the RBAC registration chain to store historical data.

## Related Issue(s)

Closes #235 

## Description of Changes

- Add new type that store `Point + Transaction Index` with associated `Data`
- `x509_certs`, `c509_certs`, `simple_keys` are now storing historical data where the data is stored Map where key is the array index and the value is Vec <-> Point + Transaction. The last index should be the valid one for the given key index.
- Add `all_role_data` to store the historical data of role data. Since the role data can be partially updated
- Remove the `chain_root_` functions

## Breaking Changes

- The `x509_certs` , `c509_certs`, `simple_keys`, `role_data` type changes

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
