### PR TITLE
fix(rust/signed-doc): Catalyst Signed Document missing signature check

### DIFF
--- a/rust/signed_doc/src/validator/mod.rs
+++ b/rust/signed_doc/src/validator/mod.rs
@@ -322,7 +322,7 @@ where
         );
         return Ok(false);
     };
-    
+
     let tbs_data = cose_sign.tbs_data(&[], signature);
     let Ok(signature_bytes) = signature.signature.as_slice().try_into() else {
         report.invalid_value(

--- a/rust/signed_doc/src/validator/mod.rs
+++ b/rust/signed_doc/src/validator/mod.rs
@@ -282,6 +282,14 @@ pub async fn validate_signatures(
         return Ok(false);
     };
 
+    if doc.signatures().is_empty() {
+        doc.report().other(
+            "Catalyst Signed Document is unsigned",
+            "During Catalyst Signed Document signature validation",
+        );
+        return Ok(false);
+    }
+
     let sign_rules = doc
         .signatures()
         .cose_signatures_with_kids()
@@ -314,7 +322,7 @@ where
         );
         return Ok(false);
     };
-
+    
     let tbs_data = cose_sign.tbs_data(&[], signature);
     let Ok(signature_bytes) = signature.signature.as_slice().try_into() else {
         report.invalid_value(

--- a/rust/signed_doc/tests/signature.rs
+++ b/rust/signed_doc/tests/signature.rs
@@ -23,14 +23,20 @@ async fn single_signature_validation_test() {
     provider.add_pk(kid.clone(), pk);
     assert!(validator::validate_signatures(&signed_doc, &provider)
         .await
-        .is_ok_and(|v| v));
+        .unwrap());
 
     // case: empty provider
     assert!(
-        validator::validate_signatures(&signed_doc, &TestVerifyingKeyProvider::default())
+        !validator::validate_signatures(&signed_doc, &TestVerifyingKeyProvider::default())
             .await
-            .is_ok_and(|v| !v)
+            .unwrap()
     );
+
+    // case: missing signatures
+    let (unsigned_doc, ..) = common::create_dummy_doc(UuidV4::new().into()).unwrap();
+    assert!(!validator::validate_signatures(&unsigned_doc, &provider)
+        .await
+        .unwrap());
 }
 
 #[tokio::test]


### PR DESCRIPTION
# Description

- Added a check under the  `validate_signatures` of the `CatalystSignedDocument`. Verifying that the doc has at least one signature