### PR TITLE
chore(general): Run CI when PR is opened

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     types:
       - synchronize
       - ready_for_review
+      - opened
     
 
 permissions:
@@ -17,6 +18,7 @@ permissions:
 
 jobs:
   ci:
+    if: ${{ !github.event.pull_request.draft }}
     uses: input-output-hk/catalyst-forge/.github/workflows/ci.yml@ci/v1.7.1
     with:
       forge_version: 0.8.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,6 @@ jobs:
       forge_version: 0.8.0
 
   test_reporting:
-    if: always()
+    if: ${{ !github.event.pull_request.draft }}
     needs: ci
     uses: ./.github/workflows/generate-allure-report.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     types:
+      - opened
       - synchronize
       - ready_for_review
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
   pull_request:
     types:
-      - opened
       - synchronize
       - ready_for_review
     

--- a/.github/workflows/semantic_pull_request.yml
+++ b/.github/workflows/semantic_pull_request.yml
@@ -32,5 +32,3 @@ jobs:
         docs
         general
         deps
-
-        

--- a/.github/workflows/semantic_pull_request.yml
+++ b/.github/workflows/semantic_pull_request.yml
@@ -32,3 +32,5 @@ jobs:
         docs
         general
         deps
+
+        


### PR DESCRIPTION
# Description

Run CI when PR is opened.

**Previous behavior:**
When PR is opened, the CI doesn't run. To fix this, need to convert to draft then convert back to ready for review.
Hence, this PR solved the issue.