### PR TITLE
fix(rust/rbac-registration): Pass the (sub)net parameter to IdUri constructor

### DIFF
--- a/rust/rbac-registration/src/cardano/cip509/cip509.rs
+++ b/rust/rbac-registration/src/cardano/cip509/cip509.rs
@@ -161,7 +161,7 @@ impl Cip509 {
             validate_stake_public_key(txn, cip509.certificate_uris(), &cip509.report);
         }
         if let Some(metadata) = &cip509.metadata {
-            cip509.catalyst_id = validate_role_data(metadata, &cip509.report);
+            cip509.catalyst_id = validate_role_data(metadata, block.network(), &cip509.report);
         }
 
         Ok(Some(cip509))


### PR DESCRIPTION
# Description

- Pass the network parameter to `IdUri` constructor  when parsing `Cip509`.
