### PR TITLE
fix(rust/cardano-chain-follower): Fix `cardano-chain-follower` build

### DIFF
--- a/rust/cardano-chain-follower/Cargo.toml
+++ b/rust/cardano-chain-follower/Cargo.toml
@@ -58,6 +58,14 @@ hickory-resolver = { version = "0.24.2", features = ["dns-over-rustls"] }
 moka = { version = "0.12.9", features = ["sync"] }
 cpu-time = "1.0.0"
 
+# Its a transitive dependency of the "mithril-client" crate,
+# but its breaks API after version "0.2.21".
+mithril-build-script = { version = "=0.2.19" }
+
+[package.metadata.cargo-machete]
+# remove that after fixing issues with latest crates
+ignored = ["mithril-build-script"]
+
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 test-log = { version = "0.2.16", default-features = false, features = [


### PR DESCRIPTION
# Description

New release of `mithril-build-script` crate (0.2.21) https://crates.io/crates/mithril-build-script/versions breaks our build. 

```
error[E0308]: mismatched types
  --> /home/dev/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/mithril-common-0.4.96/build.rs:10:62
   |
10 |     let open_api_code = generate_open_api_versions_mapping(&[Path::new("./"), (Path::new("../"))]);
   |                                                              ^^^^^^^^^^^^^^^- help: try using a conversion method: `.to_path_buf()`
   |                                                              |
   |                                                              expected `PathBuf`, found `&Path`
```