### PR TITLE
fix(rust/rbac-registration): Remove the Catalyst ID (is_some) check for non-root registrations

### DIFF
--- a/rust/rbac-registration/src/registration/cardano/mod.rs
+++ b/rust/rbac-registration/src/registration/cardano/mod.rs
@@ -334,9 +334,6 @@ impl RegistrationChainInner {
         let Some(prv_tx_id) = cip509.previous_transaction() else {
             bail!("Empty previous transaction ID");
         };
-        if cip509.catalyst_id().is_some() {
-            bail!("Catalyst id should be present only for chain root registration.");
-        }
         // Previous transaction ID in the CIP509 should equal to the current transaction ID
         // or else it is not a part of the chain
         if prv_tx_id == self.current_tx_id_hash {


### PR DESCRIPTION
# Description

- Remove the Catalyst ID (is_some) check for non-root registrations

## Description of Changes

A Catalyst ID is present in every registration with role 0, so it isn't always only the root one. The removed check prevents the following (correct) chain to be constructed:
- A first (root) registration with role 0 (has a Catalyst ID).
- A second registration with some other role (there is no Catalyst ID).
- A registration chat updates role 0: it has a Catalyst ID, but it is correct.