### PR TITLE
feat(rust/signed_doc): check protected metadata field support

### DIFF
--- a/rust/signed_doc/src/metadata/extra_fields.rs
+++ b/rust/signed_doc/src/metadata/extra_fields.rs
@@ -117,6 +117,25 @@ impl ExtraFields {
         self.category_id
     }
 
+    /// Returns count of non empty fields. These fields reflect what the
+    /// serialized/deserialized object would look like, as the empty ones are skipped.
+    #[must_use]
+    pub(super) fn count_serialized_fields(&self) -> u8 {
+        [
+            self.doc_ref().is_some(),
+            self.template().is_some(),
+            self.reply().is_some(),
+            self.section().is_some(),
+            !self.collabs().is_empty(),
+            self.brand_id().is_some(),
+            self.election_id().is_some(),
+            self.category_id().is_some(),
+        ]
+        .into_iter()
+        .map(u8::from)
+        .sum()
+    }
+
     /// Fill the COSE header `ExtraFields` data into the header builder.
     pub(super) fn fill_cose_header_fields(
         &self, mut builder: coset::HeaderBuilder,


### PR DESCRIPTION
# Description

Implements reporting of unsupported fields found in a protected header. Fields are deemed unsupported if *existing* logic discarded them by not deserialising into corresponding `Metadata` fields (if any). 

I find mismatch between the number of protected fields and the number of fields that end up in `Metadata`. To this end there's new counting functions.

I prefer this approach over validating each key individually against a list of supported keys, because the later doesn't by itself solve duplication potential and the later is always more intense computationally.

## Related Issue(s)

Closes #316

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
