### PR TITLE
chore(rust/cardano-chain-follower): Cleanup updating follower state after getting a new update

### DIFF
--- a/rust/cardano-chain-follower/src/follow.rs
+++ b/rust/cardano-chain-follower/src/follow.rs
@@ -443,8 +443,32 @@ mod tests {
         let block_data = mock_block();
         let update = ChainUpdate::new(chain_update::Kind::Block, false, block_data);
 
+        let old_current = follower.current.clone();
         follower.update_current(&update);
 
         assert_eq!(follower.current, update.block_data().point());
+        assert_eq!(follower.previous, old_current);
+        assert_eq!(follower.fork, update.block_data().fork());
+    }
+
+    #[tokio::test]
+    async fn test_chain_follower_update_current_immutable_roll_forward() {
+        let chain = Network::Mainnet;
+        let start = Point::new(100u64.into(), [0; 32].into());
+        let end = Point::fuzzy(999u64.into());
+
+        let mut follower = ChainFollower::new(chain, start.clone(), end.clone()).await;
+
+        let block_data = mock_block();
+        let update = ChainUpdate::new(
+            chain_update::Kind::ImmutableBlockRollForward,
+            false,
+            block_data,
+        );
+
+        let old_current = follower.current.clone();
+        follower.update_current(&update);
+
+        assert_eq!(follower.current, old_current);
     }
 }

--- a/rust/cardano-chain-follower/src/follow.rs
+++ b/rust/cardano-chain-follower/src/follow.rs
@@ -85,6 +85,8 @@ impl ChainFollower {
 
     /// If we can, get the next update from the mithril snapshot.
     async fn next_from_mithril(&mut self) -> Option<ChainUpdate> {
+        // This Loop allows us to re-try if we detect that the mithril snapshot has changed while we were trying to read a block from it.
+        // Typically this function never loops.
         loop {
             let current_mithril_tip = latest_mithril_snapshot_id(self.chain).tip();
 

--- a/rust/cardano-chain-follower/src/follow.rs
+++ b/rust/cardano-chain-follower/src/follow.rs
@@ -150,7 +150,7 @@ impl ChainFollower {
                 // directory, where the underlying data directory could be no longer accessible
                 if !follower.is_valid() {
                     // Set the mithril follower to None and restart the loop
-                    warn!("Mithril snapshot data directory race condition, underlying data directory is not accessible anymore");
+                    warn!("Detected Mithril snapshot data directory race condition, underlying data directory is not accessible anymore: Correcting...");
                     self.mithril_follower = None;
                     continue;
                 }

--- a/rust/cardano-chain-follower/src/mithril_snapshot_iterator.rs
+++ b/rust/cardano-chain-follower/src/mithril_snapshot_iterator.rs
@@ -46,7 +46,7 @@ impl Debug for MithrilSnapshotIteratorInner {
 /// Wraps the iterator type returned by Pallas.
 #[derive(Debug)]
 pub(crate) struct MithrilSnapshotIterator {
-    /// Mithrill snapshot directory path
+    /// Mithril snapshot directory path
     path: PathBuf,
     /// Inner Mutable Synchronous Iterator State
     inner: Arc<Mutex<MithrilSnapshotIteratorInner>>,
@@ -73,7 +73,7 @@ pub(crate) fn probe_point(point: &Point, distance: u64) -> Point {
 
 impl MithrilSnapshotIterator {
     /// Returns `true` if the `MithrilSnapshotIterator` could read data without any issues
-    /// (underlying mithrill snapshot directory exists)
+    /// (underlying mithril snapshot directory exists)
     pub(crate) fn is_valid(&self) -> bool {
         self.path.exists()
     }

--- a/rust/cardano-chain-follower/src/mithril_snapshot_iterator.rs
+++ b/rust/cardano-chain-follower/src/mithril_snapshot_iterator.rs
@@ -29,8 +29,6 @@ struct MithrilSnapshotIteratorInner {
     start: Point,
     /// Previous iteration point.
     previous: Point,
-    /// Mithrill snapshot directory path
-    path: PathBuf,
     /// Inner iterator.
     inner: ImmutableBlockIterator,
 }
@@ -48,6 +46,8 @@ impl Debug for MithrilSnapshotIteratorInner {
 /// Wraps the iterator type returned by Pallas.
 #[derive(Debug)]
 pub(crate) struct MithrilSnapshotIterator {
+    /// Mithrill snapshot directory path
+    path: PathBuf,
     /// Inner Mutable Synchronous Iterator State
     inner: Arc<Mutex<MithrilSnapshotIteratorInner>>,
 }
@@ -75,12 +75,7 @@ impl MithrilSnapshotIterator {
     /// Returns `true` if the `MithrilSnapshotIterator` could read data without any issues
     /// (underlying mithrill snapshot directory exists)
     pub(crate) fn is_valid(&self) -> bool {
-        #[allow(clippy::expect_used)]
-        let iter = self
-            .inner
-            .lock()
-            .expect("Safe here because the lock can't be poisoned");
-        iter.path.exists()
+        self.path.exists()
     }
 
     /// Try and probe to establish the iterator from the desired point.
@@ -136,11 +131,11 @@ impl MithrilSnapshotIterator {
         };
 
         Some(MithrilSnapshotIterator {
+            path: path.to_path_buf(),
             inner: Arc::new(Mutex::new(MithrilSnapshotIteratorInner {
                 chain,
                 start: this,
                 previous: previous?,
-                path: path.to_path_buf(),
                 inner: iterator,
             })),
         })
@@ -195,11 +190,11 @@ impl MithrilSnapshotIterator {
         let iterator = make_mithril_iterator(path, from, chain).await?;
 
         Ok(MithrilSnapshotIterator {
+            path: path.to_path_buf(),
             inner: Arc::new(Mutex::new(MithrilSnapshotIteratorInner {
                 chain,
                 start: from.clone(),
                 previous,
-                path: path.to_path_buf(),
                 inner: iterator,
             })),
         })


### PR DESCRIPTION
# Description

Made a small cleanup of localising applying update for the follower state under one method `update_current`.