### PR TITLE
fix(rust/cardano-chain-follower): Fix mithril snapshot validation

### DIFF
--- a/rust/cardano-chain-follower/src/mithril_snapshot_config.rs
+++ b/rust/cardano-chain-follower/src/mithril_snapshot_config.rs
@@ -359,10 +359,11 @@ impl MithrilSnapshotConfig {
             .map_err(|e| Error::MithrilClient(self.chain, url.clone(), e))?;
 
         // Check we have a snapshot, and its for our network.
-        match snapshots.first().and_then(|s| s.beacon.network.as_ref()) {
-            Some(network) => {
-                let _aggregator_network = Network::from_str(network.as_str()).map_err(|_err| {
-                    Error::MithrilClientNetworkMismatch(self.chain, network.clone())
+        match snapshots.first() {
+            Some(snapshot_info) => {
+                let network = snapshot_info.network.as_str();
+                let _aggregator_network = Network::from_str(network).map_err(|_err| {
+                    Error::MithrilClientNetworkMismatch(self.chain, network.to_string())
                 })?;
             },
             None => return Err(Error::MithrilClientNoSnapshots(self.chain, url)),


### PR DESCRIPTION
# Description

Mithril aggregator updates and changes its public API, so network field is no longer exists under the `beacon` type.

Here is the latest representation of this beacon type
https://github.com/input-output-hk/mithril/blob/4d12aae5bb86779d28094b18c73def2f0997ab95/mithril-common/src/entities/cardano_db_beacon.rs#L10