### PR TITLE
feat(rust): Revert locking `webpki-roots`, update `cat-ci`

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,7 +1,7 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/mdlint:feat/cdla-permissive-2.0 AS mdlint-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cspell:feat/cdla-permissive-2.0 AS cspell-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/mdlint:v3.4.0 AS mdlint-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cspell:v3.4.0 AS cspell-ci
 
 
 FROM debian:stable-slim

--- a/Earthfile
+++ b/Earthfile
@@ -1,7 +1,7 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/mdlint:v3.3.0 AS mdlint-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cspell:v3.3.0 AS cspell-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/mdlint:feat/cdla-permissive-2.0 AS mdlint-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cspell:feat/cdla-permissive-2.0 AS cspell-ci
 
 
 FROM debian:stable-slim

--- a/docs/Earthfile
+++ b/docs/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:feat/cdla-permissive-2.0 AS docs-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.4.0 AS docs-ci
 
 
 IMPORT .. AS repo

--- a/docs/Earthfile
+++ b/docs/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.3.0 AS docs-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:feat/cdla-permissive-2.0 AS docs-ci
 
 
 IMPORT .. AS repo

--- a/docs/src/architecture/08_concepts/catalyst_voting/cddl/Earthfile
+++ b/docs/src/architecture/08_concepts/catalyst_voting/cddl/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:feat/cdla-permissive-2.0 AS cddl-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:v3.4.0 AS cddl-ci
 
 check-cddl:
     FROM cddl-ci+cddl-base

--- a/docs/src/architecture/08_concepts/catalyst_voting/cddl/Earthfile
+++ b/docs/src/architecture/08_concepts/catalyst_voting/cddl/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:v3.3.0 AS cddl-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:feat/cdla-permissive-2.0 AS cddl-ci
 
 check-cddl:
     FROM cddl-ci+cddl-base

--- a/docs/src/architecture/08_concepts/immutable_ledger/cddl/Earthfile
+++ b/docs/src/architecture/08_concepts/immutable_ledger/cddl/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:feat/cdla-permissive-2.0 AS cddl-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:v3.4.0 AS cddl-ci
 
 check-cddl:
     FROM cddl-ci+cddl-base

--- a/docs/src/architecture/08_concepts/immutable_ledger/cddl/Earthfile
+++ b/docs/src/architecture/08_concepts/immutable_ledger/cddl/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:v3.3.0 AS cddl-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:feat/cdla-permissive-2.0 AS cddl-ci
 
 check-cddl:
     FROM cddl-ci+cddl-base

--- a/docs/src/architecture/08_concepts/signed_doc/cddl/Earthfile
+++ b/docs/src/architecture/08_concepts/signed_doc/cddl/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:feat/cdla-permissive-2.0 AS cddl-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:v3.4.0 AS cddl-ci
 
 check-cddl:
     FROM cddl-ci+cddl-base

--- a/docs/src/architecture/08_concepts/signed_doc/cddl/Earthfile
+++ b/docs/src/architecture/08_concepts/signed_doc/cddl/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:v3.3.0 AS cddl-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:feat/cdla-permissive-2.0 AS cddl-ci
 
 check-cddl:
     FROM cddl-ci+cddl-base

--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:feat/cdla-permissive-2.0 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.4.0 AS rust-ci
 
 COPY_SRC:
     FUNCTION

--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.3.0 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:feat/cdla-permissive-2.0 AS rust-ci
 
 COPY_SRC:
     FUNCTION

--- a/rust/c509-certificate/Earthfile
+++ b/rust/c509-certificate/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust::feat/cdla-permissive-2.0 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust::v3.4.0 AS rust-ci
 
 
 IMPORT .. AS rust-local

--- a/rust/c509-certificate/Earthfile
+++ b/rust/c509-certificate/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust::v3.3.0 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust::feat/cdla-permissive-2.0 AS rust-ci
 
 
 IMPORT .. AS rust-local

--- a/rust/cardano-chain-follower/Cargo.toml
+++ b/rust/cardano-chain-follower/Cargo.toml
@@ -58,14 +58,6 @@ hickory-resolver = { version = "0.24.2", features = ["dns-over-rustls"] }
 moka = { version = "0.12.9", features = ["sync"] }
 cpu-time = "1.0.0"
 
-# Its a transitive dependency of the "ureq" crate,
-# but its breaks API after version "0.26.8".
-webpki-roots = { version = "=0.26.8" }
-
-[package.metadata.cargo-machete]
-# remove that after fixing issues with latest crates
-ignored = ["webpki-roots"]
-
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 test-log = { version = "0.2.16", default-features = false, features = [

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -80,6 +80,7 @@ allow = [
     "MPL-2.0",
     "Zlib",
     "MIT-0",
+    "CDLA-Permissive-2.0",
 ]
 exceptions = [
     #{ allow = ["Zlib"], crate = "tinyvec" },

--- a/specs/Earthfile
+++ b/specs/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/python:v3.3.0 AS python-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/python:feat/cdla-permissive-2.0 AS python-ci
 
 IMPORT ../docs AS docs
 

--- a/specs/Earthfile
+++ b/specs/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/python:feat/cdla-permissive-2.0 AS python-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/python:v3.4.0 AS python-ci
 
 IMPORT ../docs AS docs
 

--- a/utilities/docs-preview/Earthfile
+++ b/utilities/docs-preview/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.3.0 AS docs-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:feat/cdla-permissive-2.0 AS docs-ci
 
 
 # update-docs-dev-script: get the latest docs dev script from CI.

--- a/utilities/docs-preview/Earthfile
+++ b/utilities/docs-preview/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:feat/cdla-permissive-2.0 AS docs-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.4.0 AS docs-ci
 
 
 # update-docs-dev-script: get the latest docs dev script from CI.


### PR DESCRIPTION
# Description

- Revert locking `webpki-roots`
- updated `cat-ci` with the new `deny.toml` file, allowing new license