### PR TITLE
fix(rust/signed-doc): Update DocumentRef to require version field

### DIFF
--- a/rust/signed_doc/src/metadata/document_ref.rs
+++ b/rust/signed_doc/src/metadata/document_ref.rs
@@ -11,18 +11,13 @@ use super::{utils::CborUuidV7, UuidV7};
 pub struct DocumentRef {
     /// Reference to the Document Id
     pub id: UuidV7,
-    /// Reference to the Document Ver, if not specified the latest document is meant
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub ver: Option<UuidV7>,
+    /// Reference to the Document Ver
+    pub ver: UuidV7,
 }
 
 impl Display for DocumentRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(ver) = self.ver {
-            write!(f, "id: {}, ver: {}", self.id, ver)
-        } else {
-            write!(f, "id: {}", self.id)
-        }
+        write!(f, "id: {}, ver: {}", self.id, self.ver)
     }
 }
 
@@ -30,14 +25,10 @@ impl TryFrom<DocumentRef> for Value {
     type Error = anyhow::Error;
 
     fn try_from(value: DocumentRef) -> Result<Self, Self::Error> {
-        if let Some(ver) = value.ver {
-            Ok(Value::Array(vec![
-                Value::try_from(CborUuidV7(value.id))?,
-                Value::try_from(CborUuidV7(ver))?,
-            ]))
-        } else {
-            Value::try_from(CborUuidV7(value.id))
-        }
+        Ok(Value::Array(vec![
+            Value::try_from(CborUuidV7(value.id))?,
+            Value::try_from(CborUuidV7(value.ver))?,
+        ]))
     }
 }
 
@@ -46,23 +37,19 @@ impl TryFrom<&Value> for DocumentRef {
 
     #[allow(clippy::indexing_slicing)]
     fn try_from(val: &Value) -> anyhow::Result<DocumentRef> {
-        if let Ok(CborUuidV7(id)) = CborUuidV7::try_from(val) {
-            Ok(DocumentRef { id, ver: None })
-        } else {
-            let Some(array) = val.as_array() else {
-                anyhow::bail!("Document Reference must be either a single UUID or an array of two");
-            };
-            anyhow::ensure!(
-                array.len() == 2,
-                "Document Reference array of two UUIDs was expected"
-            );
-            let CborUuidV7(id) = CborUuidV7::try_from(&array[0])?;
-            let CborUuidV7(ver) = CborUuidV7::try_from(&array[1])?;
-            anyhow::ensure!(
-                ver >= id,
-                "Document Reference Version can never be smaller than its ID"
-            );
-            Ok(DocumentRef { id, ver: Some(ver) })
-        }
+        let Some(array) = val.as_array() else {
+            anyhow::bail!("Document Reference must be either a single UUID or an array of two");
+        };
+        anyhow::ensure!(
+            array.len() == 2,
+            "Document Reference array of two UUIDs was expected"
+        );
+        let CborUuidV7(id) = CborUuidV7::try_from(&array[0])?;
+        let CborUuidV7(ver) = CborUuidV7::try_from(&array[1])?;
+        anyhow::ensure!(
+            ver >= id,
+            "Document Reference Version can never be smaller than its ID"
+        );
+        Ok(DocumentRef { id, ver })
     }
 }

--- a/rust/signed_doc/src/validator/rules/category.rs
+++ b/rust/signed_doc/src/validator/rules/category.rs
@@ -70,14 +70,18 @@ mod tests {
         let mut provider = TestCatalystSignedDocumentProvider::default();
 
         let valid_category_doc_id = UuidV7::new();
+        let valid_category_doc_ver = UuidV7::new();
         let another_type_category_doc_id = UuidV7::new();
+        let another_type_category_doc_ver = UuidV7::new();
         let missing_type_category_doc_id = UuidV7::new();
+        let missing_type_category_doc_ver = UuidV7::new();
 
         // prepare replied documents
         {
             let ref_doc = Builder::new()
                 .with_json_metadata(serde_json::json!({
                     "id": valid_category_doc_id.to_string(),
+                    "ver": valid_category_doc_ver.to_string(),
                     "type": CATEGORY_DOCUMENT_UUID_TYPE.to_string()
                 }))
                 .unwrap()
@@ -88,6 +92,7 @@ mod tests {
             let ref_doc = Builder::new()
                 .with_json_metadata(serde_json::json!({
                     "id": another_type_category_doc_id.to_string(),
+                    "ver": another_type_category_doc_ver.to_string(),
                     "type": UuidV4::new().to_string()
                 }))
                 .unwrap()
@@ -98,6 +103,7 @@ mod tests {
             let ref_doc = Builder::new()
                 .with_json_metadata(serde_json::json!({
                     "id": missing_type_category_doc_id.to_string(),
+                    "ver": missing_type_category_doc_ver.to_string(),
                 }))
                 .unwrap()
                 .build();
@@ -108,7 +114,7 @@ mod tests {
         let rule = CategoryRule::Specified { optional: false };
         let doc = Builder::new()
             .with_json_metadata(serde_json::json!({
-                "category_id": {"id": valid_category_doc_id.to_string() }
+                "category_id": {"id": valid_category_doc_id.to_string(), "ver": valid_category_doc_ver }
             }))
             .unwrap()
             .build();
@@ -127,7 +133,7 @@ mod tests {
         // reference to the document with another `type` field
         let doc = Builder::new()
             .with_json_metadata(serde_json::json!({
-                "category_id": {"id": another_type_category_doc_id.to_string() }
+                "category_id": {"id": another_type_category_doc_id.to_string(), "ver": another_type_category_doc_ver.to_string() }
             }))
             .unwrap()
             .build();
@@ -136,7 +142,7 @@ mod tests {
         // missing `type` field in the referenced document
         let doc = Builder::new()
             .with_json_metadata(serde_json::json!({
-                "category_id": {"id": missing_type_category_doc_id.to_string() }
+                "category_id": {"id": missing_type_category_doc_id.to_string(), "ver": missing_type_category_doc_ver.to_string() }
             }))
             .unwrap()
             .build();
@@ -145,7 +151,7 @@ mod tests {
         // cannot find a referenced document
         let doc = Builder::new()
             .with_json_metadata(serde_json::json!({
-                "category_id": {"id": UuidV7::new().to_string() }
+                "category_id": {"id": UuidV7::new().to_string(), "ver": UuidV7::new().to_string() }
             }))
             .unwrap()
             .build();
@@ -162,8 +168,11 @@ mod tests {
         assert!(rule.check(&doc, &provider).await.unwrap());
 
         let ref_id = UuidV7::new();
+        let ref_ver = UuidV7::new();
         let doc = Builder::new()
-            .with_json_metadata(serde_json::json!({"category_id": {"id": ref_id.to_string() } }))
+            .with_json_metadata(serde_json::json!({
+                "category_id": {"id": ref_id.to_string(), "ver": ref_ver.to_string(), }
+            }))
             .unwrap()
             .build();
         assert!(!rule.check(&doc, &provider).await.unwrap());

--- a/rust/signed_doc/src/validator/rules/doc_ref.rs
+++ b/rust/signed_doc/src/validator/rules/doc_ref.rs
@@ -95,14 +95,18 @@ mod tests {
         let exp_ref_type = UuidV4::new();
 
         let valid_referenced_doc_id = UuidV7::new();
+        let valid_referenced_doc_ver = UuidV7::new();
         let another_type_referenced_doc_id = UuidV7::new();
+        let another_type_referenced_doc_ver = UuidV7::new();
         let missing_type_referenced_doc_id = UuidV7::new();
+        let missing_type_referenced_doc_ver = UuidV7::new();
 
         // prepare replied documents
         {
             let ref_doc = Builder::new()
                 .with_json_metadata(serde_json::json!({
                     "id": valid_referenced_doc_id.to_string(),
+                    "ver": valid_referenced_doc_ver.to_string(),
                     "type": exp_ref_type.to_string()
                 }))
                 .unwrap()
@@ -113,6 +117,7 @@ mod tests {
             let ref_doc = Builder::new()
                 .with_json_metadata(serde_json::json!({
                     "id": another_type_referenced_doc_id.to_string(),
+                    "ver": another_type_referenced_doc_ver.to_string(),
                     "type": UuidV4::new().to_string()
                 }))
                 .unwrap()
@@ -123,6 +128,7 @@ mod tests {
             let ref_doc = Builder::new()
                 .with_json_metadata(serde_json::json!({
                     "id": missing_type_referenced_doc_id.to_string(),
+                    "ver": missing_type_referenced_doc_ver.to_string(),
                 }))
                 .unwrap()
                 .build();
@@ -136,7 +142,7 @@ mod tests {
         };
         let doc = Builder::new()
             .with_json_metadata(serde_json::json!({
-                "ref": {"id": valid_referenced_doc_id.to_string() }
+                "ref": {"id": valid_referenced_doc_id.to_string(), "ver": valid_referenced_doc_ver.to_string() }
             }))
             .unwrap()
             .build();
@@ -161,7 +167,7 @@ mod tests {
         // reference to the document with another `type` field
         let doc = Builder::new()
             .with_json_metadata(serde_json::json!({
-                "ref": {"id": another_type_referenced_doc_id.to_string() }
+                "ref": {"id": another_type_referenced_doc_id.to_string(), "ver": another_type_referenced_doc_ver.to_string() }
             }))
             .unwrap()
             .build();
@@ -170,7 +176,7 @@ mod tests {
         // missing `type` field in the referenced document
         let doc = Builder::new()
             .with_json_metadata(serde_json::json!({
-                "ref": {"id": missing_type_referenced_doc_id.to_string() }
+                "ref": {"id": missing_type_referenced_doc_id.to_string(), "ver": missing_type_referenced_doc_ver.to_string() }
             }))
             .unwrap()
             .build();
@@ -179,7 +185,7 @@ mod tests {
         // cannot find a referenced document
         let doc = Builder::new()
             .with_json_metadata(serde_json::json!({
-                "ref": {"id": UuidV7::new().to_string() }
+                "ref": {"id": UuidV7::new().to_string(), "ver": UuidV7::new().to_string() }
             }))
             .unwrap()
             .build();
@@ -195,8 +201,9 @@ mod tests {
         assert!(rule.check(&doc, &provider).await.unwrap());
 
         let ref_id = UuidV7::new();
+        let ref_ver = UuidV7::new();
         let doc = Builder::new()
-            .with_json_metadata(serde_json::json!({"ref": {"id": ref_id.to_string() } }))
+            .with_json_metadata(serde_json::json!({"ref": {"id": ref_id.to_string(), "ver": ref_ver.to_string() } }))
             .unwrap()
             .build();
         assert!(!rule.check(&doc, &provider).await.unwrap());

--- a/rust/signed_doc/src/validator/rules/reply.rs
+++ b/rust/signed_doc/src/validator/rules/reply.rs
@@ -104,18 +104,24 @@ mod tests {
 
         let exp_reply_type = UuidV4::new();
         let common_ref_id = UuidV7::new();
+        let common_ref_ver = UuidV7::new();
 
         let valid_replied_doc_id = UuidV7::new();
+        let valid_replied_doc_ver = UuidV7::new();
+        let another_type_replied_doc_ver = UuidV7::new();
         let another_type_replied_doc_id = UuidV7::new();
+        let missing_ref_replied_doc_ver = UuidV7::new();
         let missing_ref_replied_doc_id = UuidV7::new();
+        let missing_type_replied_doc_ver = UuidV7::new();
         let missing_type_replied_doc_id = UuidV7::new();
 
         // prepare replied documents
         {
             let ref_doc = Builder::new()
                 .with_json_metadata(serde_json::json!({
-                    "ref": { "id": common_ref_id.to_string() },
+                    "ref": { "id": common_ref_id.to_string(), "ver": common_ref_ver.to_string() },
                     "id": valid_replied_doc_id.to_string(),
+                    "ver": valid_replied_doc_ver.to_string(),
                     "type": exp_reply_type.to_string()
                 }))
                 .unwrap()
@@ -125,8 +131,9 @@ mod tests {
             // reply doc with other `type` field
             let ref_doc = Builder::new()
                 .with_json_metadata(serde_json::json!({
-                    "ref": { "id": common_ref_id.to_string() },
+                    "ref": { "id": common_ref_id.to_string(), "ver": common_ref_ver.to_string() },
                     "id": another_type_replied_doc_id.to_string(),
+                    "ver": another_type_replied_doc_ver.to_string(),
                     "type": UuidV4::new().to_string()
                 }))
                 .unwrap()
@@ -137,6 +144,7 @@ mod tests {
             let ref_doc = Builder::new()
                 .with_json_metadata(serde_json::json!({
                     "id": missing_ref_replied_doc_id.to_string(),
+                    "ver": missing_ref_replied_doc_ver.to_string(),
                     "type": exp_reply_type.to_string()
                 }))
                 .unwrap()
@@ -146,8 +154,9 @@ mod tests {
             // missing `type` field in the referenced document
             let ref_doc = Builder::new()
                 .with_json_metadata(serde_json::json!({
-                    "ref": { "id": common_ref_id.to_string() },
+                    "ref": { "id": common_ref_id.to_string(), "ver": common_ref_ver.to_string() },
                     "id": missing_type_replied_doc_id.to_string(),
+                    "ver": missing_type_replied_doc_ver.to_string(),
                 }))
                 .unwrap()
                 .build();
@@ -161,8 +170,8 @@ mod tests {
         };
         let doc = Builder::new()
             .with_json_metadata(serde_json::json!({
-                "ref": { "id": common_ref_id.to_string() },
-                "reply": { "id": valid_replied_doc_id.to_string() }
+                "ref": { "id": common_ref_id.to_string(), "ver": common_ref_ver.to_string() },
+                "reply": { "id": valid_replied_doc_id.to_string(), "ver": valid_replied_doc_ver.to_string() }
             }))
             .unwrap()
             .build();
@@ -183,7 +192,7 @@ mod tests {
         };
         let doc = Builder::new()
             .with_json_metadata(serde_json::json!({
-                "ref": { "id": common_ref_id.to_string() },
+                "ref": { "id": common_ref_id.to_string(), "ver": common_ref_ver.to_string() },
             }))
             .unwrap()
             .build();
@@ -192,7 +201,7 @@ mod tests {
         // missing `ref` field
         let doc = Builder::new()
             .with_json_metadata(serde_json::json!({
-                "reply": { "id": valid_replied_doc_id.to_string() }
+                "reply": { "id": valid_replied_doc_id.to_string(), "ver": valid_replied_doc_ver.to_string() }
             }))
             .unwrap()
             .build();
@@ -201,8 +210,8 @@ mod tests {
         // reference to the document with another `type` field
         let doc = Builder::new()
             .with_json_metadata(serde_json::json!({
-                "ref": { "id": common_ref_id.to_string() },
-                "reply": { "id": another_type_replied_doc_id.to_string() }
+                "ref": { "id": common_ref_id.to_string(), "ver": common_ref_ver.to_string() },
+                "reply": { "id": another_type_replied_doc_id.to_string(), "ver": another_type_replied_doc_ver.to_string() }
             }))
             .unwrap()
             .build();
@@ -211,8 +220,8 @@ mod tests {
         // missing `ref` field in the referenced document
         let doc = Builder::new()
             .with_json_metadata(serde_json::json!({
-                "ref": { "id": common_ref_id.to_string() },
-                "reply": { "id": missing_ref_replied_doc_id.to_string() }
+                "ref": { "id": common_ref_id.to_string(), "ver": common_ref_ver.to_string() },
+                "reply": { "id": missing_ref_replied_doc_id.to_string(), "ver": missing_type_replied_doc_ver.to_string() }
             }))
             .unwrap()
             .build();
@@ -221,8 +230,8 @@ mod tests {
         // missing `type` field in the referenced document
         let doc = Builder::new()
             .with_json_metadata(serde_json::json!({
-                "ref": {"id": common_ref_id.to_string() },
-                "reply": { "id": missing_type_replied_doc_id.to_string() }
+                "ref": { "id": common_ref_id.to_string(), "ver": common_ref_ver.to_string() },
+                "reply": { "id": missing_type_replied_doc_id.to_string(), "ver": missing_type_replied_doc_ver.to_string() }
             }))
             .unwrap()
             .build();
@@ -231,8 +240,8 @@ mod tests {
         // `ref` field does not align with the referenced document
         let doc = Builder::new()
             .with_json_metadata(serde_json::json!({
-                "ref": { "id": UuidV7::new().to_string() },
-                "reply": { "id": valid_replied_doc_id.to_string() }
+                "ref": { "id": UuidV7::new().to_string(), "ver": UuidV7::new().to_string() },
+                "reply": { "id": valid_replied_doc_id.to_string(), "ver": valid_replied_doc_ver.to_string() }
             }))
             .unwrap()
             .build();
@@ -241,8 +250,8 @@ mod tests {
         // cannot find a referenced document
         let doc = Builder::new()
             .with_json_metadata(serde_json::json!({
-                "ref": { "id": common_ref_id.to_string() },
-                "reply": {"id": UuidV7::new().to_string() }
+                "ref": { "id": common_ref_id.to_string(), "ver": common_ref_ver.to_string() },
+                "reply": {"id": UuidV7::new().to_string(), "ver": UuidV7::new().to_string() }
             }))
             .unwrap()
             .build();
@@ -258,8 +267,9 @@ mod tests {
         assert!(rule.check(&doc, &provider).await.unwrap());
 
         let ref_id = UuidV7::new();
+        let ref_ver = UuidV7::new();
         let doc = Builder::new()
-            .with_json_metadata(serde_json::json!({"reply": {"id": ref_id.to_string() } }))
+            .with_json_metadata(serde_json::json!({"reply": {"id": ref_id.to_string(), "ver": ref_ver.to_string() } }))
             .unwrap()
             .build();
         assert!(!rule.check(&doc, &provider).await.unwrap());

--- a/rust/signed_doc/src/validator/rules/template.rs
+++ b/rust/signed_doc/src/validator/rules/template.rs
@@ -160,16 +160,22 @@ mod tests {
         let json_content = serde_json::to_vec(&serde_json::json!({})).unwrap();
 
         let valid_template_doc_id = UuidV7::new();
+        let valid_template_doc_ver = UuidV7::new();
         let another_type_template_doc_id = UuidV7::new();
+        let another_type_template_doc_ver = UuidV7::new();
         let missing_type_template_doc_id = UuidV7::new();
+        let missing_type_template_doc_ver = UuidV7::new();
         let missing_content_template_doc_id = UuidV7::new();
+        let missing_content_template_doc_ver = UuidV7::new();
         let invalid_content_template_doc_id = UuidV7::new();
+        let invalid_content_template_doc_ver = UuidV7::new();
 
         // prepare replied documents
         {
             let ref_doc = Builder::new()
                 .with_json_metadata(serde_json::json!({
                     "id": valid_template_doc_id.to_string(),
+                    "ver": valid_template_doc_ver.to_string(),
                     "type": exp_template_type.to_string()
                 }))
                 .unwrap()
@@ -181,6 +187,7 @@ mod tests {
             let ref_doc = Builder::new()
                 .with_json_metadata(serde_json::json!({
                     "id": another_type_template_doc_id.to_string(),
+                    "ver": another_type_template_doc_ver.to_string(),
                     "type": UuidV4::new().to_string()
                 }))
                 .unwrap()
@@ -192,6 +199,7 @@ mod tests {
             let ref_doc = Builder::new()
                 .with_json_metadata(serde_json::json!({
                     "id": missing_type_template_doc_id.to_string(),
+                    "ver": missing_type_template_doc_ver.to_string(),
                 }))
                 .unwrap()
                 .with_decoded_content(json_schema.clone())
@@ -202,6 +210,7 @@ mod tests {
             let ref_doc = Builder::new()
                 .with_json_metadata(serde_json::json!({
                     "id": missing_content_template_doc_id.to_string(),
+                    "ver": missing_content_template_doc_ver.to_string(),
                     "type": exp_template_type.to_string()
                 }))
                 .unwrap()
@@ -212,6 +221,7 @@ mod tests {
             let ref_doc = Builder::new()
                 .with_json_metadata(serde_json::json!({
                     "id": invalid_content_template_doc_id.to_string(),
+                    "ver": invalid_content_template_doc_ver.to_string(),
                     "type": exp_template_type.to_string()
                 }))
                 .unwrap()
@@ -225,7 +235,7 @@ mod tests {
         let doc = Builder::new()
             .with_json_metadata(serde_json::json!({
                 "content-type": content_type.to_string(),
-                "template": {"id": valid_template_doc_id.to_string() }
+                "template": {"id": valid_template_doc_id.to_string(), "ver": valid_template_doc_ver.to_string() }
             }))
             .unwrap()
             .with_decoded_content(json_content.clone())
@@ -246,7 +256,7 @@ mod tests {
         let rule = TemplateRule::Specified { exp_template_type };
         let doc = Builder::new()
             .with_json_metadata(serde_json::json!({
-                "template": {"id": valid_template_doc_id.to_string() }
+                "template": {"id": valid_template_doc_id.to_string(), "ver": valid_template_doc_ver.to_string() }
             }))
             .unwrap()
             .with_decoded_content(json_content.clone())
@@ -258,7 +268,7 @@ mod tests {
         let doc = Builder::new()
             .with_json_metadata(serde_json::json!({
                 "content-type": content_type.to_string(),
-                "template": {"id": valid_template_doc_id.to_string() }
+                "template": {"id": valid_template_doc_id.to_string(), "ver": valid_template_doc_ver.to_string() }
             }))
             .unwrap()
             .build();
@@ -269,7 +279,7 @@ mod tests {
         let doc = Builder::new()
             .with_json_metadata(serde_json::json!({
                 "content-type": content_type.to_string(),
-                "template": {"id": valid_template_doc_id.to_string() }
+                "template": {"id": valid_template_doc_id.to_string(), "ver": valid_template_doc_ver.to_string() }
             }))
             .unwrap()
             .with_decoded_content(vec![])
@@ -280,7 +290,7 @@ mod tests {
         let doc = Builder::new()
             .with_json_metadata(serde_json::json!({
                 "content-type": content_type.to_string(),
-                "template": {"id": another_type_template_doc_id.to_string() }
+                "template": {"id": another_type_template_doc_id.to_string(), "ver": another_type_template_doc_ver.to_string() }
             }))
             .unwrap()
             .with_decoded_content(json_content.clone())
@@ -291,7 +301,7 @@ mod tests {
         let doc = Builder::new()
             .with_json_metadata(serde_json::json!({
                 "content-type": content_type.to_string(),
-                "template": {"id": missing_type_template_doc_id.to_string() }
+                "template": {"id": missing_type_template_doc_id.to_string(), "ver": missing_type_template_doc_ver.to_string() }
             }))
             .unwrap()
             .with_decoded_content(json_content.clone())
@@ -302,7 +312,7 @@ mod tests {
         let doc = Builder::new()
             .with_json_metadata(serde_json::json!({
                 "content-type": content_type.to_string(),
-                "template": {"id": missing_content_template_doc_id.to_string() }
+                "template": {"id": missing_content_template_doc_id.to_string(), "ver": missing_content_template_doc_ver.to_string() }
             }))
             .unwrap()
             .with_decoded_content(json_content.clone())
@@ -313,7 +323,7 @@ mod tests {
         let doc = Builder::new()
             .with_json_metadata(serde_json::json!({
                 "content-type": content_type.to_string(),
-                "template": {"id": missing_content_template_doc_id.to_string() }
+                "template": {"id": missing_content_template_doc_id.to_string(), "ver": missing_content_template_doc_ver.to_string() }
             }))
             .unwrap()
             .with_decoded_content(json_content.clone())
@@ -324,7 +334,7 @@ mod tests {
         let doc = Builder::new()
             .with_json_metadata(serde_json::json!({
                 "content-type": content_type.to_string(),
-                "template": {"id": UuidV7::new().to_string() }
+                "template": {"id": UuidV7::new().to_string(), "ver": UuidV7::new().to_string() }
             }))
             .unwrap()
             .with_decoded_content(json_content.clone())
@@ -341,8 +351,9 @@ mod tests {
         assert!(rule.check(&doc, &provider).await.unwrap());
 
         let ref_id = UuidV7::new();
+        let ref_ver = UuidV7::new();
         let doc = Builder::new()
-            .with_json_metadata(serde_json::json!({"template": {"id": ref_id.to_string() } }))
+            .with_json_metadata(serde_json::json!({"template": {"id": ref_id.to_string(), "ver": ref_ver.to_string() } }))
             .unwrap()
             .build();
         assert!(!rule.check(&doc, &provider).await.unwrap());

--- a/rust/signed_doc/tests/comment.rs
+++ b/rust/signed_doc/tests/comment.rs
@@ -6,9 +6,9 @@ mod common;
 
 #[tokio::test]
 async fn test_valid_comment_doc() {
-    let (proposal_doc, proposal_doc_id) =
+    let (proposal_doc, proposal_doc_id, proposal_doc_ver) =
         common::create_dummy_doc(doc_types::PROPOSAL_DOCUMENT_UUID_TYPE).unwrap();
-    let (template_doc, template_doc_id) =
+    let (template_doc, template_doc_id, template_doc_ver) =
         common::create_dummy_doc(doc_types::COMMENT_TEMPLATE_UUID_TYPE).unwrap();
 
     let uuid_v7 = UuidV7::new();
@@ -19,10 +19,12 @@ async fn test_valid_comment_doc() {
         "id": uuid_v7.to_string(),
         "ver": uuid_v7.to_string(),
         "template": {
-          "id": template_doc_id
+          "id": template_doc_id,
+          "ver": template_doc_ver
         },
         "ref": {
-            "id": proposal_doc_id
+            "id": proposal_doc_id,
+            "ver": proposal_doc_ver
         }
     })))
     .unwrap();
@@ -40,20 +42,23 @@ async fn test_valid_comment_doc() {
 async fn test_valid_comment_doc_with_reply() {
     let empty_json = serde_json::to_vec(&serde_json::json!({})).unwrap();
 
-    let (proposal_doc, proposal_doc_id) =
+    let (proposal_doc, proposal_doc_id, proposal_doc_ver) =
         common::create_dummy_doc(doc_types::PROPOSAL_DOCUMENT_UUID_TYPE).unwrap();
-    let (template_doc, template_doc_id) =
+    let (template_doc, template_doc_id, template_doc_ver) =
         common::create_dummy_doc(doc_types::COMMENT_TEMPLATE_UUID_TYPE).unwrap();
 
     let comment_doc_id = UuidV7::new();
+    let comment_doc_ver = UuidV7::new();
     let comment_doc = Builder::new()
         .with_json_metadata(serde_json::json!({
             "id": comment_doc_id,
+            "ver": comment_doc_ver,
             "type": doc_types::COMMENT_DOCUMENT_UUID_TYPE,
             "content-type": ContentType::Json.to_string(),
-            "template": { "id": comment_doc_id.to_string() },
+            "template": { "id": template_doc_id.to_string(), "ver": template_doc_ver.to_string() },
             "ref": {
-                "id": proposal_doc_id
+                "id": proposal_doc_id,
+                "ver": proposal_doc_ver
             },
         }))
         .unwrap()
@@ -68,14 +73,16 @@ async fn test_valid_comment_doc_with_reply() {
         "id": uuid_v7.to_string(),
         "ver": uuid_v7.to_string(),
         "template": {
-          "id": template_doc_id
+          "id": template_doc_id,
+          "ver": template_doc_ver
         },
         "ref": {
-            "id": proposal_doc_id
+            "id": proposal_doc_id,
+            "ver": proposal_doc_ver
         },
         "reply": {
             "id": comment_doc_id,
-            "ver": uuid_v7
+            "ver": comment_doc_ver
         }
     })))
     .unwrap();
@@ -92,9 +99,9 @@ async fn test_valid_comment_doc_with_reply() {
 
 #[tokio::test]
 async fn test_invalid_comment_doc() {
-    let (proposal_doc, _) =
+    let (proposal_doc, ..) =
         common::create_dummy_doc(doc_types::PROPOSAL_DOCUMENT_UUID_TYPE).unwrap();
-    let (template_doc, template_doc_id) =
+    let (template_doc, template_doc_id, template_doc_ver) =
         common::create_dummy_doc(doc_types::COMMENT_TEMPLATE_UUID_TYPE).unwrap();
 
     let uuid_v7 = UuidV7::new();
@@ -105,7 +112,8 @@ async fn test_invalid_comment_doc() {
         "id": uuid_v7.to_string(),
         "ver": uuid_v7.to_string(),
         "template": {
-          "id": template_doc_id
+          "id": template_doc_id,
+          "ver": template_doc_ver
         },
         // without ref
         "ref": serde_json::Value::Null

--- a/rust/signed_doc/tests/common/mod.rs
+++ b/rust/signed_doc/tests/common/mod.rs
@@ -14,15 +14,15 @@ pub fn test_metadata() -> (UuidV7, UuidV4, serde_json::Value) {
         "type": uuid_v4.to_string(),
         "id": uuid_v7.to_string(),
         "ver": uuid_v7.to_string(),
-        "ref": {"id": uuid_v7.to_string()},
+        "ref": {"id": uuid_v7.to_string(), "ver": uuid_v7.to_string()},
         "reply": {"id": uuid_v7.to_string(), "ver": uuid_v7.to_string()},
-        "template": {"id": uuid_v7.to_string()},
+        "template": {"id": uuid_v7.to_string(), "ver": uuid_v7.to_string()},
         "section": "$".to_string(),
         "collabs": vec!["Alex1".to_string(), "Alex2".to_string()],
-        "campaign_id": {"id": uuid_v7.to_string()},
+        "campaign_id": {"id": uuid_v7.to_string(), "ver": uuid_v7.to_string()},
         "election_id":  uuid_v4.to_string(),
-        "brand_id":  {"id": uuid_v7.to_string()},
-        "category_id": {"id": uuid_v7.to_string()},
+        "brand_id":  {"id": uuid_v7.to_string(), "ver": uuid_v7.to_string()},
+        "category_id": {"id": uuid_v7.to_string(), "ver": uuid_v7.to_string()},
     });
 
     (uuid_v7, uuid_v4, metadata_fields)
@@ -43,22 +43,26 @@ pub fn create_dummy_key_pair() -> anyhow::Result<(
     Ok((sk, pk, kid))
 }
 
-pub fn create_dummy_doc(doc_type_id: Uuid) -> anyhow::Result<(CatalystSignedDocument, UuidV7)> {
+pub fn create_dummy_doc(
+    doc_type_id: Uuid,
+) -> anyhow::Result<(CatalystSignedDocument, UuidV7, UuidV7)> {
     let empty_json = serde_json::to_vec(&serde_json::json!({}))?;
 
     let doc_id = UuidV7::new();
+    let doc_ver = UuidV7::new();
 
     let doc = Builder::new()
         .with_json_metadata(serde_json::json!({
-            "id": doc_id,
-            "type": doc_type_id,
             "content-type": ContentType::Json.to_string(),
-            "template": { "id": doc_id.to_string() }
+            "type": doc_type_id,
+            "id": doc_id,
+            "ver": doc_ver,
+            "template": { "id": doc_id.to_string(), "ver": doc_ver.to_string() }
         }))?
         .with_decoded_content(empty_json.clone())
         .build();
 
-    Ok((doc, doc_id))
+    Ok((doc, doc_id, doc_ver))
 }
 
 pub fn create_signing_key() -> ed25519_dalek::SigningKey {

--- a/rust/signed_doc/tests/proposal.rs
+++ b/rust/signed_doc/tests/proposal.rs
@@ -6,7 +6,7 @@ mod common;
 
 #[tokio::test]
 async fn test_valid_proposal_doc() {
-    let (template_doc, template_doc_id) =
+    let (template_doc, template_doc_id, template_doc_ver) =
         common::create_dummy_doc(doc_types::PROPOSAL_TEMPLATE_UUID_TYPE).unwrap();
 
     let uuid_v7 = UuidV7::new();
@@ -17,7 +17,8 @@ async fn test_valid_proposal_doc() {
         "id": uuid_v7.to_string(),
         "ver": uuid_v7.to_string(),
         "template": {
-          "id": template_doc_id
+          "id": template_doc_id,
+          "ver": template_doc_ver
         },
     })))
     .unwrap();
@@ -34,6 +35,7 @@ async fn test_valid_proposal_doc() {
 async fn test_valid_proposal_doc_with_empty_provider() {
     // dummy template doc to dummy provider
     let template_doc_id = UuidV7::new();
+    let template_doc_ver = UuidV7::new();
 
     let uuid_v7 = UuidV7::new();
     let (doc, ..) = common::create_dummy_signed_doc(Some(serde_json::json!({
@@ -43,7 +45,8 @@ async fn test_valid_proposal_doc_with_empty_provider() {
         "id": uuid_v7.to_string(),
         "ver": uuid_v7.to_string(),
         "template": {
-          "id": template_doc_id
+          "id": template_doc_id,
+          "ver": template_doc_ver
         },
     })))
     .unwrap();

--- a/rust/signed_doc/tests/submission.rs
+++ b/rust/signed_doc/tests/submission.rs
@@ -6,7 +6,7 @@ mod common;
 
 #[tokio::test]
 async fn test_valid_submission_action() {
-    let (proposal_doc, proposal_doc_id) =
+    let (proposal_doc, proposal_doc_id, proposal_doc_ver) =
         common::create_dummy_doc(doc_types::PROPOSAL_DOCUMENT_UUID_TYPE).unwrap();
 
     let uuid_v7 = UuidV7::new();
@@ -17,7 +17,8 @@ async fn test_valid_submission_action() {
         "id": uuid_v7.to_string(),
         "ver": uuid_v7.to_string(),
         "ref": {
-            "id": proposal_doc_id
+            "id": proposal_doc_id,
+            "ver": proposal_doc_ver
         },
     })))
     .unwrap();
@@ -33,6 +34,7 @@ async fn test_valid_submission_action() {
 #[tokio::test]
 async fn test_valid_submission_action_with_empty_provider() {
     let proposal_doc_id = UuidV7::new();
+    let proposal_doc_ver = UuidV7::new();
 
     let uuid_v7 = UuidV7::new();
     let (doc, ..) = common::create_dummy_signed_doc(Some(serde_json::json!({
@@ -42,7 +44,8 @@ async fn test_valid_submission_action_with_empty_provider() {
         "id": uuid_v7.to_string(),
         "ver": uuid_v7.to_string(),
         "ref": {
-            "id": proposal_doc_id
+            "id": proposal_doc_id,
+            "ver": proposal_doc_ver
         },
     })))
     .unwrap();


### PR DESCRIPTION
# Description

Catalyst Signed Documents `DocumentRef` requires the `ver` field, it is no longer optional.

## Related Issue(s)

Closes #270 


## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
