### PR TITLE
fix(rust/rbac-registration): Implement (derive) Copy for LocalRefInt and KeyLocalRef

### DIFF
--- a/rust/rbac-registration/src/cardano/cip509/types/key_local_ref.rs
+++ b/rust/rbac-registration/src/cardano/cip509/types/key_local_ref.rs
@@ -7,7 +7,7 @@ use strum_macros::FromRepr;
 use crate::cardano::cip509::rbac::Cip509RbacMetadataInt;
 
 /// Local key reference.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub struct KeyLocalRef {
     /// Local reference.
     pub local_ref: LocalRefInt,
@@ -16,7 +16,7 @@ pub struct KeyLocalRef {
 }
 
 /// Enum of local reference with its associated unsigned integer value.
-#[derive(FromRepr, Debug, PartialEq, Clone, Eq, Hash)]
+#[derive(FromRepr, Debug, PartialEq, Clone, Copy, Eq, Hash)]
 #[repr(u8)]
 pub enum LocalRefInt {
     /// x509 certificates.

--- a/rust/rbac-registration/src/registration/cardano/mod.rs
+++ b/rust/rbac-registration/src/registration/cardano/mod.rs
@@ -432,7 +432,7 @@ fn update_role_data(
                 .role_data
                 .get(&number)
                 .and_then(|pd| pd.data().signing_key())
-                .cloned();
+                .copied();
             data.set_signing_key(signing_key);
         }
 
@@ -442,7 +442,7 @@ fn update_role_data(
                 .role_data
                 .get(&number)
                 .and_then(|pd| pd.data().encryption_key())
-                .cloned();
+                .copied();
             data.set_encryption_key(encryption_key);
         }
 


### PR DESCRIPTION
# Description

- Implement (derive) the `Copy` trait for `LocalRefInt` and `KeyLocalRef` types.
