### PR TITLE
fix(rust/signed-doc): Correct CBOR content type and data validation

### DIFF
--- a/rust/signed_doc/Cargo.toml
+++ b/rust/signed_doc/Cargo.toml
@@ -31,6 +31,7 @@ ed25519-bip32 = "0.4.1" # used by the `mk_signed_doc` cli tool
 
 [dev-dependencies]
 base64-url = "3.0.0"
+proptest = "1.5.0"
 rand = "0.8.5"
 uuid = { version = "1.12.0", features = ["v7"] }
 tokio = { version = "1.42.0", features = [ "macros" ] }

--- a/rust/signed_doc/Cargo.toml
+++ b/rust/signed_doc/Cargo.toml
@@ -31,7 +31,6 @@ ed25519-bip32 = "0.4.1" # used by the `mk_signed_doc` cli tool
 
 [dev-dependencies]
 base64-url = "3.0.0"
-proptest = "1.5.0"
 rand = "0.8.5"
 uuid = { version = "1.12.0", features = ["v7"] }
 tokio = { version = "1.42.0", features = [ "macros" ] }

--- a/rust/signed_doc/Cargo.toml
+++ b/rust/signed_doc/Cargo.toml
@@ -15,7 +15,7 @@ catalyst-types = { version = "0.0.3", path = "../catalyst-types" }
 
 anyhow = "1.0.95"
 serde = { version = "1.0.217", features = ["derive"] }
-serde_json = "1.0.134"
+serde_json = { version = "1.0.134", features = ["raw_value"] }
 coset = "0.3.8"
 minicbor = { version = "0.25.1", features = ["half"] }
 brotli = "7.0.0"

--- a/rust/signed_doc/src/metadata/content_type.rs
+++ b/rust/signed_doc/src/metadata/content_type.rs
@@ -18,25 +18,6 @@ pub enum ContentType {
     Json,
 }
 
-impl ContentType {
-    /// Validates the provided `content` bytes to be a defined `ContentType`.
-    pub(crate) fn validate(self, content: &[u8]) -> anyhow::Result<()> {
-        match self {
-            Self::Json => {
-                if let Err(e) = serde_json::from_slice::<serde_json::Value>(content) {
-                    anyhow::bail!("Invalid {self} content: {e}")
-                }
-            },
-            Self::Cbor => {
-                if let Err(e) = minicbor::decode::<minicbor::data::Token>(content) {
-                    anyhow::bail!("Invalid {self} content: {e}")
-                }
-            },
-        }
-        Ok(())
-    }
-}
-
 impl Display for ContentType {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self {
@@ -107,17 +88,6 @@ impl TryFrom<&coset::ContentType> for ContentType {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn content_type_validate_test() {
-        let json_bytes = serde_json::to_vec(&serde_json::Value::Null).unwrap();
-        assert!(ContentType::Json.validate(&json_bytes).is_ok());
-        assert!(ContentType::Cbor.validate(&json_bytes).is_err());
-
-        let cbor_bytes = minicbor::to_vec(minicbor::data::Token::Null).unwrap();
-        assert!(ContentType::Json.validate(&cbor_bytes).is_err());
-        assert!(ContentType::Cbor.validate(&cbor_bytes).is_ok());
-    }
 
     #[test]
     fn content_type_string_test() {

--- a/rust/signed_doc/src/validator/rules/content_type.rs
+++ b/rust/signed_doc/src/validator/rules/content_type.rs
@@ -53,7 +53,7 @@ impl ContentTypeRule {
     fn validate(&self, content: &[u8]) -> anyhow::Result<()> {
         match self.exp {
             ContentType::Json => {
-                if let Err(e) = serde_json::from_slice::<serde_json::Value>(content) {
+                if let Err(e) = serde_json::from_slice::<&serde_json::value::RawValue>(content) {
                     anyhow::bail!("Invalid {} content: {e}", self.exp)
                 }
             },

--- a/rust/signed_doc/src/validator/rules/content_type.rs
+++ b/rust/signed_doc/src/validator/rules/content_type.rs
@@ -136,6 +136,21 @@ mod tests {
             .with_decoded_content(minicbor::to_vec(minicbor::data::Token::Null).unwrap())
             .build();
         assert!(matches!(cbor_rule.check(&doc).await, Ok(true)));
+
+        // without content
+        let doc = Builder::new()
+            .with_json_metadata(serde_json::json!({"content-type": cbor_rule.exp.to_string() }))
+            .unwrap()
+            .build();
+        assert!(matches!(cbor_rule.check(&doc).await, Ok(false)));
+
+        // with empty content
+        let doc = Builder::new()
+            .with_json_metadata(serde_json::json!({"content-type": cbor_rule.exp.to_string() }))
+            .unwrap()
+            .with_decoded_content(vec![])
+            .build();
+        assert!(matches!(cbor_rule.check(&doc).await, Ok(false)));
     }
 
     #[tokio::test]
@@ -151,6 +166,14 @@ mod tests {
             .with_decoded_content(serde_json::to_vec(&serde_json::json!({})).unwrap())
             .build();
         assert!(matches!(json_rule.check(&doc).await, Ok(true)));
+
+        // with cbor bytes
+        let doc = Builder::new()
+            .with_json_metadata(serde_json::json!({"content-type": json_rule.exp.to_string() }))
+            .unwrap()
+            .with_decoded_content(minicbor::to_vec(minicbor::data::Token::Null).unwrap())
+            .build();
+        assert!(matches!(json_rule.check(&doc).await, Ok(false)));
 
         // without content
         let doc = Builder::new()

--- a/rust/signed_doc/src/validator/rules/content_type.rs
+++ b/rust/signed_doc/src/validator/rules/content_type.rs
@@ -50,7 +50,7 @@ impl ContentTypeRule {
     }
 
     /// Validates the provided `content` bytes to be a defined `ContentType`.
-    pub(crate) fn validate(&self, content: &[u8]) -> anyhow::Result<()> {
+    fn validate(&self, content: &[u8]) -> anyhow::Result<()> {
         match self.exp {
             ContentType::Json => {
                 if let Err(e) = serde_json::from_slice::<serde_json::Value>(content) {

--- a/rust/signed_doc/src/validator/rules/content_type.rs
+++ b/rust/signed_doc/src/validator/rules/content_type.rs
@@ -94,6 +94,32 @@ mod tests {
         assert!(cbor_rule.validate(&cbor_bytes).is_ok());
     }
 
+    #[test]
+    fn cbor_with_trailing_bytes_fails_test() {
+        // Valid CBOR: {1: 2} but with trailing 0xff
+        let mut buf = Vec::new();
+        let mut enc = minicbor::Encoder::new(&mut buf);
+        enc.map(1).unwrap().u8(1).unwrap().u8(2).unwrap();
+        buf.push(0xFF); // extra byte
+
+        let cbor_rule = ContentTypeRule {
+            exp: ContentType::Cbor,
+        };
+
+        assert!(cbor_rule.validate(&buf).is_err());
+    }
+
+    #[test]
+    fn invalid_cbor_fails_test() {
+        let invalid_bytes = &[0x1F, 0x00, 0x00];
+
+        let cbor_rule = ContentTypeRule {
+            exp: ContentType::Cbor,
+        };
+
+        assert!(cbor_rule.validate(invalid_bytes).is_err());
+    }
+
     #[tokio::test]
     async fn content_type_rule_test() {
         let content_type = ContentType::Json;

--- a/rust/signed_doc/src/validator/rules/content_type.rs
+++ b/rust/signed_doc/src/validator/rules/content_type.rs
@@ -98,7 +98,7 @@ mod tests {
 
     #[test]
     fn cbor_with_trailing_bytes_test() {
-        // Valid CBOR: {1: 2} but with trailing 0xff
+        // valid cbor: {1: 2} but with trailing 0xff
         let mut buf = Vec::new();
         let mut enc = minicbor::Encoder::new(&mut buf);
         enc.map(1).unwrap().u8(1).unwrap().u8(2).unwrap();

--- a/rust/signed_doc/src/validator/rules/content_type.rs
+++ b/rust/signed_doc/src/validator/rules/content_type.rs
@@ -73,26 +73,26 @@ impl ContentTypeRule {
 
 #[cfg(test)]
 mod tests {
-    use proptest::prelude::*;
-
     use super::*;
     use crate::Builder;
 
     #[test]
-    fn content_type_validate_test() {
+    fn content_type_json_validate_test() {
         let json_rule = ContentTypeRule {
             exp: ContentType::Json,
         };
+
+        let json_bytes = serde_json::to_vec(&serde_json::Value::Null).unwrap();
+        assert!(json_rule.validate(&json_bytes).is_err());
+    }
+
+    #[test]
+    fn content_type_cbor_validate_test() {
         let cbor_rule = ContentTypeRule {
             exp: ContentType::Cbor,
         };
 
-        let json_bytes = serde_json::to_vec(&serde_json::Value::Null).unwrap();
-        assert!(json_rule.validate(&json_bytes).is_ok());
-        assert!(cbor_rule.validate(&json_bytes).is_err());
-
         let cbor_bytes = minicbor::to_vec(minicbor::data::Token::Null).unwrap();
-        assert!(json_rule.validate(&cbor_bytes).is_err());
         assert!(cbor_rule.validate(&cbor_bytes).is_ok());
     }
 
@@ -121,18 +121,6 @@ mod tests {
         };
 
         assert!(cbor_rule.validate(invalid_bytes).is_err());
-    }
-
-    proptest! {
-        #[test]
-        fn invalid_cbor_from_random_data_test(ref data in proptest::collection::vec(any::<u8>(), 1..100)) {
-            let cbor_rule = ContentTypeRule {
-                exp: ContentType::Cbor,
-            };
-
-            // allow any result; we just want to ensure no panic
-            drop(cbor_rule.validate(data));
-        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
# Description

- Fixed CBOR validation using `.skip()`
- Moved the validation method and the test from `metadata/content_type.rs` to `validator/rules/content_type.rs`

## Related Issue(s)

Closes #348

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
