### PR TITLE
feat(rust/rbac-registration): Certificate self-signed validation

### DIFF
--- a/rust/c509-certificate/src/cert_tbs.rs
+++ b/rust/c509-certificate/src/cert_tbs.rs
@@ -133,7 +133,7 @@ impl TbsCert {
     pub fn issuer_signature_algorithm(&self) -> &IssuerSignatureAlgorithm {
         &self.issuer_signature_algorithm
     }
-    
+
     /// Convert the TBS Certificate to CBOR.
     #[must_use]
     pub fn to_cbor(&self) -> Vec<u8> {

--- a/rust/c509-certificate/src/cert_tbs.rs
+++ b/rust/c509-certificate/src/cert_tbs.rs
@@ -133,6 +133,15 @@ impl TbsCert {
     pub fn issuer_signature_algorithm(&self) -> &IssuerSignatureAlgorithm {
         &self.issuer_signature_algorithm
     }
+    
+    /// Convert the TBS Certificate to CBOR.
+    #[must_use]
+    pub fn to_cbor(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+        let mut e = Encoder::new(&mut buf);
+        let _unused = self.encode(&mut e, &mut ());
+        buf
+    }
 }
 
 impl Encode<()> for TbsCert {

--- a/rust/c509-certificate/src/cert_tbs.rs
+++ b/rust/c509-certificate/src/cert_tbs.rs
@@ -135,12 +135,15 @@ impl TbsCert {
     }
 
     /// Convert the TBS Certificate to CBOR.
-    #[must_use]
-    pub fn to_cbor(&self) -> Vec<u8> {
+    ///
+    /// # Errors
+    /// Returns an error if encoding fails.
+    pub fn to_cbor<W: Write>(&self) -> Result<Vec<u8>, minicbor::encode::Error<W::Error>> {
         let mut buf = Vec::new();
         let mut e = Encoder::new(&mut buf);
-        let _unused = self.encode(&mut e, &mut ());
-        buf
+        self.encode(&mut e, &mut ())
+            .map_err(minicbor::encode::Error::message)?;
+        Ok(buf)
     }
 }
 

--- a/rust/rbac-registration/src/cardano/cip509/cip509.rs
+++ b/rust/rbac-registration/src/cardano/cip509/cip509.rs
@@ -36,7 +36,8 @@ use crate::cardano::cip509::{
     types::{PaymentHistory, RoleNumber, TxInputHash, ValidationSignature},
     utils::Cip0134UriSet,
     validation::{
-        validate_aux, validate_role_data, validate_stake_public_key, validate_txn_inputs_hash,
+        validate_aux, validate_role_data, validate_self_sign_cert, validate_stake_public_key,
+        validate_txn_inputs_hash,
     },
     x509_chunks::X509Chunks,
     Payment, PointTxnIdx, RoleData,
@@ -162,6 +163,7 @@ impl Cip509 {
         }
         if let Some(metadata) = &cip509.metadata {
             cip509.catalyst_id = validate_role_data(metadata, block.network(), &cip509.report);
+            validate_self_sign_cert(metadata, &report);
         }
 
         Ok(Some(cip509))

--- a/rust/rbac-registration/src/cardano/cip509/validation.rs
+++ b/rust/rbac-registration/src/cardano/cip509/validation.rs
@@ -202,7 +202,6 @@ fn validate_c509_self_signed_cert(c: &C509, index: usize, report: &ProblemReport
             report.other(
                 &format!(
                     "Failed to extract subject public key from C509 certificate at index {index}: {e:?}",
-                    
                 ),
                 context,
             );

--- a/rust/rbac-registration/src/cardano/cip509/validation.rs
+++ b/rust/rbac-registration/src/cardano/cip509/validation.rs
@@ -21,7 +21,7 @@ use pallas::{
     },
     ledger::{addresses::Address, primitives::conway, traverse::MultiEraTx},
 };
-use x509_cert::{der::Encode as X509Encode, Certificate};
+use x509_cert::{der::Encode as X509Encode, Certificate as X509};
 
 use super::{
     extract_key::{c509_key, x509_key},
@@ -172,105 +172,125 @@ pub fn validate_self_sign_cert(metadata: &Cip509RbacMetadata, report: &ProblemRe
 
     for (index, cert) in metadata.c509_certs.iter().enumerate() {
         if let C509Cert::C509Certificate(c) = cert {
-            // Self-sign certificate must be type 2
-            if c.tbs_cert().c509_certificate_type() != 2 {
-                report.invalid_value(
-                    &format!("C509 certificate type at index {index}"),
-                    &c.tbs_cert().c509_certificate_type().to_string(),
-                    "Certificate must have cert type 2",
-                    context,
-                );
-                continue;
-            }
-
-            let pk = match c509_key(c) {
-                Ok(pk) => pk,
-                Err(e) => {
-                    report.other(
-                        &format!(
-                            "Failed to extract subject public key from C509 certificate at index {index}: {e:?}",
-                        ),
-                        context,
-                    );
-                    continue;
-                },
-            };
-
-            let Some(sig) = c
-                .issuer_signature_value()
-                .clone()
-                .and_then(|b| b.try_into().ok())
-                .map(|arr: [u8; 64]| Signature::from_bytes(&arr))
-            else {
-                report.conversion_error(
-                    &format!("C509 issuer signature at index {index}"),
-                    &format!("{:?}", c.issuer_signature_value()),
-                    "Expected 64-byte Ed25519 signature",
-                    context,
-                );
-                continue;
-            };
-
-            // TODO(bkioshn): signature verification should be improved in c509 crate
-            if pk.verify_strict(&c.tbs_cert().to_cbor(), &sig).is_err() {
-                report.other(
-                    &format!("Cannot verify C509 certificate signature at index {index}"),
-                    context,
-                );
-            }
+            validate_c509_self_signed_cert(c, index, report, context);
         }
     }
 
     for (index, cert) in metadata.x509_certs.iter().enumerate() {
         if let X509DerCert::X509Cert(c) = cert {
-            let pk = match x509_key(c) {
-                Ok(pk) => pk,
-                Err(e) => {
-                    report.other(
-                        &format!(
-                            "Failed to extract subject public key from X509 certificate at index {index}: {e:?}",
-                        ),
-                        context,
-                    );
-                    continue;
-                },
-            };
-
-            let Some(sig) = c
-                .signature
-                .as_bytes()
-                .and_then(|b| b.try_into().ok())
-                .map(|arr: [u8; 64]| Signature::from_bytes(&arr))
-            else {
-                report.conversion_error(
-                    &format!("X509 signature at index {index}"),
-                    &format!("{:?}", c.signature.as_bytes()),
-                    "Expected 64-byte Ed25519 signature",
-                    context,
-                );
-                continue;
-            };
-
-            let tbs_der = match c.tbs_certificate.to_der() {
-                Ok(tbs_der) => tbs_der,
-                Err(e) => {
-                    report.invalid_encoding(
-                        &format!("X509 tbs certificate at index {index}"),
-                        "DER encoding",
-                        &format!("Expected DER encoded X509 certificate: {e:?}"),
-                        context,
-                    );
-                    continue;
-                },
-            };
-
-            if pk.verify_strict(&tbs_der, &sig).is_err() {
-                report.other(
-                    &format!("Cannot verify X509 certificate signature at index {index} "),
-                    context,
-                );
-            }
+            validate_x509_self_signed_cert(c, index, report, context);
         }
+    }
+}
+
+/// Validate C509 certificate that it is a self-signed.
+fn validate_c509_self_signed_cert(c: &C509, index: usize, report: &ProblemReport, context: &str) {
+    // Self-sign certificate must be type 2
+    if c.tbs_cert().c509_certificate_type() != 2 {
+        report.invalid_value(
+            &format!("C509 certificate type at index {index}"),
+            &c.tbs_cert().c509_certificate_type().to_string(),
+            "Certificate must have cert type 2",
+            context,
+        );
+        return;
+    }
+
+    let pk = match c509_key(c) {
+        Ok(pk) => pk,
+        Err(e) => {
+            report.other(
+                &format!(
+                    "Failed to extract subject public key from C509 certificate at index {index}: {e:?}",
+                    
+                ),
+                context,
+            );
+            return;
+        },
+    };
+
+    let Some(sig) = c
+        .issuer_signature_value()
+        .clone()
+        .and_then(|b| b.try_into().ok())
+        .map(|arr: [u8; 64]| Signature::from_bytes(&arr))
+    else {
+        report.conversion_error(
+            &format!("C509 issuer signature at index {index}"),
+            &format!("{:?}", c.issuer_signature_value()),
+            "Expected 64-byte Ed25519 signature",
+            context,
+        );
+        return;
+    };
+
+    // TODO(bkioshn): signature verification should be improved in c509 crate
+    let Ok(tbs_cbor) = c.tbs_cert().to_cbor::<Vec<u8>>() else {
+        report.invalid_encoding(
+            &format!("C509 TBS certificate at index {index}"),
+            "CBOR encoding",
+            "Expected CBOR encoded TBS certificate",
+            context,
+        );
+        return;
+    };
+    if pk.verify_strict(&tbs_cbor, &sig).is_err() {
+        report.other(
+            &format!("Cannot verify C509 certificate signature at index {index}",),
+            context,
+        );
+    }
+}
+
+/// Validate X509 certificate that it is a self-signed.
+fn validate_x509_self_signed_cert(c: &X509, index: usize, report: &ProblemReport, context: &str) {
+    let pk = match x509_key(c) {
+        Ok(pk) => pk,
+        Err(e) => {
+            report.other(
+                &format!(
+                    "Failed to extract subject public key from X509 certificate at index {index}: {e:?}",
+                ),
+                context,
+            );
+            return;
+        },
+    };
+
+    let Some(sig) = c
+        .signature
+        .as_bytes()
+        .and_then(|b| b.try_into().ok())
+        .map(|arr: [u8; 64]| Signature::from_bytes(&arr))
+    else {
+        report.conversion_error(
+            &format!("X509 signature at index {index}"),
+            &format!("{:?}", c.signature.as_bytes()),
+            "Expected 64-byte Ed25519 signature",
+            context,
+        );
+        return;
+    };
+
+    let tbs_der = match c.tbs_certificate.to_der() {
+        Ok(tbs_der) => tbs_der,
+        Err(e) => {
+            report.invalid_encoding(
+                &format!("X509 tbs certificate at index {index}"),
+                "DER encoding",
+                &format!("Expected DER encoded X509 certificate: {e:?}"),
+                context,
+            );
+            return;
+        },
+    };
+
+    if pk.verify_strict(&tbs_der, &sig).is_err() {
+        report.other(
+            &format!("Cannot verify X509 certificate signature at index {index} "),
+            context,
+        );
     }
 }
 
@@ -455,9 +475,7 @@ fn validate_role_0(
 }
 
 /// Extracts `VerifyingKey` from the given `X509` certificate.
-fn x509_cert_key(
-    cert: &Certificate, context: &str, report: &ProblemReport,
-) -> Option<VerifyingKey> {
+fn x509_cert_key(cert: &X509, context: &str, report: &ProblemReport) -> Option<VerifyingKey> {
     let Some(extended_public_key) = cert
         .tbs_certificate
         .subject_public_key_info


### PR DESCRIPTION
# Description

Add validation for all certificate in RBAC registration should be self-signed (currently only support self-signed)

Note that for self-signed -  issuer == subject, so we can retrieve the subject public key to verify the signature

## Related Issue(s)

> Closes https://github.com/input-output-hk/catalyst-voices/issues/2219

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
