### PR TITLE
fix(rust/cardano-chain-follower): `webpki-roots` crate release breaking change 

### DIFF
--- a/rust/cardano-chain-follower/Cargo.toml
+++ b/rust/cardano-chain-follower/Cargo.toml
@@ -58,6 +58,14 @@ hickory-resolver = { version = "0.24.2", features = ["dns-over-rustls"] }
 moka = { version = "0.12.9", features = ["sync"] }
 cpu-time = "1.0.0"
 
+# Its a transitive dependency of the "ureq" crate,
+# but its breaks API after version "0.26.8".
+webpki-roots = { version = "=0.26.8" }
+
+[package.metadata.cargo-machete]
+# remove that after fixing issues with latest crates
+ignored = ["webpki-roots"]
+
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 test-log = { version = "0.2.16", default-features = false, features = [


### PR DESCRIPTION
# Description

[`webpki-roots@0.26.9`](https://crates.io/crates/webpki-roots/versions) new version has a breaking change with changed licencing. Stick to the previously used version