### PR TITLE
fix(rust/rbac-registration): empty role data wrong error report

### DIFF
--- a/rust/rbac-registration/src/cardano/cip509/validation.rs
+++ b/rust/rbac-registration/src/cardano/cip509/validation.rs
@@ -167,46 +167,48 @@ fn extract_stake_addresses(uris: Option<&Cip0134UriSet>) -> Vec<VKeyHash> {
 pub fn validate_role_data(metadata: &Cip509RbacMetadata, report: &ProblemReport) -> Option<IdUri> {
     let context = "Role data validation";
 
-    if metadata.role_data.contains_key(&RoleNumber::ROLE_0) {
-        // For the role 0 there must be exactly once certificate and it must not have `deleted`,
-        // `undefined` or `C509CertInMetadatumReference` values.
-        if matches!(metadata.x509_certs.first(), Some(X509DerCert::X509Cert(_)))
-            && matches!(
-                metadata.c509_certs.first(),
-                Some(C509Cert::C509Certificate(_))
-            )
-        {
-            report.other(
-                "Only one certificate can be defined at index 0 for the role 0",
-                context,
-            );
-        }
-        if !matches!(metadata.x509_certs.first(), Some(X509DerCert::X509Cert(_)))
-            && !matches!(
-                metadata.c509_certs.first(),
-                Some(C509Cert::C509Certificate(_))
-            )
-        {
-            report.other("The role 0 certificate must be present", context);
-        }
-    } else {
-        // For other roles there still must be exactly one certificate at 0 index, but it must
-        // have the `undefined` value.
-        if matches!(metadata.x509_certs.first(), Some(X509DerCert::X509Cert(_)))
-            || matches!(
-                metadata.c509_certs.first(),
-                Some(C509Cert::C509Certificate(_))
-            )
-        {
-            report.other("Only role 0 can contain a certificate at 0 index", context);
-        }
-        if matches!(metadata.x509_certs.first(), Some(X509DerCert::Deleted))
-            || matches!(metadata.c509_certs.first(), Some(C509Cert::Deleted))
-        {
-            report.other("Only role 0 can delete a certificate at 0 index", context);
+    // There should be some role data
+    if !metadata.role_data.is_empty() {
+        if metadata.role_data.contains_key(&RoleNumber::ROLE_0) {
+            // For the role 0 there must be exactly once certificate and it must not have `deleted`,
+            // `undefined` or `C509CertInMetadatumReference` values.
+            if matches!(metadata.x509_certs.first(), Some(X509DerCert::X509Cert(_)))
+                && matches!(
+                    metadata.c509_certs.first(),
+                    Some(C509Cert::C509Certificate(_))
+                )
+            {
+                report.other(
+                    "Only one certificate can be defined at index 0 for the role 0",
+                    context,
+                );
+            }
+            if !matches!(metadata.x509_certs.first(), Some(X509DerCert::X509Cert(_)))
+                && !matches!(
+                    metadata.c509_certs.first(),
+                    Some(C509Cert::C509Certificate(_))
+                )
+            {
+                report.other("The role 0 certificate must be present", context);
+            }
+        } else {
+            // For other roles there still must be exactly one certificate at 0 index, but it must
+            // have the `undefined` value.
+            if matches!(metadata.x509_certs.first(), Some(X509DerCert::X509Cert(_)))
+                || matches!(
+                    metadata.c509_certs.first(),
+                    Some(C509Cert::C509Certificate(_))
+                )
+            {
+                report.other("Only role 0 can contain a certificate at 0 index", context);
+            }
+            if matches!(metadata.x509_certs.first(), Some(X509DerCert::Deleted))
+                || matches!(metadata.c509_certs.first(), Some(C509Cert::Deleted))
+            {
+                report.other("Only role 0 can delete a certificate at 0 index", context);
+            }
         }
     }
-
     // It isn't allowed for any role to use a public key at 0 index.
     if !matches!(
         metadata.pub_keys.first(),


### PR DESCRIPTION
# Description

Wrong error log added to error report when role data is empty.

## Example of wrong log
Slot = 87192736
Sending tx with role 0 where x509 and c509 cert (wrong format) has certificate in index 0, and no public key 

**Wrong log  "Only role 0 can contain a certificate at 0 index"** 
```
ProblemReport(State { context: "Decoding and validating Cip509", report: Report([Entry { kind: Other { description: "Unable to decode array value: Error { err: Message, pos: None, msg: \"Name must be an array, text or bytes\" }" }, context: "Cip509RbacMetadata c509 certificates" }, Entry { kind: Other { description: "Only role 0 can contain a certificate at 0 index" }, context: "Role data validation" }]) }) })), network: "preprod"
```

After this fix
```
ProblemReport(State { context: "Decoding and validating Cip509", report: Report([Entry { kind: Other { description: "Unable to decode array value: Error { err: Message, pos: None, msg: \"Name must be an array, text or bytes\" }" }, context: "Cip509RbacMetadata c509 certificates" }]) }) })), network: "preprod"
```

Testing the same data but correct c509 cert format
Slot = 87191337

**Expected log = "Only one certificate can be defined at index 0 for the role 0"**
```
ProblemReport(State { context: "Decoding and validating Cip509", report: Report([Entry { kind: Other { description: "Failed to compare public keys with witnesses: Public key hash not found in transaction witness set given Hash<28>(\"e075be10ec5c575caffb68b08c31470666d4fe1aeea07c16d6473903\")" }, context: "Cip509 stake public key validation" }, Entry { kind: Other { description: "Only one certificate can be defined at index 0 for the role 0" }, context: "Role data validation" }, Entry { kind: Other { description: "Unexpected extended public key length in certificate: 32, expected 64" }, context: "Role data validation" }]) }) })), network: "preprod"
```