### PR TITLE
feat(rust/signed-doc): Validation and tests for submission action 

### DIFF
--- a/rust/signed_doc/src/validator/mod.rs
+++ b/rust/signed_doc/src/validator/mod.rs
@@ -79,7 +79,7 @@ fn document_rules_init() -> HashMap<Uuid, Rules> {
     };
     document_rules_map.insert(COMMENT_DOCUMENT_UUID_TYPE, comment_document_rules);
 
-    let proposal_action_rules = Rules {
+    let proposal_submission_action_rules = Rules {
         content_type: ContentTypeRule {
             exp: ContentType::Json,
         },
@@ -99,7 +99,10 @@ fn document_rules_init() -> HashMap<Uuid, Rules> {
         section: SectionRule::NotSpecified,
     };
 
-    document_rules_map.insert(PROPOSAL_ACTION_DOCUMENT_UUID_TYPE, proposal_action_rules);
+    document_rules_map.insert(
+        PROPOSAL_ACTION_DOCUMENT_UUID_TYPE,
+        proposal_submission_action_rules,
+    );
 
     document_rules_map
 }

--- a/rust/signed_doc/src/validator/mod.rs
+++ b/rust/signed_doc/src/validator/mod.rs
@@ -14,8 +14,8 @@ use rules::{
 
 use crate::{
     doc_types::{
-        COMMENT_DOCUMENT_UUID_TYPE, COMMENT_TEMPLATE_UUID_TYPE, PROPOSAL_DOCUMENT_UUID_TYPE,
-        PROPOSAL_TEMPLATE_UUID_TYPE,
+        COMMENT_DOCUMENT_UUID_TYPE, COMMENT_TEMPLATE_UUID_TYPE, PROPOSAL_ACTION_DOCUMENT_UUID_TYPE,
+        PROPOSAL_DOCUMENT_UUID_TYPE, PROPOSAL_TEMPLATE_UUID_TYPE,
     },
     providers::{CatalystSignedDocumentProvider, VerifyingKeyProvider},
     CatalystSignedDocument, ContentEncoding, ContentType,
@@ -78,6 +78,28 @@ fn document_rules_init() -> HashMap<Uuid, Rules> {
         category: CategoryRule::NotSpecified,
     };
     document_rules_map.insert(COMMENT_DOCUMENT_UUID_TYPE, comment_document_rules);
+
+    let proposal_action_rules = Rules {
+        content_type: ContentTypeRule {
+            exp: ContentType::Json,
+        },
+        content_encoding: ContentEncodingRule {
+            exp: ContentEncoding::Brotli,
+            optional: false,
+        },
+        template: TemplateRule::NotSpecified,
+        category: CategoryRule::Specified { optional: true },
+        doc_ref: RefRule::Specified {
+            exp_ref_type: PROPOSAL_DOCUMENT_UUID_TYPE
+                .try_into()
+                .expect("Must be a valid UUID V4"),
+            optional: false,
+        },
+        reply: ReplyRule::NotSpecified,
+        section: SectionRule::NotSpecified,
+    };
+
+    document_rules_map.insert(PROPOSAL_ACTION_DOCUMENT_UUID_TYPE, proposal_action_rules);
 
     document_rules_map
 }

--- a/rust/signed_doc/tests/submission.rs
+++ b/rust/signed_doc/tests/submission.rs
@@ -1,0 +1,76 @@
+//! Test for proposal submission action.
+
+use catalyst_signed_doc::{providers::tests::TestCatalystSignedDocumentProvider, *};
+
+mod common;
+
+#[tokio::test]
+async fn test_valid_submission_action() {
+    let (proposal_doc, proposal_doc_id) =
+        common::create_dummy_doc(doc_types::PROPOSAL_DOCUMENT_UUID_TYPE).unwrap();
+
+    let uuid_v7 = UuidV7::new();
+    let (doc, ..) = common::create_dummy_signed_doc(Some(serde_json::json!({
+        "content-type": ContentType::Json.to_string(),
+        "content-encoding": ContentEncoding::Brotli.to_string(),
+        "type": doc_types::PROPOSAL_ACTION_DOCUMENT_UUID_TYPE,
+        "id": uuid_v7.to_string(),
+        "ver": uuid_v7.to_string(),
+        "ref": {
+            "id": proposal_doc_id
+        },
+    })))
+    .unwrap();
+
+    let mut provider = TestCatalystSignedDocumentProvider::default();
+    provider.add_document(proposal_doc).unwrap();
+
+    let is_valid = validator::validate(&doc, &provider).await.unwrap();
+
+    assert!(is_valid);
+}
+
+#[tokio::test]
+async fn test_valid_submission_action_with_empty_provider() {
+    let proposal_doc_id = UuidV7::new();
+
+    let uuid_v7 = UuidV7::new();
+    let (doc, ..) = common::create_dummy_signed_doc(Some(serde_json::json!({
+        "content-type": ContentType::Json.to_string(),
+        "content-encoding": ContentEncoding::Brotli.to_string(),
+        "type": doc_types::PROPOSAL_ACTION_DOCUMENT_UUID_TYPE,
+        "id": uuid_v7.to_string(),
+        "ver": uuid_v7.to_string(),
+        "ref": {
+            "id": proposal_doc_id
+        },
+    })))
+    .unwrap();
+
+    let provider = TestCatalystSignedDocumentProvider::default();
+
+    let is_valid = validator::validate(&doc, &provider).await.unwrap();
+
+    assert!(!is_valid);
+}
+
+#[tokio::test]
+async fn test_invalid_submission_action() {
+    let uuid_v7 = UuidV7::new();
+    let (doc, ..) = common::create_dummy_signed_doc(Some(serde_json::json!({
+        "content-type": ContentType::Json.to_string(),
+        "content-encoding": ContentEncoding::Brotli.to_string(),
+        "type": doc_types::PROPOSAL_ACTION_DOCUMENT_UUID_TYPE,
+        "id": uuid_v7.to_string(),
+        "ver": uuid_v7.to_string(),
+        // without specifying ref
+        "ref": serde_json::Value::Null,
+    })))
+    .unwrap();
+
+    let provider = TestCatalystSignedDocumentProvider::default();
+
+    let is_valid = validator::validate(&doc, &provider).await.unwrap();
+
+    assert!(!is_valid);
+}


### PR DESCRIPTION
Validation for  proposal submission action. As defined in the [spec](https://github.com/input-output-hk/catalyst-libs/blob/wip/document-schemas/specs/signed_docs/docs/proposal_submission_action.cue).