### PR TITLE
fix(rust/signed-doc): Update the Catalyst Signed Document time based validation

### DIFF
--- a/rust/signed_doc/tests/comment.rs
+++ b/rust/signed_doc/tests/comment.rs
@@ -35,9 +35,14 @@ async fn test_valid_comment_doc() {
     provider.add_document(template_doc).unwrap();
     provider.add_document(proposal_doc).unwrap();
 
-    let is_valid = validator::validate(&doc, TEST_FUTURE_THRESHOLD, TEST_PAST_THRESHOLD, &provider)
-        .await
-        .unwrap();
+    let is_valid = validator::validate(
+        &doc,
+        Some(TEST_FUTURE_THRESHOLD),
+        Some(TEST_PAST_THRESHOLD),
+        &provider,
+    )
+    .await
+    .unwrap();
 
     assert!(is_valid);
 }
@@ -91,9 +96,14 @@ async fn test_valid_comment_doc_with_reply() {
     provider.add_document(proposal_doc).unwrap();
     provider.add_document(comment_doc).unwrap();
 
-    let is_valid = validator::validate(&doc, TEST_FUTURE_THRESHOLD, TEST_PAST_THRESHOLD, &provider)
-        .await
-        .unwrap();
+    let is_valid = validator::validate(
+        &doc,
+        Some(TEST_FUTURE_THRESHOLD),
+        Some(TEST_PAST_THRESHOLD),
+        &provider,
+    )
+    .await
+    .unwrap();
 
     assert!(is_valid);
 }
@@ -124,9 +134,14 @@ async fn test_invalid_comment_doc() {
     provider.add_document(template_doc).unwrap();
     provider.add_document(proposal_doc).unwrap();
 
-    let is_valid = validator::validate(&doc, TEST_FUTURE_THRESHOLD, TEST_PAST_THRESHOLD, &provider)
-        .await
-        .unwrap();
+    let is_valid = validator::validate(
+        &doc,
+        Some(TEST_FUTURE_THRESHOLD),
+        Some(TEST_PAST_THRESHOLD),
+        &provider,
+    )
+    .await
+    .unwrap();
 
     assert!(!is_valid);
 }

--- a/rust/signed_doc/tests/comment.rs
+++ b/rust/signed_doc/tests/comment.rs
@@ -1,10 +1,6 @@
 //! Integration test for comment document validation part.
 
-use catalyst_signed_doc::{
-    providers::tests::TestCatalystSignedDocumentProvider,
-    validator::tests::{TEST_FUTURE_THRESHOLD, TEST_PAST_THRESHOLD},
-    *,
-};
+use catalyst_signed_doc::{providers::tests::TestCatalystSignedDocumentProvider, *};
 
 mod common;
 
@@ -35,14 +31,7 @@ async fn test_valid_comment_doc() {
     provider.add_document(template_doc).unwrap();
     provider.add_document(proposal_doc).unwrap();
 
-    let is_valid = validator::validate(
-        &doc,
-        Some(TEST_FUTURE_THRESHOLD),
-        Some(TEST_PAST_THRESHOLD),
-        &provider,
-    )
-    .await
-    .unwrap();
+    let is_valid = validator::validate(&doc, &provider).await.unwrap();
 
     assert!(is_valid);
 }
@@ -96,14 +85,7 @@ async fn test_valid_comment_doc_with_reply() {
     provider.add_document(proposal_doc).unwrap();
     provider.add_document(comment_doc).unwrap();
 
-    let is_valid = validator::validate(
-        &doc,
-        Some(TEST_FUTURE_THRESHOLD),
-        Some(TEST_PAST_THRESHOLD),
-        &provider,
-    )
-    .await
-    .unwrap();
+    let is_valid = validator::validate(&doc, &provider).await.unwrap();
 
     assert!(is_valid);
 }
@@ -134,14 +116,7 @@ async fn test_invalid_comment_doc() {
     provider.add_document(template_doc).unwrap();
     provider.add_document(proposal_doc).unwrap();
 
-    let is_valid = validator::validate(
-        &doc,
-        Some(TEST_FUTURE_THRESHOLD),
-        Some(TEST_PAST_THRESHOLD),
-        &provider,
-    )
-    .await
-    .unwrap();
+    let is_valid = validator::validate(&doc, &provider).await.unwrap();
 
     assert!(!is_valid);
 }

--- a/rust/signed_doc/tests/proposal.rs
+++ b/rust/signed_doc/tests/proposal.rs
@@ -1,10 +1,6 @@
 //! Integration test for proposal document validation part.
 
-use catalyst_signed_doc::{
-    providers::tests::TestCatalystSignedDocumentProvider,
-    validator::tests::{TEST_FUTURE_THRESHOLD, TEST_PAST_THRESHOLD},
-    *,
-};
+use catalyst_signed_doc::{providers::tests::TestCatalystSignedDocumentProvider, *};
 
 mod common;
 
@@ -29,14 +25,7 @@ async fn test_valid_proposal_doc() {
     let mut provider = TestCatalystSignedDocumentProvider::default();
     provider.add_document(template_doc).unwrap();
 
-    let is_valid = validator::validate(
-        &doc,
-        Some(TEST_FUTURE_THRESHOLD),
-        Some(TEST_PAST_THRESHOLD),
-        &provider,
-    )
-    .await
-    .unwrap();
+    let is_valid = validator::validate(&doc, &provider).await.unwrap();
 
     assert!(is_valid);
 }
@@ -61,14 +50,7 @@ async fn test_valid_proposal_doc_with_empty_provider() {
 
     let provider = TestCatalystSignedDocumentProvider::default();
 
-    let is_valid = validator::validate(
-        &doc,
-        Some(TEST_FUTURE_THRESHOLD),
-        Some(TEST_PAST_THRESHOLD),
-        &provider,
-    )
-    .await
-    .unwrap();
+    let is_valid = validator::validate(&doc, &provider).await.unwrap();
 
     assert!(!is_valid);
 }
@@ -89,14 +71,7 @@ async fn test_invalid_proposal_doc() {
 
     let provider = TestCatalystSignedDocumentProvider::default();
 
-    let is_valid = validator::validate(
-        &doc,
-        Some(TEST_FUTURE_THRESHOLD),
-        Some(TEST_PAST_THRESHOLD),
-        &provider,
-    )
-    .await
-    .unwrap();
+    let is_valid = validator::validate(&doc, &provider).await.unwrap();
 
     assert!(!is_valid);
 }

--- a/rust/signed_doc/tests/proposal.rs
+++ b/rust/signed_doc/tests/proposal.rs
@@ -29,9 +29,14 @@ async fn test_valid_proposal_doc() {
     let mut provider = TestCatalystSignedDocumentProvider::default();
     provider.add_document(template_doc).unwrap();
 
-    let is_valid = validator::validate(&doc, TEST_FUTURE_THRESHOLD, TEST_PAST_THRESHOLD, &provider)
-        .await
-        .unwrap();
+    let is_valid = validator::validate(
+        &doc,
+        Some(TEST_FUTURE_THRESHOLD),
+        Some(TEST_PAST_THRESHOLD),
+        &provider,
+    )
+    .await
+    .unwrap();
 
     assert!(is_valid);
 }
@@ -56,9 +61,14 @@ async fn test_valid_proposal_doc_with_empty_provider() {
 
     let provider = TestCatalystSignedDocumentProvider::default();
 
-    let is_valid = validator::validate(&doc, TEST_FUTURE_THRESHOLD, TEST_PAST_THRESHOLD, &provider)
-        .await
-        .unwrap();
+    let is_valid = validator::validate(
+        &doc,
+        Some(TEST_FUTURE_THRESHOLD),
+        Some(TEST_PAST_THRESHOLD),
+        &provider,
+    )
+    .await
+    .unwrap();
 
     assert!(!is_valid);
 }
@@ -79,9 +89,14 @@ async fn test_invalid_proposal_doc() {
 
     let provider = TestCatalystSignedDocumentProvider::default();
 
-    let is_valid = validator::validate(&doc, TEST_FUTURE_THRESHOLD, TEST_PAST_THRESHOLD, &provider)
-        .await
-        .unwrap();
+    let is_valid = validator::validate(
+        &doc,
+        Some(TEST_FUTURE_THRESHOLD),
+        Some(TEST_PAST_THRESHOLD),
+        &provider,
+    )
+    .await
+    .unwrap();
 
     assert!(!is_valid);
 }

--- a/rust/signed_doc/tests/submission.rs
+++ b/rust/signed_doc/tests/submission.rs
@@ -1,10 +1,6 @@
 //! Test for proposal submission action.
 
-use catalyst_signed_doc::{
-    providers::tests::TestCatalystSignedDocumentProvider,
-    validator::tests::{TEST_FUTURE_THRESHOLD, TEST_PAST_THRESHOLD},
-    *,
-};
+use catalyst_signed_doc::{providers::tests::TestCatalystSignedDocumentProvider, *};
 
 mod common;
 
@@ -29,14 +25,7 @@ async fn test_valid_submission_action() {
     let mut provider = TestCatalystSignedDocumentProvider::default();
     provider.add_document(proposal_doc).unwrap();
 
-    let is_valid = validator::validate(
-        &doc,
-        Some(TEST_FUTURE_THRESHOLD),
-        Some(TEST_PAST_THRESHOLD),
-        &provider,
-    )
-    .await
-    .unwrap();
+    let is_valid = validator::validate(&doc, &provider).await.unwrap();
 
     assert!(is_valid);
 }
@@ -60,14 +49,7 @@ async fn test_valid_submission_action_with_empty_provider() {
 
     let provider = TestCatalystSignedDocumentProvider::default();
 
-    let is_valid = validator::validate(
-        &doc,
-        Some(TEST_FUTURE_THRESHOLD),
-        Some(TEST_PAST_THRESHOLD),
-        &provider,
-    )
-    .await
-    .unwrap();
+    let is_valid = validator::validate(&doc, &provider).await.unwrap();
 
     assert!(!is_valid);
 }
@@ -88,14 +70,7 @@ async fn test_invalid_submission_action() {
 
     let provider = TestCatalystSignedDocumentProvider::default();
 
-    let is_valid = validator::validate(
-        &doc,
-        Some(TEST_FUTURE_THRESHOLD),
-        Some(TEST_PAST_THRESHOLD),
-        &provider,
-    )
-    .await
-    .unwrap();
+    let is_valid = validator::validate(&doc, &provider).await.unwrap();
 
     assert!(!is_valid);
 }

--- a/rust/signed_doc/tests/submission.rs
+++ b/rust/signed_doc/tests/submission.rs
@@ -29,9 +29,14 @@ async fn test_valid_submission_action() {
     let mut provider = TestCatalystSignedDocumentProvider::default();
     provider.add_document(proposal_doc).unwrap();
 
-    let is_valid = validator::validate(&doc, TEST_FUTURE_THRESHOLD, TEST_PAST_THRESHOLD, &provider)
-        .await
-        .unwrap();
+    let is_valid = validator::validate(
+        &doc,
+        Some(TEST_FUTURE_THRESHOLD),
+        Some(TEST_PAST_THRESHOLD),
+        &provider,
+    )
+    .await
+    .unwrap();
 
     assert!(is_valid);
 }
@@ -55,9 +60,14 @@ async fn test_valid_submission_action_with_empty_provider() {
 
     let provider = TestCatalystSignedDocumentProvider::default();
 
-    let is_valid = validator::validate(&doc, TEST_FUTURE_THRESHOLD, TEST_PAST_THRESHOLD, &provider)
-        .await
-        .unwrap();
+    let is_valid = validator::validate(
+        &doc,
+        Some(TEST_FUTURE_THRESHOLD),
+        Some(TEST_PAST_THRESHOLD),
+        &provider,
+    )
+    .await
+    .unwrap();
 
     assert!(!is_valid);
 }
@@ -78,9 +88,14 @@ async fn test_invalid_submission_action() {
 
     let provider = TestCatalystSignedDocumentProvider::default();
 
-    let is_valid = validator::validate(&doc, TEST_FUTURE_THRESHOLD, TEST_PAST_THRESHOLD, &provider)
-        .await
-        .unwrap();
+    let is_valid = validator::validate(
+        &doc,
+        Some(TEST_FUTURE_THRESHOLD),
+        Some(TEST_PAST_THRESHOLD),
+        &provider,
+    )
+    .await
+    .unwrap();
 
     assert!(!is_valid);
 }


### PR DESCRIPTION
# Description

- changed validation arguments from `u64` to `Option<Duration>`, so if `None is passed validation is not performed.
- changing the validation from the `id` field to the `ver` field on this time based validation.