### PR TITLE
feat(rust/rbac-registration): Add `Clone` to `RegistrationChain`

### DIFF
--- a/rust/rbac-registration/src/registration/cardano/mod.rs
+++ b/rust/rbac-registration/src/registration/cardano/mod.rs
@@ -21,7 +21,7 @@ use crate::cardano::cip509::{
 };
 
 /// Registration chains.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RegistrationChain {
     /// Inner part of the registration chain.
     inner: Arc<RegistrationChainInner>,


### PR DESCRIPTION
# Description

Added `Clone` to `RegistrationChain` as we are going to add the field in an RBAC token that can hold the pre-queried/built `RegistrationChain`.

## Related Pull Requests

[#2123](https://github.com/input-output-hk/catalyst-voices/pull/2123)

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
