### PR TITLE
fix(rust/rbac-registration): Fix `deleted` tag cbor decoding

### DIFF
--- a/rust/rbac-registration/src/cardano/cip509/rbac/certs/c509.rs
+++ b/rust/rbac-registration/src/cardano/cip509/rbac/certs/c509.rs
@@ -28,7 +28,10 @@ impl Decode<'_, ProblemReport> for C509Cert {
             minicbor::data::Type::Tag => {
                 let tag = decode_tag(d, "C509Cert")?;
                 match tag {
-                    t if t == KeyTag::Deleted.tag() => Ok(Self::Deleted),
+                    t if t == KeyTag::Deleted.tag() => {
+                        d.undefined()?;
+                        Ok(Self::Deleted)
+                    },
                     _ => Err(decode::Error::message("Unknown tag for C509Cert")),
                 }
             },

--- a/rust/rbac-registration/src/cardano/cip509/rbac/certs/x509.rs
+++ b/rust/rbac-registration/src/cardano/cip509/rbac/certs/x509.rs
@@ -26,7 +26,10 @@ impl Decode<'_, ProblemReport> for X509DerCert {
             minicbor::data::Type::Tag => {
                 let tag = decode_tag(d, "X509DerCert")?;
                 match tag {
-                    t if t == KeyTag::Deleted.tag() => Ok(Self::Deleted),
+                    t if t == KeyTag::Deleted.tag() => {
+                        d.undefined()?;
+                        Ok(Self::Deleted)
+                    },
                     _ => Err(decode::Error::message("Unknown tag for X509DerCert")),
                 }
             },

--- a/rust/rbac-registration/src/cardano/cip509/rbac/pub_key.rs
+++ b/rust/rbac-registration/src/cardano/cip509/rbac/pub_key.rs
@@ -25,7 +25,10 @@ impl Decode<'_, ProblemReport> for SimplePublicKeyType {
             minicbor::data::Type::Tag => {
                 let tag = decode_tag(d, "SimplePublicKeyType")?;
                 match tag {
-                    t if t == KeyTag::Deleted.tag() => Ok(Self::Deleted),
+                    t if t == KeyTag::Deleted.tag() => {
+                        d.undefined()?;
+                        Ok(Self::Deleted)
+                    },
                     t if t == KeyTag::Ed25519.tag() => {
                         let bytes = decode_bytes(d, "Ed25519 SimplePublicKeyType")?;
                         let mut ed25519 = [0u8; 32];
@@ -42,7 +45,11 @@ impl Decode<'_, ProblemReport> for SimplePublicKeyType {
                             )))
                         }
                     },
-                    _ => Err(decode::Error::message("Unknown tag for Self")),
+                    _ => {
+                        Err(decode::Error::message(
+                            "Unknown tag for SimplePublicKeyType",
+                        ))
+                    },
                 }
             },
             minicbor::data::Type::Undefined => {

--- a/rust/rbac-registration/src/cardano/cip509/rbac/tag.rs
+++ b/rust/rbac-registration/src/cardano/cip509/rbac/tag.rs
@@ -7,6 +7,7 @@ pub(crate) enum KeyTag {
     /// Deleted Key tag 31.
     Deleted,
     /// Ed25519 Key tag 32773.
+    /// <https://cips.cardano.org/cip/CIP-0115>
     Ed25519,
 }
 
@@ -14,8 +15,8 @@ impl KeyTag {
     /// Get the tag value.
     pub(crate) fn tag(self) -> Tag {
         match self {
-            KeyTag::Deleted => Tag::new(0x31),
-            KeyTag::Ed25519 => Tag::new(0x8005),
+            KeyTag::Deleted => Tag::new(31),
+            KeyTag::Ed25519 => Tag::new(32773),
         }
     }
 }


### PR DESCRIPTION
# Description

Fix `deleted` tag cbor decoding for X509, C509, Simple Public Key
As defined 
`deleted-key = #6.31(undefined) ; delete the key (if any) at this position of the array`
deleted-key is of tag 31 follow by undefined.

Ref: https://github.com/input-output-hk/catalyst-CIPs/blob/x509-role-registration-metadata/CIP-XXXX/x509-roles.cddl