### PR TITLE
fix(rust/catalyst-types): Hash length check logic

### DIFF
--- a/rust/catalyst-types/src/hashes.rs
+++ b/rust/catalyst-types/src/hashes.rs
@@ -102,7 +102,7 @@ impl<const BYTES: usize> TryFrom<&[u8]> for Blake2bHash<BYTES> {
     type Error = Blake2bHashError;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        if value.len() < BYTES {
+        if value.len() != BYTES  {
             return Err(Blake2bHashError::InvalidLength {
                 expected: BYTES,
                 actual: value.len(),
@@ -204,6 +204,17 @@ mod tests {
     #[test]
     fn test_blake2b_hash_invalid_length() {
         let invalid_data = vec![0u8; 10];
+        let result = Blake2b224Hash::try_from(&invalid_data);
+        assert!(result.is_err());
+
+        if let Err(Blake2bHashError::InvalidLength { expected, actual }) = result {
+            assert_eq!(expected, BLAKE_2B224_SIZE);
+            assert_eq!(actual, invalid_data.len());
+        } else {
+            panic!("Expected InvalidLength error");
+        }
+
+        let invalid_data = vec![0u8; 50];
         let result = Blake2b224Hash::try_from(&invalid_data);
         assert!(result.is_err());
 

--- a/rust/catalyst-types/src/hashes.rs
+++ b/rust/catalyst-types/src/hashes.rs
@@ -102,7 +102,7 @@ impl<const BYTES: usize> TryFrom<&[u8]> for Blake2bHash<BYTES> {
     type Error = Blake2bHashError;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        if value.len() != BYTES  {
+        if value.len() != BYTES {
             return Err(Blake2bHashError::InvalidLength {
                 expected: BYTES,
                 actual: value.len(),


### PR DESCRIPTION
# Description

Wrong logic for hash length.
Got this error when the length is > the expected hash length
```
thread 'tokio-runtime-worker' panicked at /home/bkioshn/Work/Catalyst/catalyst-libs/rust/catalyst-types/src/hashes.rs:113:14:
copy_from_slice: source slice length (32) does not match destination slice length (16)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Error: JoinError::Panic(Id(20), "copy_from_slice: source slice length (32) does not match destination slice length (16)", ...)
error: Recipe `run-mithril-download-example-preprod` failed on line 14 with exit code 1
```

Added test to check when given hash length > expected hash length
