### PR TITLE
fix(rust/signed-doc): Preserve original `raw_bytes`

### DIFF
--- a/rust/signed_doc/src/builder.rs
+++ b/rust/signed_doc/src/builder.rs
@@ -26,6 +26,7 @@ impl Builder {
             metadata: Metadata::default(),
             content: Content::default(),
             signatures: Signatures::default(),
+            raw_bytes: None,
         })
     }
 
@@ -91,6 +92,7 @@ impl From<&CatalystSignedDocument> for Builder {
             content: value.inner.content.clone(),
             signatures: value.inner.signatures.clone(),
             report: value.inner.report.clone(),
+            raw_bytes: None,
         })
     }
 }

--- a/rust/signed_doc/src/lib.rs
+++ b/rust/signed_doc/src/lib.rs
@@ -43,7 +43,7 @@ struct InnerCatalystSignedDocument {
     report: ProblemReport,
 
     /// raw CBOR bytes of the `CatalystSignedDocument` object.
-    /// It is improtant to keep them to have a consistency what comes from the decoding
+    /// It is important to keep them to have a consistency what comes from the decoding
     /// process, so we would return the same data again
     raw_bytes: Option<Vec<u8>>,
 }

--- a/rust/signed_doc/tests/decoding.rs
+++ b/rust/signed_doc/tests/decoding.rs
@@ -57,6 +57,7 @@ fn catalyst_signed_doc_cbor_roundtrip_kid_as_id_test() {
 }
 
 #[tokio::test]
+#[allow(clippy::too_many_lines)]
 async fn catalyst_signed_doc_parameters_aliases_test() {
     let (_, _, metadata_fields) = common::test_metadata();
     let (sk, pk, kid) = common::create_dummy_key_pair(RoleId::Role0).unwrap();

--- a/rust/signed_doc/tests/decoding.rs
+++ b/rust/signed_doc/tests/decoding.rs
@@ -1,6 +1,6 @@
 //! Integration test for COSE decoding part.
 
-use catalyst_signed_doc::*;
+use catalyst_signed_doc::{providers::tests::TestVerifyingKeyProvider, *};
 use catalyst_types::catalyst_id::role_index::RoleId;
 use common::create_dummy_key_pair;
 use coset::TaggedCborSerializable;
@@ -56,9 +56,12 @@ fn catalyst_signed_doc_cbor_roundtrip_kid_as_id_test() {
     assert!(doc.problem_report().is_problematic());
 }
 
-#[test]
-fn catalyst_signed_doc_parameters_aliases_test() {
+#[tokio::test]
+async fn catalyst_signed_doc_parameters_aliases_test() {
     let (_, _, metadata_fields) = common::test_metadata();
+    let (sk, pk, kid) = common::create_dummy_key_pair(RoleId::Role0).unwrap();
+    let mut provider = TestVerifyingKeyProvider::default();
+    provider.add_pk(kid.clone(), pk);
 
     let content = serde_json::to_vec(&serde_json::Value::Null).unwrap();
 
@@ -99,35 +102,56 @@ fn catalyst_signed_doc_parameters_aliases_test() {
 
     let cbor_bytes = cose_with_category_id.to_tagged_vec().unwrap();
     let doc: CatalystSignedDocument = cbor_bytes.as_slice().try_into().unwrap();
+    let doc = doc
+        .into_builder()
+        .add_signature(|m| sk.sign(&m).to_vec(), &kid)
+        .unwrap()
+        .build();
     assert!(!doc.problem_report().is_problematic());
     assert!(doc.doc_meta().parameters().is_some());
-    assert_eq!(cbor_bytes, Vec::try_from(doc).unwrap().as_slice());
+    assert!(validator::validate_signatures(&doc, &provider)
+        .await
+        .unwrap());
 
     // case: `brand_id`.
-    let mut cose_with_category_id = cose.clone();
-    cose_with_category_id.protected.header.rest.push((
+    let mut cose_with_brand_id = cose.clone();
+    cose_with_brand_id.protected.header.rest.push((
         coset::Label::Text("brand_id".to_string()),
         parameters_val_cbor.clone(),
     ));
 
-    let cbor_bytes = cose_with_category_id.to_tagged_vec().unwrap();
+    let cbor_bytes = cose_with_brand_id.to_tagged_vec().unwrap();
     let doc: CatalystSignedDocument = cbor_bytes.as_slice().try_into().unwrap();
+    let doc = doc
+        .into_builder()
+        .add_signature(|m| sk.sign(&m).to_vec(), &kid)
+        .unwrap()
+        .build();
     assert!(!doc.problem_report().is_problematic());
     assert!(doc.doc_meta().parameters().is_some());
-    assert_eq!(cbor_bytes, Vec::try_from(doc).unwrap().as_slice());
+    assert!(validator::validate_signatures(&doc, &provider)
+        .await
+        .unwrap());
 
     // case: `campaign_id`.
-    let mut cose_with_category_id = cose.clone();
-    cose_with_category_id.protected.header.rest.push((
+    let mut cose_with_campaign_id = cose.clone();
+    cose_with_campaign_id.protected.header.rest.push((
         coset::Label::Text("campaign_id".to_string()),
         parameters_val_cbor.clone(),
     ));
 
-    let cbor_bytes = cose_with_category_id.to_tagged_vec().unwrap();
+    let cbor_bytes = cose_with_campaign_id.to_tagged_vec().unwrap();
     let doc: CatalystSignedDocument = cbor_bytes.as_slice().try_into().unwrap();
+    let doc = doc
+        .into_builder()
+        .add_signature(|m| sk.sign(&m).to_vec(), &kid)
+        .unwrap()
+        .build();
     assert!(!doc.problem_report().is_problematic());
     assert!(doc.doc_meta().parameters().is_some());
-    assert_eq!(cbor_bytes, Vec::try_from(doc).unwrap().as_slice());
+    assert!(validator::validate_signatures(&doc, &provider)
+        .await
+        .unwrap());
 
     // `parameters` value along with its aliases are not allowed to be present at the
     let mut cose_with_category_id = cose.clone();

--- a/rust/signed_doc/tests/decoding.rs
+++ b/rust/signed_doc/tests/decoding.rs
@@ -97,14 +97,11 @@ fn catalyst_signed_doc_parameters_aliases_test() {
         parameters_val_cbor.clone(),
     ));
 
-    let doc: CatalystSignedDocument = cose_with_category_id
-        .to_tagged_vec()
-        .unwrap()
-        .as_slice()
-        .try_into()
-        .unwrap();
+    let cbor_bytes = cose_with_category_id.to_tagged_vec().unwrap();
+    let doc: CatalystSignedDocument = cbor_bytes.as_slice().try_into().unwrap();
     assert!(!doc.problem_report().is_problematic());
     assert!(doc.doc_meta().parameters().is_some());
+    assert_eq!(cbor_bytes, Vec::try_from(doc).unwrap().as_slice());
 
     // case: `brand_id`.
     let mut cose_with_category_id = cose.clone();
@@ -113,14 +110,11 @@ fn catalyst_signed_doc_parameters_aliases_test() {
         parameters_val_cbor.clone(),
     ));
 
-    let doc: CatalystSignedDocument = cose_with_category_id
-        .to_tagged_vec()
-        .unwrap()
-        .as_slice()
-        .try_into()
-        .unwrap();
+    let cbor_bytes = cose_with_category_id.to_tagged_vec().unwrap();
+    let doc: CatalystSignedDocument = cbor_bytes.as_slice().try_into().unwrap();
     assert!(!doc.problem_report().is_problematic());
     assert!(doc.doc_meta().parameters().is_some());
+    assert_eq!(cbor_bytes, Vec::try_from(doc).unwrap().as_slice());
 
     // case: `campaign_id`.
     let mut cose_with_category_id = cose.clone();
@@ -129,14 +123,11 @@ fn catalyst_signed_doc_parameters_aliases_test() {
         parameters_val_cbor.clone(),
     ));
 
-    let doc: CatalystSignedDocument = cose_with_category_id
-        .to_tagged_vec()
-        .unwrap()
-        .as_slice()
-        .try_into()
-        .unwrap();
+    let cbor_bytes = cose_with_category_id.to_tagged_vec().unwrap();
+    let doc: CatalystSignedDocument = cbor_bytes.as_slice().try_into().unwrap();
     assert!(!doc.problem_report().is_problematic());
     assert!(doc.doc_meta().parameters().is_some());
+    assert_eq!(cbor_bytes, Vec::try_from(doc).unwrap().as_slice());
 
     // `parameters` value along with its aliases are not allowed to be present at the
     let mut cose_with_category_id = cose.clone();


### PR DESCRIPTION
# Description

Fixed a new`parameters` field backwards compatibility.
If `category_id`, `campaign_id` or `brand_id` was passed (as an alias of `parameters`) encoding implementation was not symetric with decoding impl (we were lossing original representation).

## Related Issue(s)

Closes #344 