### PR TITLE
feat(rust/signed-doc): New implementation of `DocType`

### DIFF
--- a/rust/catalyst-types/src/uuid/mod.rs
+++ b/rust/catalyst-types/src/uuid/mod.rs
@@ -15,8 +15,7 @@ use minicbor::data::Tag;
 pub const INVALID_UUID: uuid::Uuid = uuid::Uuid::from_bytes([0x00; 16]);
 
 /// UUID CBOR tag <https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml/>.
-#[allow(dead_code)]
-const UUID_CBOR_TAG: u64 = 37;
+pub const UUID_CBOR_TAG: u64 = 37;
 
 /// Uuid validation errors, which could occur during decoding or converting to
 /// `UuidV4` or `UuidV7` types.
@@ -29,6 +28,9 @@ pub enum UuidError {
     /// `UUIDv7` invalid error
     #[error("'{0}' is not a valid UUIDv7")]
     InvalidUuidV7(uuid::Uuid),
+    /// Invalid string conversion
+    #[error("Invalid string conversion: {0}")]
+    StringConversion(String),
 }
 
 /// Context for `CBOR` encoding and decoding

--- a/rust/catalyst-types/src/uuid/uuid_v4.rs
+++ b/rust/catalyst-types/src/uuid/uuid_v4.rs
@@ -1,5 +1,8 @@
 //! `UUIDv4` Type.
-use std::fmt::{Display, Formatter};
+use std::{
+    fmt::{Display, Formatter},
+    str::FromStr,
+};
 
 use minicbor::{Decode, Decoder, Encode};
 use uuid::Uuid;
@@ -7,7 +10,7 @@ use uuid::Uuid;
 use super::{decode_cbor_uuid, encode_cbor_uuid, CborContext, UuidError, INVALID_UUID};
 
 /// Type representing a `UUIDv4`.
-#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, serde::Serialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, serde::Serialize)]
 pub struct UuidV4(Uuid);
 
 impl UuidV4 {
@@ -103,6 +106,15 @@ impl<'de> serde::Deserialize<'de> for UuidV4 {
         } else {
             Err(serde::de::Error::custom(UuidError::InvalidUuidV4(uuid)))
         }
+    }
+}
+
+impl FromStr for UuidV4 {
+    type Err = UuidError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let uuid = Uuid::parse_str(s).map_err(|_| UuidError::StringConversion(s.to_string()))?;
+        UuidV4::try_from(uuid).map_err(|_| UuidError::InvalidUuidV4(uuid))
     }
 }
 

--- a/rust/catalyst-types/src/uuid/uuid_v7.rs
+++ b/rust/catalyst-types/src/uuid/uuid_v7.rs
@@ -1,5 +1,8 @@
 //! `UUIDv7` Type.
-use std::fmt::{Display, Formatter};
+use std::{
+    fmt::{Display, Formatter},
+    str::FromStr,
+};
 
 use minicbor::{Decode, Decoder, Encode};
 use uuid::Uuid;
@@ -103,6 +106,15 @@ impl<'de> serde::Deserialize<'de> for UuidV7 {
         } else {
             Err(serde::de::Error::custom(UuidError::InvalidUuidV7(uuid)))
         }
+    }
+}
+
+impl FromStr for UuidV7 {
+    type Err = UuidError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let uuid = Uuid::parse_str(s).map_err(|_| UuidError::StringConversion(s.to_string()))?;
+        UuidV7::try_from(uuid).map_err(|_| UuidError::InvalidUuidV7(uuid))
     }
 }
 

--- a/rust/signed_doc/Cargo.toml
+++ b/rust/signed_doc/Cargo.toml
@@ -27,7 +27,8 @@ jsonschema = "0.28.3"
 jsonpath-rust = "0.7.5"
 futures = "0.3.31"
 ed25519-bip32 = "0.4.1" # used by the `mk_signed_doc` cli tool
-
+tracing = "0.1.40"
+thiserror = "2.0.11"
 
 [dev-dependencies]
 base64-url = "3.0.0"

--- a/rust/signed_doc/src/decode_context.rs
+++ b/rust/signed_doc/src/decode_context.rs
@@ -1,0 +1,24 @@
+//! Context used to pass in decoder for additional information.
+
+use catalyst_types::problem_report::ProblemReport;
+
+/// Compatibility policy
+#[allow(dead_code)]
+pub(crate) enum CompatibilityPolicy {
+    /// Silently allow obsoleted type conversions or non deterministic encoding.
+    Accept,
+    /// Allow but log Warnings for all obsoleted type conversions or non deterministic
+    /// encoding.
+    Warn,
+    /// Fail and update problem report when an obsolete type is encountered or the data is
+    /// not deterministically encoded.
+    Fail,
+}
+
+/// A context use to pass to decoder.
+pub(crate) struct DecodeContext<'r> {
+    /// Compatibility policy.
+    pub compatibility_policy: CompatibilityPolicy,
+    /// Problem report.
+    pub report: &'r mut ProblemReport,
+}

--- a/rust/signed_doc/src/doc_types/mod.rs
+++ b/rust/signed_doc/src/doc_types/mod.rs
@@ -1,55 +1,108 @@
 //! An implementation of different defined document types
 //! <https://input-output-hk.github.io/catalyst-libs/architecture/08_concepts/signed_doc/types/>
 
-use catalyst_types::uuid::Uuid;
+use std::sync::LazyLock;
 
-/// Proposal document `UuidV4` type.
-pub const PROPOSAL_DOCUMENT_UUID_TYPE: Uuid =
-    Uuid::from_u128(0x7808_D2BA_D511_40AF_84E8_C0D1_625F_DFDC);
-/// Proposal template `UuidV4` type.
-pub const PROPOSAL_TEMPLATE_UUID_TYPE: Uuid =
-    Uuid::from_u128(0x0CE8_AB38_9258_4FBC_A62E_7FAA_6E58_318F);
-/// Comment document `UuidV4` type.
-pub const COMMENT_DOCUMENT_UUID_TYPE: Uuid =
-    Uuid::from_u128(0xB679_DED3_0E7C_41BA_89F8_DA62_A178_98EA);
-/// Comment template `UuidV4` type.
-pub const COMMENT_TEMPLATE_UUID_TYPE: Uuid =
-    Uuid::from_u128(0x0B84_24D4_EBFD_46E3_9577_1775_A69D_290C);
-/// Review document `UuidV4` type.
-pub const REVIEW_DOCUMENT_UUID_TYPE: Uuid =
-    Uuid::from_u128(0xE4CA_F5F0_098B_45FD_94F3_0702_A457_3DB5);
-/// Review template `UuidV4` type.
-pub const REVIEW_TEMPLATE_UUID_TYPE: Uuid =
-    Uuid::from_u128(0xEBE5_D0BF_5D86_4577_AF4D_008F_DDBE_2EDC);
-/// Category document `UuidV4` type.
-pub const CATEGORY_DOCUMENT_UUID_TYPE: Uuid =
-    Uuid::from_u128(0x48C2_0109_362A_4D32_9BBA_E0A9_CF8B_45BE);
-/// Category template `UuidV4` type.
-pub const CATEGORY_TEMPLATE_UUID_TYPE: Uuid =
-    Uuid::from_u128(0x65B1_E8B0_51F1_46A5_9970_72CD_F268_84BE);
-/// Campaign parameters document `UuidV4` type.
-pub const CAMPAIGN_DOCUMENT_UUID_TYPE: Uuid =
-    Uuid::from_u128(0x0110_EA96_A555_47CE_8408_36EF_E6ED_6F7C);
-/// Campaign parameters template `UuidV4` type.
-pub const CAMPAIGN_TEMPLATE_UUID_TYPE: Uuid =
-    Uuid::from_u128(0x7E8F_5FA2_44CE_49C8_BFD5_02AF_42C1_79A3);
-/// Brand parameters document `UuidV4` type.
-pub const BRAND_DOCUMENT_UUID_TYPE: Uuid =
-    Uuid::from_u128(0x3E48_08CC_C86E_467B_9702_D60B_AA9D_1FCA);
-/// Brand parameters template `UuidV4` type.
-pub const BRAND_TEMPLATE_UUID_TYPE: Uuid =
-    Uuid::from_u128(0xFD3C_1735_80B1_4EEA_8D63_5F43_6D97_EA31);
-/// Proposal action document `UuidV4` type.
-pub const PROPOSAL_ACTION_DOCUMENT_UUID_TYPE: Uuid =
-    Uuid::from_u128(0x5E60_E623_AD02_4A1B_A1AC_406D_B978_EE48);
-/// Public vote transaction v2 `UuidV4` type.
-pub const PUBLIC_VOTE_TX_V2_UUID_TYPE: Uuid =
-    Uuid::from_u128(0x8DE5_586C_E998_4B95_8742_7BE3_C859_2803);
-/// Private vote transaction v2 `UuidV4` type.
-pub const PRIVATE_VOTE_TX_V2_UUID_TYPE: Uuid =
-    Uuid::from_u128(0xE78E_E18D_F380_44C1_A852_80AA_6ECB_07FE);
-/// Immutable ledger block `UuidV4` type.
-pub const IMMUTABLE_LEDGER_BLOCK_UUID_TYPE: Uuid =
-    Uuid::from_u128(0xD9E7_E6CE_2401_4D7D_9492_F4F7_C642_41C3);
-/// Submission Action `UuidV4` type.
-pub const SUBMISSION_ACTION: Uuid = Uuid::from_u128(0x7892_7329_CFD9_4EA1_9C71_0E01_9B12_6A65);
+use catalyst_types::uuid::Uuid;
+use deprecated::{
+    COMMENT_DOCUMENT_UUID_TYPE, PROPOSAL_ACTION_DOCUMENT_UUID_TYPE, PROPOSAL_DOCUMENT_UUID_TYPE,
+};
+
+use crate::DocType;
+
+/// Proposal document type.
+#[allow(clippy::expect_used)]
+pub static PROPOSAL_DOC_TYPE: LazyLock<DocType> = LazyLock::new(|| {
+    let ids = &[PROPOSAL_UUID_TYPE];
+    ids.to_vec()
+        .try_into()
+        .expect("Failed to convert proposal document Uuid to DocType")
+});
+
+/// Proposal comment document type.
+#[allow(clippy::expect_used)]
+pub static PROPOSAL_COMMENT_DOC: LazyLock<DocType> = LazyLock::new(|| {
+    let ids = &[COMMENT_UUID_TYPE, PROPOSAL_UUID_TYPE];
+    ids.to_vec()
+        .try_into()
+        .expect("Failed to convert proposal comment document Uuid to DocType")
+});
+
+/// Proposal action document type.
+#[allow(clippy::expect_used)]
+pub static PROPOSAL_ACTION_DOC: LazyLock<DocType> = LazyLock::new(|| {
+    let ids = &[
+        ACTION_UUID_TYPE,
+        PROPOSAL_UUID_TYPE,
+        SUBMISSION_ACTION_UUID_TYPE,
+    ];
+    ids.to_vec()
+        .try_into()
+        .expect("Failed to convert proposal action document Uuid to DocType")
+});
+
+/// Submission Action UUID type.
+pub const SUBMISSION_ACTION_UUID_TYPE: Uuid =
+    Uuid::from_u128(0x7892_7329_CFD9_4EA1_9C71_0E01_9B12_6A65);
+/// Proposal UUID type.
+pub const PROPOSAL_UUID_TYPE: Uuid = PROPOSAL_DOCUMENT_UUID_TYPE;
+/// Comment UUID type.
+pub const COMMENT_UUID_TYPE: Uuid = COMMENT_DOCUMENT_UUID_TYPE;
+/// Action UUID type.
+pub const ACTION_UUID_TYPE: Uuid = PROPOSAL_ACTION_DOCUMENT_UUID_TYPE;
+
+/// Document type which will be deprecated.
+pub mod deprecated {
+    use catalyst_types::uuid::Uuid;
+
+    /// Proposal document `UuidV4` type.
+    pub const PROPOSAL_DOCUMENT_UUID_TYPE: Uuid =
+        Uuid::from_u128(0x7808_D2BA_D511_40AF_84E8_C0D1_625F_DFDC);
+    /// Proposal template `UuidV4` type.
+    pub const PROPOSAL_TEMPLATE_UUID_TYPE: Uuid =
+        Uuid::from_u128(0x0CE8_AB38_9258_4FBC_A62E_7FAA_6E58_318F);
+    /// Comment document `UuidV4` type.
+    pub const COMMENT_DOCUMENT_UUID_TYPE: Uuid =
+        Uuid::from_u128(0xB679_DED3_0E7C_41BA_89F8_DA62_A178_98EA);
+    /// Comment template `UuidV4` type.
+    pub const COMMENT_TEMPLATE_UUID_TYPE: Uuid =
+        Uuid::from_u128(0x0B84_24D4_EBFD_46E3_9577_1775_A69D_290C);
+    /// Review document `UuidV4` type.
+    pub const REVIEW_DOCUMENT_UUID_TYPE: Uuid =
+        Uuid::from_u128(0xE4CA_F5F0_098B_45FD_94F3_0702_A457_3DB5);
+    /// Review template `UuidV4` type.
+    pub const REVIEW_TEMPLATE_UUID_TYPE: Uuid =
+        Uuid::from_u128(0xEBE5_D0BF_5D86_4577_AF4D_008F_DDBE_2EDC);
+    /// Category document `UuidV4` type.
+    pub const CATEGORY_DOCUMENT_UUID_TYPE: Uuid =
+        Uuid::from_u128(0x48C2_0109_362A_4D32_9BBA_E0A9_CF8B_45BE);
+    /// Category template `UuidV4` type.
+    pub const CATEGORY_TEMPLATE_UUID_TYPE: Uuid =
+        Uuid::from_u128(0x65B1_E8B0_51F1_46A5_9970_72CD_F268_84BE);
+    /// Campaign parameters document `UuidV4` type.
+    pub const CAMPAIGN_DOCUMENT_UUID_TYPE: Uuid =
+        Uuid::from_u128(0x0110_EA96_A555_47CE_8408_36EF_E6ED_6F7C);
+    /// Campaign parameters template `UuidV4` type.
+    pub const CAMPAIGN_TEMPLATE_UUID_TYPE: Uuid =
+        Uuid::from_u128(0x7E8F_5FA2_44CE_49C8_BFD5_02AF_42C1_79A3);
+    /// Brand parameters document `UuidV4` type.
+    pub const BRAND_DOCUMENT_UUID_TYPE: Uuid =
+        Uuid::from_u128(0x3E48_08CC_C86E_467B_9702_D60B_AA9D_1FCA);
+    /// Brand parameters template `UuidV4` type.
+    pub const BRAND_TEMPLATE_UUID_TYPE: Uuid =
+        Uuid::from_u128(0xFD3C_1735_80B1_4EEA_8D63_5F43_6D97_EA31);
+    /// Proposal action document `UuidV4` type.
+    pub const PROPOSAL_ACTION_DOCUMENT_UUID_TYPE: Uuid =
+        Uuid::from_u128(0x5E60_E623_AD02_4A1B_A1AC_406D_B978_EE48);
+    /// Public vote transaction v2 `UuidV4` type.
+    pub const PUBLIC_VOTE_TX_V2_UUID_TYPE: Uuid =
+        Uuid::from_u128(0x8DE5_586C_E998_4B95_8742_7BE3_C859_2803);
+    /// Private vote transaction v2 `UuidV4` type.
+    pub const PRIVATE_VOTE_TX_V2_UUID_TYPE: Uuid =
+        Uuid::from_u128(0xE78E_E18D_F380_44C1_A852_80AA_6ECB_07FE);
+    /// Immutable ledger block `UuidV4` type.
+    pub const IMMUTABLE_LEDGER_BLOCK_UUID_TYPE: Uuid =
+        Uuid::from_u128(0xD9E7_E6CE_2401_4D7D_9492_F4F7_C642_41C3);
+    /// Submission Action `UuidV4` type.
+    pub const SUBMISSION_ACTION: Uuid = Uuid::from_u128(0x7892_7329_CFD9_4EA1_9C71_0E01_9B12_6A65);
+}

--- a/rust/signed_doc/src/doc_types/mod.rs
+++ b/rust/signed_doc/src/doc_types/mod.rs
@@ -41,24 +41,6 @@ pub static PROPOSAL_ACTION_DOC: LazyLock<DocType> = LazyLock::new(|| {
         .expect("Failed to convert proposal action document Uuid to DocType")
 });
 
-/// Proposal template document type.
-#[allow(clippy::expect_used)]
-pub static PROPOSAL_TEMPLATE: LazyLock<DocType> = LazyLock::new(|| {
-    let ids = &[TEMPLATE_UUID_TYPE, PROPOSAL_UUID_TYPE];
-    ids.to_vec()
-        .try_into()
-        .expect("Failed to convert proposal template Uuid to DocType")
-});
-
-/// Proposal comment template document type.
-#[allow(clippy::expect_used)]
-pub static PROPOSAL_COMMENT_TEMPLATE: LazyLock<DocType> = LazyLock::new(|| {
-    let ids = &[TEMPLATE_UUID_TYPE, COMMENT_UUID_TYPE, PROPOSAL_UUID_TYPE];
-    ids.to_vec()
-        .try_into()
-        .expect("Failed to convert proposal comment template Uuid to DocType")
-});
-
 /// Submission Action UUID type.
 pub const SUBMISSION_ACTION_UUID_TYPE: Uuid =
     Uuid::from_u128(0x7892_7329_CFD9_4EA1_9C71_0E01_9B12_6A65);

--- a/rust/signed_doc/src/doc_types/mod.rs
+++ b/rust/signed_doc/src/doc_types/mod.rs
@@ -51,3 +51,5 @@ pub const PRIVATE_VOTE_TX_V2_UUID_TYPE: Uuid =
 /// Immutable ledger block `UuidV4` type.
 pub const IMMUTABLE_LEDGER_BLOCK_UUID_TYPE: Uuid =
     Uuid::from_u128(0xD9E7_E6CE_2401_4D7D_9492_F4F7_C642_41C3);
+/// Submission Action `UuidV4` type.
+pub const SUBMISSION_ACTION: Uuid = Uuid::from_u128(0x7892_7329_CFD9_4EA1_9C71_0E01_9B12_6A65);

--- a/rust/signed_doc/src/doc_types/mod.rs
+++ b/rust/signed_doc/src/doc_types/mod.rs
@@ -8,7 +8,7 @@ use deprecated::{
     COMMENT_DOCUMENT_UUID_TYPE, PROPOSAL_ACTION_DOCUMENT_UUID_TYPE, PROPOSAL_DOCUMENT_UUID_TYPE,
 };
 
-use crate::DocType;
+use crate::{doc_types::deprecated::PROPOSAL_TEMPLATE_UUID_TYPE, DocType};
 
 /// Proposal document type.
 #[allow(clippy::expect_used)]
@@ -41,15 +41,37 @@ pub static PROPOSAL_ACTION_DOC: LazyLock<DocType> = LazyLock::new(|| {
         .expect("Failed to convert proposal action document Uuid to DocType")
 });
 
+/// Proposal template document type.
+#[allow(clippy::expect_used)]
+pub static PROPOSAL_TEMPLATE: LazyLock<DocType> = LazyLock::new(|| {
+    let ids = &[TEMPLATE_UUID_TYPE, PROPOSAL_UUID_TYPE];
+    ids.to_vec()
+        .try_into()
+        .expect("Failed to convert proposal template Uuid to DocType")
+});
+
+/// Proposal comment template document type.
+#[allow(clippy::expect_used)]
+pub static PROPOSAL_COMMENT_TEMPLATE: LazyLock<DocType> = LazyLock::new(|| {
+    let ids = &[TEMPLATE_UUID_TYPE, COMMENT_UUID_TYPE, PROPOSAL_UUID_TYPE];
+    ids.to_vec()
+        .try_into()
+        .expect("Failed to convert proposal comment template Uuid to DocType")
+});
+
 /// Submission Action UUID type.
 pub const SUBMISSION_ACTION_UUID_TYPE: Uuid =
     Uuid::from_u128(0x7892_7329_CFD9_4EA1_9C71_0E01_9B12_6A65);
+/// Category UUID type.
+pub const CATEGORY_UUID_TYPE: Uuid = Uuid::from_u128(0x818938C3_3139_4DAA_AFE6_974C78488E95);
 /// Proposal UUID type.
 pub const PROPOSAL_UUID_TYPE: Uuid = PROPOSAL_DOCUMENT_UUID_TYPE;
 /// Comment UUID type.
 pub const COMMENT_UUID_TYPE: Uuid = COMMENT_DOCUMENT_UUID_TYPE;
 /// Action UUID type.
 pub const ACTION_UUID_TYPE: Uuid = PROPOSAL_ACTION_DOCUMENT_UUID_TYPE;
+/// Template UUID type.
+pub const TEMPLATE_UUID_TYPE: Uuid = PROPOSAL_TEMPLATE_UUID_TYPE;
 
 /// Document type which will be deprecated.
 pub mod deprecated {

--- a/rust/signed_doc/src/doc_types/mod.rs
+++ b/rust/signed_doc/src/doc_types/mod.rs
@@ -4,16 +4,13 @@
 use std::sync::LazyLock;
 
 use catalyst_types::uuid::Uuid;
-use deprecated::{
-    COMMENT_DOCUMENT_UUID_TYPE, PROPOSAL_ACTION_DOCUMENT_UUID_TYPE, PROPOSAL_DOCUMENT_UUID_TYPE,
-};
 
-use crate::{doc_types::deprecated::PROPOSAL_TEMPLATE_UUID_TYPE, DocType};
+use crate::DocType;
 
 /// Proposal document type.
 #[allow(clippy::expect_used)]
-pub static PROPOSAL_DOC_TYPE: LazyLock<DocType> = LazyLock::new(|| {
-    let ids = &[PROPOSAL_UUID_TYPE];
+pub static PROPOSAL: LazyLock<DocType> = LazyLock::new(|| {
+    let ids = &[PROPOSAL_BASE_TYPE];
     ids.to_vec()
         .try_into()
         .expect("Failed to convert proposal document Uuid to DocType")
@@ -21,8 +18,8 @@ pub static PROPOSAL_DOC_TYPE: LazyLock<DocType> = LazyLock::new(|| {
 
 /// Proposal comment document type.
 #[allow(clippy::expect_used)]
-pub static PROPOSAL_COMMENT_DOC: LazyLock<DocType> = LazyLock::new(|| {
-    let ids = &[COMMENT_UUID_TYPE, PROPOSAL_UUID_TYPE];
+pub static PROPOSAL_COMMENT: LazyLock<DocType> = LazyLock::new(|| {
+    let ids = &[COMMENT_BASE_TYPE, PROPOSAL_BASE_TYPE];
     ids.to_vec()
         .try_into()
         .expect("Failed to convert proposal comment document Uuid to DocType")
@@ -30,30 +27,40 @@ pub static PROPOSAL_COMMENT_DOC: LazyLock<DocType> = LazyLock::new(|| {
 
 /// Proposal action document type.
 #[allow(clippy::expect_used)]
-pub static PROPOSAL_ACTION_DOC: LazyLock<DocType> = LazyLock::new(|| {
+pub static PROPOSAL_SUBMISSION_ACTION: LazyLock<DocType> = LazyLock::new(|| {
     let ids = &[
-        ACTION_UUID_TYPE,
-        PROPOSAL_UUID_TYPE,
-        SUBMISSION_ACTION_UUID_TYPE,
+        ACTION_BASE_TYPE,
+        PROPOSAL_BASE_TYPE,
+        SUBMISSION_ACTION_BASE_TYPE,
     ];
     ids.to_vec()
         .try_into()
         .expect("Failed to convert proposal action document Uuid to DocType")
 });
 
-/// Submission Action UUID type.
-pub const SUBMISSION_ACTION_UUID_TYPE: Uuid =
+/// -------------- Base Types --------------
+/// Action UUID base type.
+pub const ACTION_BASE_TYPE: Uuid = Uuid::from_u128(0x5E60_E623_AD02_4A1B_A1AC_406D_B978_EE48);
+/// Brand UUID base type.
+pub const BRAND_BASE_TYPE: Uuid = Uuid::from_u128(0xEBCA_BEEB_5BC5_4F95_91E8_CAB8_CA72_4172);
+/// Campaign UUID base type.
+pub const CAMPAIGN_BASE_TYPE: Uuid = Uuid::from_u128(0x5EF3_2D5D_F240_462C_A7A4_BA4A_F221_FA23);
+/// Category UUID base type.
+pub const CATEGORY_BASE_TYPE: Uuid = Uuid::from_u128(0x8189_38C3_3139_4DAA_AFE6_974C_7848_8E95);
+/// Comment UUID base type.
+pub const COMMENT_BASE_TYPE: Uuid = Uuid::from_u128(0xB679_DED3_0E7C_41BA_89F8_DA62_A178_98EA);
+/// Decision UUID base type.
+pub const DECISION_BASE_TYPE: Uuid = Uuid::from_u128(0x788F_F4C6_D65A_451F_BB33_575F_E056_B411);
+/// Moderation Action UUID base type.
+pub const MODERATION_ACTION_BASE_TYPE: Uuid =
+    Uuid::from_u128(0xA5D2_32B8_5E03_4117_9AFD_BE32_B878_FCDD);
+/// Proposal UUID base type.
+pub const PROPOSAL_BASE_TYPE: Uuid = Uuid::from_u128(0x7808_D2BA_D511_40AF_84E8_C0D1_625F_DFDC);
+/// Submission Action UUID base type.
+pub const SUBMISSION_ACTION_BASE_TYPE: Uuid =
     Uuid::from_u128(0x7892_7329_CFD9_4EA1_9C71_0E01_9B12_6A65);
-/// Category UUID type.
-pub const CATEGORY_UUID_TYPE: Uuid = Uuid::from_u128(0x818938C3_3139_4DAA_AFE6_974C78488E95);
-/// Proposal UUID type.
-pub const PROPOSAL_UUID_TYPE: Uuid = PROPOSAL_DOCUMENT_UUID_TYPE;
-/// Comment UUID type.
-pub const COMMENT_UUID_TYPE: Uuid = COMMENT_DOCUMENT_UUID_TYPE;
-/// Action UUID type.
-pub const ACTION_UUID_TYPE: Uuid = PROPOSAL_ACTION_DOCUMENT_UUID_TYPE;
-/// Template UUID type.
-pub const TEMPLATE_UUID_TYPE: Uuid = PROPOSAL_TEMPLATE_UUID_TYPE;
+/// Template UUID base type.
+pub const TEMPLATE_BASE_TYPE: Uuid = Uuid::from_u128(0x0CE8_AB38_9258_4FBC_A62E_7FAA_6E58_318F);
 
 /// Document type which will be deprecated.
 pub mod deprecated {

--- a/rust/signed_doc/src/lib.rs
+++ b/rust/signed_doc/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod builder;
 mod content;
+mod decode_context;
 pub mod doc_types;
 mod metadata;
 pub mod providers;
@@ -22,7 +23,9 @@ pub use catalyst_types::{
 };
 pub use content::Content;
 use coset::{CborSerializable, Header, TaggedCborSerializable};
-pub use metadata::{ContentEncoding, ContentType, DocumentRef, ExtraFields, Metadata, Section};
+pub use metadata::{
+    ContentEncoding, ContentType, DocType, DocumentRef, ExtraFields, Metadata, Section,
+};
 use minicbor::{decode, encode, Decode, Decoder, Encode};
 pub use signature::{CatalystId, Signatures};
 

--- a/rust/signed_doc/src/lib.rs
+++ b/rust/signed_doc/src/lib.rs
@@ -23,6 +23,7 @@ pub use catalyst_types::{
 };
 pub use content::Content;
 use coset::{CborSerializable, Header, TaggedCborSerializable};
+use decode_context::{CompatibilityPolicy, DecodeContext};
 pub use metadata::{
     ContentEncoding, ContentType, DocType, DocumentRef, ExtraFields, Metadata, Section,
 };
@@ -88,11 +89,11 @@ impl From<InnerCatalystSignedDocument> for CatalystSignedDocument {
 impl CatalystSignedDocument {
     // A bunch of getters to access the contents, or reason through the document, such as.
 
-    /// Return Document Type `UUIDv4`.
+    /// Return Document Type `DocType` - List of `UUIDv4`.
     ///
     /// # Errors
     /// - Missing 'type' field.
-    pub fn doc_type(&self) -> anyhow::Result<UuidV4> {
+    pub fn doc_type(&self) -> anyhow::Result<&DocType> {
         self.inner.metadata.doc_type()
     }
 
@@ -238,8 +239,12 @@ impl Decode<'_, ()> for CatalystSignedDocument {
                 minicbor::decode::Error::message(format!("Invalid COSE Sign document: {e}"))
             })?;
 
-        let report = ProblemReport::new(PROBLEM_REPORT_CTX);
-        let metadata = Metadata::from_protected_header(&cose_sign.protected, &report);
+        let mut report = ProblemReport::new(PROBLEM_REPORT_CTX);
+        let mut ctx = DecodeContext {
+            compatibility_policy: CompatibilityPolicy::Accept,
+            report: &mut report,
+        };
+        let metadata = Metadata::from_protected_header(&cose_sign.protected, &mut ctx);
         let signatures = Signatures::from_cose_sig_list(&cose_sign.signatures, &report);
 
         let content = if let Some(payload) = cose_sign.payload {

--- a/rust/signed_doc/src/metadata/doc_type.rs
+++ b/rust/signed_doc/src/metadata/doc_type.rs
@@ -1,0 +1,333 @@
+//! Document Type.
+
+use std::fmt::{Display, Formatter};
+
+use catalyst_types::{
+    problem_report::ProblemReport,
+    uuid::{CborContext, Uuid, UuidV4},
+};
+use minicbor::{Decode, Decoder, Encode};
+use tracing::warn;
+
+use crate::{
+    decode_context::{CompatibilityPolicy, DecodeContext},
+    doc_types::{
+        COMMENT_DOCUMENT_UUID_TYPE, PROPOSAL_ACTION_DOCUMENT_UUID_TYPE,
+        PROPOSAL_DOCUMENT_UUID_TYPE, SUBMISSION_ACTION,
+    },
+};
+
+/// List of `UUIDv4` document type.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct DocType(Vec<UuidV4>);
+
+/// `DocType` Errors.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum DocTypeError {
+    /// Invalid UUID.
+    #[error("Invalid UUID: {0}")]
+    InvalidUuid(Uuid),
+    /// `DocType` cannot be empty.
+    #[error("DocType cannot be empty")]
+    Empty,
+}
+
+impl DocType {
+    /// Get a list of `UUIDv4` document types.
+    #[must_use]
+    pub fn doc_types(&self) -> &Vec<UuidV4> {
+        &self.0
+    }
+}
+
+impl From<UuidV4> for DocType {
+    fn from(value: UuidV4) -> Self {
+        DocType(vec![value])
+    }
+}
+
+impl TryFrom<Uuid> for DocType {
+    type Error = DocTypeError;
+
+    fn try_from(value: Uuid) -> Result<Self, Self::Error> {
+        let uuid_v4 = UuidV4::try_from(value).map_err(|_| DocTypeError::InvalidUuid(value))?;
+        Ok(DocType(vec![uuid_v4]))
+    }
+}
+
+impl TryFrom<Vec<Uuid>> for DocType {
+    type Error = DocTypeError;
+
+    fn try_from(value: Vec<Uuid>) -> Result<Self, Self::Error> {
+        if value.is_empty() {
+            return Err(DocTypeError::Empty);
+        }
+
+        let converted = value
+            .into_iter()
+            .map(|u| UuidV4::try_from(u).map_err(|_| DocTypeError::InvalidUuid(u)))
+            .collect::<Result<Vec<UuidV4>, DocTypeError>>()?;
+
+        DocType::try_from(converted)
+    }
+}
+
+impl TryFrom<Vec<UuidV4>> for DocType {
+    type Error = DocTypeError;
+
+    fn try_from(value: Vec<UuidV4>) -> Result<Self, Self::Error> {
+        if value.is_empty() {
+            return Err(DocTypeError::Empty);
+        }
+        Ok(DocType(value))
+    }
+}
+
+impl Display for DocType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(
+            f,
+            "[{}]",
+            self.0
+                .iter()
+                .map(UuidV4::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    }
+}
+
+// ; Document Type
+// document_type = [ 1* uuid_v4 ]
+// ; UUIDv4
+// uuid_v4 = #6.37(bytes .size 16)
+impl Decode<'_, DecodeContext<'_>> for DocType {
+    fn decode(
+        d: &mut Decoder, decode_context: &mut DecodeContext,
+    ) -> Result<Self, minicbor::decode::Error> {
+        const CONTEXT: &str = "DocType decoding";
+        let parse_uuid = |d: &mut Decoder| UuidV4::decode(d, &mut CborContext::Tagged);
+
+        match d.datatype()? {
+            minicbor::data::Type::Array => {
+                let len = d.array()?.ok_or_else(|| {
+                    decode_context
+                        .report
+                        .other("Unable to decode array length", CONTEXT);
+                    minicbor::decode::Error::message(format!(
+                        "{CONTEXT}: Unable to decode array length"
+                    ))
+                })?;
+
+                if len == 0 {
+                    decode_context.report.invalid_value(
+                        "array length",
+                        "0",
+                        "must contain at least one UUIDv4",
+                        CONTEXT,
+                    );
+                    return Err(minicbor::decode::Error::message(format!(
+                        "{CONTEXT}: empty array"
+                    )));
+                }
+
+                (0..len)
+                    .map(|_| parse_uuid(d))
+                    .collect::<Result<Vec<_>, _>>()
+                    .map(Self)
+                    .map_err(|e| {
+                        decode_context
+                            .report
+                            .other(&format!("Invalid UUIDv4 in array: {e}"), CONTEXT);
+                        minicbor::decode::Error::message(format!(
+                            "{CONTEXT}: Invalid UUIDv4 in array: {e}"
+                        ))
+                    })
+            },
+            minicbor::data::Type::Tag => {
+                // Handle single tagged UUID
+                match decode_context.compatibility_policy {
+                    CompatibilityPolicy::Accept | CompatibilityPolicy::Warn => {
+                        if matches!(
+                            decode_context.compatibility_policy,
+                            CompatibilityPolicy::Warn
+                        ) {
+                            warn!("{CONTEXT}: Conversion of document type single UUID to type DocType");
+                        }
+
+                        let uuid = parse_uuid(d).map_err(|e| {
+                            let msg = format!("Cannot decode single UUIDv4: {e}");
+                            decode_context.report.invalid_value(
+                                "Decode single UUIDv4",
+                                &e.to_string(),
+                                &msg,
+                                CONTEXT,
+                            );
+                            minicbor::decode::Error::message(format!("{CONTEXT}: {msg}"))
+                        })?;
+
+                        let ids = map_doc_type(uuid.into()).map_err(|e| {
+                            decode_context.report.other(&e.to_string(), CONTEXT);
+                            minicbor::decode::Error::message(format!("{CONTEXT}: {e}"))
+                        })?;
+
+                        let doc_type = ids.to_vec().try_into().map_err(|e: DocTypeError| {
+                            decode_context.report.other(&e.to_string(), CONTEXT);
+                            minicbor::decode::Error::message(format!("{CONTEXT}: {e}"))
+                        })?;
+
+                        Ok(doc_type)
+                    },
+
+                    CompatibilityPolicy::Fail => {
+                        let msg = "Conversion of document type single UUID to type DocType is not allowed";
+                        decode_context.report.other(msg, CONTEXT);
+                        Err(minicbor::decode::Error::message(format!(
+                            "{CONTEXT}: {msg}"
+                        )))
+                    },
+                }
+            },
+            other => {
+                decode_context.report.invalid_value(
+                    "decoding type",
+                    &format!("{other:?}"),
+                    "array or tag cbor",
+                    CONTEXT,
+                );
+                Err(minicbor::decode::Error::message(format!(
+                    "{CONTEXT}: expected array of UUIDor tagged UUIDv4, got {other:?}",
+                )))
+            },
+        }
+    }
+}
+
+/// Map single UUID doc type to new list of doc types
+/// <https://github.com/input-output-hk/catalyst-libs/blob/main/docs/src/architecture/08_concepts/signed_doc/types.md#document-types>
+fn map_doc_type(uuid: Uuid) -> anyhow::Result<&'static [Uuid]> {
+    const PROPOSAL_DOC: &[Uuid] = &[PROPOSAL_DOCUMENT_UUID_TYPE];
+    const PROPOSAL_COMMENT_DOC: &[Uuid] =
+        &[COMMENT_DOCUMENT_UUID_TYPE, PROPOSAL_DOCUMENT_UUID_TYPE];
+    const PROPOSAL_ACTION_DOC: &[Uuid] = &[
+        PROPOSAL_ACTION_DOCUMENT_UUID_TYPE,
+        PROPOSAL_DOCUMENT_UUID_TYPE,
+        SUBMISSION_ACTION,
+    ];
+
+    match uuid {
+        id if id == PROPOSAL_DOCUMENT_UUID_TYPE => Ok(PROPOSAL_DOC),
+        id if id == COMMENT_DOCUMENT_UUID_TYPE => Ok(PROPOSAL_COMMENT_DOC),
+        id if id == PROPOSAL_ACTION_DOCUMENT_UUID_TYPE => Ok(PROPOSAL_ACTION_DOC),
+        _ => anyhow::bail!("Unknown document type: {uuid}"),
+    }
+}
+
+impl Encode<ProblemReport> for DocType {
+    fn encode<W: minicbor::encode::Write>(
+        &self, e: &mut minicbor::Encoder<W>, report: &mut ProblemReport,
+    ) -> Result<(), minicbor::encode::Error<W::Error>> {
+        const CONTEXT: &str = "DocType encoding";
+        if self.0.is_empty() {
+            report.invalid_value("DocType", "empty", "DocType cannot be empty", CONTEXT);
+            return Err(minicbor::encode::Error::message(format!(
+                "{CONTEXT}: DocType cannot be empty"
+            )));
+        }
+
+        e.array(self.0.len().try_into().map_err(|_| {
+            report.other("Unable to encode array length", CONTEXT);
+            minicbor::encode::Error::message(format!("{CONTEXT}, unable to encode array length"))
+        })?)?;
+
+        for id in &self.0 {
+            id.encode(e, &mut CborContext::Tagged).map_err(|_| {
+                report.other("Failed to encode UUIDv4", CONTEXT);
+                minicbor::encode::Error::message(format!("{CONTEXT}: UUIDv4 encoding failed"))
+            })?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use minicbor::Encoder;
+
+    use super::*;
+
+    // <https://input-output-hk.github.io/catalyst-libs/architecture/08_concepts/signed_doc/types/>
+    // Proposal Submission Action = 37(h'5e60e623ad024a1ba1ac406db978ee48') should map to
+    // [37(h'5e60e623ad024a1ba1ac406db978ee48'), 37(h'7808d2bad51140af84e8c0d1625fdfdc'),
+    // 37(h'78927329cfd94ea19c710e019b126a65')]
+    const PSA: &str = "D825505E60E623AD024A1BA1AC406DB978EE48";
+
+    #[test]
+    fn test_empty_doc_type() {
+        assert!(<DocType as TryFrom<Vec<UuidV4>>>::try_from(vec![]).is_err());
+
+        let mut report = ProblemReport::new("Test empty doc type");
+        let mut decoded_context = DecodeContext {
+            compatibility_policy: CompatibilityPolicy::Accept,
+            report: &mut report,
+        };
+        let mut decoder = Decoder::new(&[]);
+        assert!(DocType::decode(&mut decoder, &mut decoded_context).is_err());
+    }
+
+    #[test]
+    fn test_single_uuid_doc_type_fail_policy() {
+        let mut report = ProblemReport::new("Test single uuid doc type - fail");
+        let data = hex::decode(PSA).unwrap();
+        let decoder = Decoder::new(&data);
+        let mut decoded_context = DecodeContext {
+            compatibility_policy: CompatibilityPolicy::Fail,
+            report: &mut report,
+        };
+        assert!(DocType::decode(&mut decoder.clone(), &mut decoded_context).is_err());
+    }
+
+    #[test]
+    fn test_single_uuid_doc_type_warn_policy() {
+        let mut report = ProblemReport::new("Test single uuid doc type - warn");
+        let data = hex::decode(PSA).unwrap();
+        let decoder = Decoder::new(&data);
+        let mut decoded_context = DecodeContext {
+            compatibility_policy: CompatibilityPolicy::Warn,
+            report: &mut report,
+        };
+        let decoded_doc_type = DocType::decode(&mut decoder.clone(), &mut decoded_context).unwrap();
+        assert_eq!(decoded_doc_type.doc_types().len(), 3);
+    }
+
+    #[test]
+    fn test_single_uuid_doc_type_accept_policy() {
+        let mut report = ProblemReport::new("Test single uuid doc type - accept");
+        let data = hex::decode(PSA).unwrap();
+        let decoder = Decoder::new(&data);
+        let mut decoded_context = DecodeContext {
+            compatibility_policy: CompatibilityPolicy::Accept,
+            report: &mut report,
+        };
+        let decoded_doc_type = DocType::decode(&mut decoder.clone(), &mut decoded_context).unwrap();
+        assert_eq!(decoded_doc_type.doc_types().len(), 3);
+    }
+
+    #[test]
+    fn test_multi_uuid_doc_type() {
+        let uuidv4 = UuidV4::new();
+        let mut report = ProblemReport::new("Test multi uuid doc type");
+        let doc_type_list: DocType = vec![uuidv4, uuidv4].try_into().unwrap();
+        let mut buffer = Vec::new();
+        let mut encoder = Encoder::new(&mut buffer);
+        doc_type_list.encode(&mut encoder, &mut report).unwrap();
+        let mut decoder = Decoder::new(&buffer);
+        let mut decoded_context = DecodeContext {
+            compatibility_policy: CompatibilityPolicy::Accept,
+            report: &mut report.clone(),
+        };
+        let decoded_doc_type = DocType::decode(&mut decoder, &mut decoded_context).unwrap();
+        assert_eq!(decoded_doc_type, doc_type_list);
+    }
+}

--- a/rust/signed_doc/src/metadata/doc_type.rs
+++ b/rust/signed_doc/src/metadata/doc_type.rs
@@ -16,10 +16,7 @@ use tracing::warn;
 
 use crate::{
     decode_context::{CompatibilityPolicy, DecodeContext},
-    doc_types::{
-        ACTION_UUID_TYPE, COMMENT_UUID_TYPE, PROPOSAL_ACTION_DOC, PROPOSAL_COMMENT_DOC,
-        PROPOSAL_DOC_TYPE, PROPOSAL_UUID_TYPE,
-    },
+    doc_types::{deprecated, PROPOSAL, PROPOSAL_COMMENT, PROPOSAL_SUBMISSION_ACTION},
 };
 
 /// List of `UUIDv4` document type.
@@ -252,9 +249,11 @@ impl Decode<'_, DecodeContext<'_>> for DocType {
 /// <https://github.com/input-output-hk/catalyst-libs/blob/main/docs/src/architecture/08_concepts/signed_doc/types.md#document-types>
 fn map_doc_type(uuid: Uuid) -> anyhow::Result<DocType> {
     match uuid {
-        id if id == PROPOSAL_UUID_TYPE => Ok(PROPOSAL_DOC_TYPE.clone()),
-        id if id == COMMENT_UUID_TYPE => Ok(PROPOSAL_COMMENT_DOC.clone()),
-        id if id == ACTION_UUID_TYPE => Ok(PROPOSAL_ACTION_DOC.clone()),
+        id if id == deprecated::PROPOSAL_DOCUMENT_UUID_TYPE => Ok(PROPOSAL.clone()),
+        id if id == deprecated::COMMENT_DOCUMENT_UUID_TYPE => Ok(PROPOSAL_COMMENT.clone()),
+        id if id == deprecated::PROPOSAL_ACTION_DOCUMENT_UUID_TYPE => {
+            Ok(PROPOSAL_SUBMISSION_ACTION.clone())
+        },
         _ => anyhow::bail!("Unknown document type: {uuid}"),
     }
 }
@@ -337,9 +336,12 @@ impl PartialEq for DocType {
         // List of special-case (single UUID) -> new DocType
         // The old one should equal to the new one
         let special_cases = [
-            (PROPOSAL_UUID_TYPE, &*PROPOSAL_DOC_TYPE),
-            (COMMENT_UUID_TYPE, &*PROPOSAL_COMMENT_DOC),
-            (ACTION_UUID_TYPE, &*PROPOSAL_ACTION_DOC),
+            (deprecated::PROPOSAL_DOCUMENT_UUID_TYPE, &*PROPOSAL),
+            (deprecated::COMMENT_DOCUMENT_UUID_TYPE, &*PROPOSAL_COMMENT),
+            (
+                deprecated::PROPOSAL_ACTION_DOCUMENT_UUID_TYPE,
+                &*PROPOSAL_SUBMISSION_ACTION,
+            ),
         ];
         for (uuid, expected) in special_cases {
             match DocType::try_from(uuid) {
@@ -478,18 +480,18 @@ mod tests {
     #[test]
     fn test_doctype_equal_special_cases() {
         // Direct equal
-        let uuid = PROPOSAL_UUID_TYPE;
+        let uuid = deprecated::PROPOSAL_DOCUMENT_UUID_TYPE;
         let dt1 = DocType::try_from(vec![uuid]).unwrap();
         let dt2 = DocType::try_from(vec![uuid]).unwrap();
         assert_eq!(dt1, dt2);
 
         // single -> special mapped type
-        let single = DocType::try_from(PROPOSAL_UUID_TYPE).unwrap();
-        assert_eq!(single, *PROPOSAL_DOC_TYPE);
-        let single = DocType::try_from(COMMENT_UUID_TYPE).unwrap();
-        assert_eq!(single, *PROPOSAL_COMMENT_DOC);
-        let single = DocType::try_from(ACTION_UUID_TYPE).unwrap();
-        assert_eq!(single, *PROPOSAL_ACTION_DOC);
+        let single = DocType::try_from(deprecated::PROPOSAL_DOCUMENT_UUID_TYPE).unwrap();
+        assert_eq!(single, *PROPOSAL);
+        let single = DocType::try_from(deprecated::COMMENT_DOCUMENT_UUID_TYPE).unwrap();
+        assert_eq!(single, *PROPOSAL_COMMENT);
+        let single = DocType::try_from(deprecated::PROPOSAL_ACTION_DOCUMENT_UUID_TYPE).unwrap();
+        assert_eq!(single, *PROPOSAL_SUBMISSION_ACTION);
     }
 
     #[test]
@@ -518,10 +520,10 @@ mod tests {
 
     #[test]
     fn test_deserialize_special_case() {
-        let uuid = PROPOSAL_UUID_TYPE.to_string();
+        let uuid = deprecated::PROPOSAL_DOCUMENT_UUID_TYPE.to_string();
         let json = json!(uuid);
         let dt: DocType = serde_json::from_value(json).unwrap();
 
-        assert_eq!(dt, *PROPOSAL_DOC_TYPE);
+        assert_eq!(dt, *PROPOSAL);
     }
 }

--- a/rust/signed_doc/src/metadata/doc_type.rs
+++ b/rust/signed_doc/src/metadata/doc_type.rs
@@ -91,9 +91,9 @@ impl TryFrom<Vec<Uuid>> for DocType {
     }
 }
 
-impl From<DocType> for Vec<String> {
-    fn from(val: DocType) -> Self {
-        val.0.into_iter().map(|uuid| uuid.to_string()).collect()
+impl From<DocType> for Vec<Uuid> {
+    fn from(value: DocType) -> Vec<Uuid> {
+        value.0.into_iter().map(Uuid::from).collect()
     }
 }
 

--- a/rust/signed_doc/src/metadata/doc_type.rs
+++ b/rust/signed_doc/src/metadata/doc_type.rs
@@ -91,9 +91,9 @@ impl TryFrom<Vec<Uuid>> for DocType {
     }
 }
 
-impl From<DocType> for Vec<Uuid> {
-    fn from(value: DocType) -> Vec<Uuid> {
-        value.0.into_iter().map(Uuid::from).collect()
+impl From<DocType> for Vec<String> {
+    fn from(val: DocType) -> Self {
+        val.0.into_iter().map(|uuid| uuid.to_string()).collect()
     }
 }
 
@@ -282,9 +282,7 @@ impl Encode<ProblemReport> for DocType {
 
 impl<'de> Deserialize<'de> for DocType {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
+    where D: Deserializer<'de> {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum DocTypeInput {

--- a/rust/signed_doc/src/metadata/doc_type.rs
+++ b/rust/signed_doc/src/metadata/doc_type.rs
@@ -97,6 +97,12 @@ impl From<DocType> for Vec<Uuid> {
     }
 }
 
+impl From<DocType> for Vec<String> {
+    fn from(val: DocType) -> Self {
+        val.0.into_iter().map(|uuid| uuid.to_string()).collect()
+    }
+}
+
 impl TryFrom<Vec<UuidV4>> for DocType {
     type Error = DocTypeError;
 

--- a/rust/signed_doc/src/metadata/doc_type.rs
+++ b/rust/signed_doc/src/metadata/doc_type.rs
@@ -91,6 +91,12 @@ impl TryFrom<Vec<Uuid>> for DocType {
     }
 }
 
+impl From<DocType> for Vec<Uuid> {
+    fn from(value: DocType) -> Vec<Uuid> {
+        value.0.into_iter().map(Uuid::from).collect()
+    }
+}
+
 impl TryFrom<Vec<UuidV4>> for DocType {
     type Error = DocTypeError;
 
@@ -276,7 +282,9 @@ impl Encode<ProblemReport> for DocType {
 
 impl<'de> Deserialize<'de> for DocType {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where D: Deserializer<'de> {
+    where
+        D: Deserializer<'de>,
+    {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum DocTypeInput {

--- a/rust/signed_doc/src/metadata/extra_fields.rs
+++ b/rust/signed_doc/src/metadata/extra_fields.rs
@@ -79,8 +79,8 @@ impl ExtraFields {
 
     /// Return `collabs` field.
     #[must_use]
-    pub fn collabs(&self) -> &Vec<String> {
-        &self.collabs
+    pub fn collabs(&self) -> &[String] {
+        self.collabs.as_slice()
     }
 
     /// Return `parameters` field.

--- a/rust/signed_doc/src/metadata/mod.rs
+++ b/rust/signed_doc/src/metadata/mod.rs
@@ -259,3 +259,4 @@ impl TryFrom<&Metadata> for coset::Header {
         Ok(builder.build())
     }
 }
+

--- a/rust/signed_doc/src/metadata/mod.rs
+++ b/rust/signed_doc/src/metadata/mod.rs
@@ -246,7 +246,7 @@ impl TryFrom<&Metadata> for coset::Header {
         }
 
         builder = builder
-            .text_value(TYPE_KEY.to_string(), meta.doc_type()?.to_value())
+            .text_value(TYPE_KEY.to_string(), meta.doc_type()?.clone().into())
             .text_value(
                 ID_KEY.to_string(),
                 Value::try_from(CborUuidV7(meta.doc_id()?))?,

--- a/rust/signed_doc/src/metadata/mod.rs
+++ b/rust/signed_doc/src/metadata/mod.rs
@@ -259,4 +259,3 @@ impl TryFrom<&Metadata> for coset::Header {
         Ok(builder.build())
     }
 }
-

--- a/rust/signed_doc/src/metadata/mod.rs
+++ b/rust/signed_doc/src/metadata/mod.rs
@@ -3,6 +3,7 @@ use std::fmt::{Display, Formatter};
 
 mod content_encoding;
 mod content_type;
+mod doc_type;
 mod document_ref;
 mod extra_fields;
 mod section;
@@ -15,6 +16,7 @@ use catalyst_types::{
 pub use content_encoding::ContentEncoding;
 pub use content_type::ContentType;
 use coset::{cbor::Value, iana::CoapContentFormat};
+pub use doc_type::DocType;
 pub use document_ref::DocumentRef;
 pub use extra_fields::ExtraFields;
 pub use section::Section;

--- a/rust/signed_doc/src/validator/mod.rs
+++ b/rust/signed_doc/src/validator/mod.rs
@@ -23,7 +23,7 @@ use rules::{
 use crate::{
     doc_types::{
         deprecated::{self},
-        PROPOSAL_ACTION_DOC, PROPOSAL_COMMENT_DOC, PROPOSAL_DOC_TYPE,
+        PROPOSAL, PROPOSAL_COMMENT, PROPOSAL_SUBMISSION_ACTION,
     },
     metadata::DocType,
     providers::{CatalystSignedDocumentProvider, VerifyingKeyProvider},
@@ -136,9 +136,12 @@ fn document_rules_init() -> HashMap<DocType, Arc<Rules>> {
     let comment_rules = Arc::new(comment_document_rules);
     let action_rules = Arc::new(proposal_submission_action_rules);
 
-    document_rules_map.insert(PROPOSAL_DOC_TYPE.clone(), Arc::clone(&proposal_rules));
-    document_rules_map.insert(PROPOSAL_COMMENT_DOC.clone(), Arc::clone(&comment_rules));
-    document_rules_map.insert(PROPOSAL_ACTION_DOC.clone(), Arc::clone(&action_rules));
+    document_rules_map.insert(PROPOSAL.clone(), Arc::clone(&proposal_rules));
+    document_rules_map.insert(PROPOSAL_COMMENT.clone(), Arc::clone(&comment_rules));
+    document_rules_map.insert(
+        PROPOSAL_SUBMISSION_ACTION.clone(),
+        Arc::clone(&action_rules),
+    );
 
     // Insert old rules (for backward compatibility)
     document_rules_map.insert(

--- a/rust/signed_doc/src/validator/rules/parameters.rs
+++ b/rust/signed_doc/src/validator/rules/parameters.rs
@@ -1,11 +1,9 @@
 //! `parameters` rule type impl.
 
-use catalyst_types::uuid::UuidV4;
-
 use super::doc_ref::referenced_doc_check;
 use crate::{
-    providers::CatalystSignedDocumentProvider, validator::utils::validate_provided_doc,
-    CatalystSignedDocument,
+    metadata::DocType, providers::CatalystSignedDocumentProvider,
+    validator::utils::validate_provided_doc, CatalystSignedDocument,
 };
 
 /// `parameters` field validation rule
@@ -14,7 +12,7 @@ pub(crate) enum ParametersRule {
     /// Is `parameters` specified
     Specified {
         /// expected `type` field of the parameter doc
-        exp_parameters_type: UuidV4,
+        exp_parameters_type: DocType,
         /// optional flag for the `parameters` field
         optional: bool,
     },
@@ -37,7 +35,7 @@ impl ParametersRule {
                 let parameters_validator = |replied_doc: CatalystSignedDocument| {
                     referenced_doc_check(
                         &replied_doc,
-                        exp_parameters_type.uuid(),
+                        exp_parameters_type,
                         "parameters",
                         doc.report(),
                     )
@@ -126,7 +124,7 @@ mod tests {
 
         // all correct
         let rule = ParametersRule::Specified {
-            exp_parameters_type,
+            exp_parameters_type: exp_parameters_type.into(),
             optional: false,
         };
         let doc = Builder::new()
@@ -139,7 +137,7 @@ mod tests {
 
         // all correct, `parameters` field is missing, but its optional
         let rule = ParametersRule::Specified {
-            exp_parameters_type,
+            exp_parameters_type: exp_parameters_type.into(),
             optional: true,
         };
         let doc = Builder::new().build();
@@ -147,7 +145,7 @@ mod tests {
 
         // missing `parameters` field, but its required
         let rule = ParametersRule::Specified {
-            exp_parameters_type,
+            exp_parameters_type: exp_parameters_type.into(),
             optional: false,
         };
         let doc = Builder::new().build();

--- a/rust/signed_doc/tests/comment.rs
+++ b/rust/signed_doc/tests/comment.rs
@@ -1,6 +1,8 @@
 //! Integration test for comment document validation part.
 
-use catalyst_signed_doc::{providers::tests::TestCatalystSignedDocumentProvider, *};
+use catalyst_signed_doc::{
+    doc_types::deprecated, providers::tests::TestCatalystSignedDocumentProvider, *,
+};
 use catalyst_types::catalyst_id::role_index::RoleId;
 
 mod common;
@@ -8,16 +10,16 @@ mod common;
 #[tokio::test]
 async fn test_valid_comment_doc() {
     let (proposal_doc, proposal_doc_id, proposal_doc_ver) =
-        common::create_dummy_doc(doc_types::PROPOSAL_UUID_TYPE).unwrap();
+        common::create_dummy_doc(deprecated::PROPOSAL_DOCUMENT_UUID_TYPE).unwrap();
     let (template_doc, template_doc_id, template_doc_ver) =
-        common::create_dummy_doc(doc_types::deprecated::COMMENT_TEMPLATE_UUID_TYPE).unwrap();
+        common::create_dummy_doc(deprecated::COMMENT_TEMPLATE_UUID_TYPE).unwrap();
 
     let uuid_v7 = UuidV7::new();
     let (doc, ..) = common::create_dummy_signed_doc(
         serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": doc_types::PROPOSAL_COMMENT_DOC.clone(),
+            "type": doc_types::PROPOSAL_COMMENT.clone(),
             "id": uuid_v7.to_string(),
             "ver": uuid_v7.to_string(),
             "template": {
@@ -46,9 +48,9 @@ async fn test_valid_comment_doc() {
 #[tokio::test]
 async fn test_valid_comment_doc_old_type() {
     let (proposal_doc, proposal_doc_id, proposal_doc_ver) =
-        common::create_dummy_doc(doc_types::PROPOSAL_UUID_TYPE).unwrap();
+        common::create_dummy_doc(deprecated::PROPOSAL_DOCUMENT_UUID_TYPE).unwrap();
     let (template_doc, template_doc_id, template_doc_ver) =
-        common::create_dummy_doc(doc_types::deprecated::COMMENT_TEMPLATE_UUID_TYPE).unwrap();
+        common::create_dummy_doc(deprecated::COMMENT_TEMPLATE_UUID_TYPE).unwrap();
 
     let uuid_v7 = UuidV7::new();
     let (doc, ..) = common::create_dummy_signed_doc(
@@ -56,7 +58,7 @@ async fn test_valid_comment_doc_old_type() {
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
             // Using old (single uuid)
-            "type": doc_types::deprecated::COMMENT_DOCUMENT_UUID_TYPE,
+            "type": deprecated::COMMENT_DOCUMENT_UUID_TYPE,
             "id": uuid_v7.to_string(),
             "ver": uuid_v7.to_string(),
             "template": {
@@ -87,9 +89,9 @@ async fn test_valid_comment_doc_with_reply() {
     let empty_json = serde_json::to_vec(&serde_json::json!({})).unwrap();
 
     let (proposal_doc, proposal_doc_id, proposal_doc_ver) =
-        common::create_dummy_doc(doc_types::PROPOSAL_UUID_TYPE).unwrap();
+        common::create_dummy_doc(deprecated::PROPOSAL_DOCUMENT_UUID_TYPE).unwrap();
     let (template_doc, template_doc_id, template_doc_ver) =
-        common::create_dummy_doc(doc_types::deprecated::COMMENT_TEMPLATE_UUID_TYPE).unwrap();
+        common::create_dummy_doc(deprecated::COMMENT_TEMPLATE_UUID_TYPE).unwrap();
 
     let comment_doc_id = UuidV7::new();
     let comment_doc_ver = UuidV7::new();
@@ -97,7 +99,7 @@ async fn test_valid_comment_doc_with_reply() {
         .with_json_metadata(serde_json::json!({
             "id": comment_doc_id,
             "ver": comment_doc_ver,
-            "type": doc_types::PROPOSAL_COMMENT_DOC.clone(),
+            "type": doc_types::PROPOSAL_COMMENT.clone(),
             "content-type": ContentType::Json.to_string(),
             "template": { "id": template_doc_id.to_string(), "ver": template_doc_ver.to_string() },
             "ref": {
@@ -114,7 +116,7 @@ async fn test_valid_comment_doc_with_reply() {
         serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": doc_types::PROPOSAL_COMMENT_DOC.clone(),
+            "type": doc_types::PROPOSAL_COMMENT.clone(),
             "id": uuid_v7.to_string(),
             "ver": uuid_v7.to_string(),
             "template": {
@@ -147,16 +149,17 @@ async fn test_valid_comment_doc_with_reply() {
 
 #[tokio::test]
 async fn test_invalid_comment_doc() {
-    let (proposal_doc, ..) = common::create_dummy_doc(doc_types::PROPOSAL_UUID_TYPE).unwrap();
+    let (proposal_doc, ..) =
+        common::create_dummy_doc(deprecated::PROPOSAL_DOCUMENT_UUID_TYPE).unwrap();
     let (template_doc, template_doc_id, template_doc_ver) =
-        common::create_dummy_doc(doc_types::deprecated::COMMENT_TEMPLATE_UUID_TYPE).unwrap();
+        common::create_dummy_doc(deprecated::COMMENT_TEMPLATE_UUID_TYPE).unwrap();
 
     let uuid_v7 = UuidV7::new();
     let (doc, ..) = common::create_dummy_signed_doc(
         serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": doc_types::PROPOSAL_COMMENT_DOC.clone(),
+            "type": doc_types::PROPOSAL_COMMENT.clone(),
             "id": uuid_v7.to_string(),
             "ver": uuid_v7.to_string(),
             "template": {

--- a/rust/signed_doc/tests/comment.rs
+++ b/rust/signed_doc/tests/comment.rs
@@ -8,16 +8,55 @@ mod common;
 #[tokio::test]
 async fn test_valid_comment_doc() {
     let (proposal_doc, proposal_doc_id, proposal_doc_ver) =
-        common::create_dummy_doc(doc_types::PROPOSAL_DOCUMENT_UUID_TYPE).unwrap();
+        common::create_dummy_doc(doc_types::PROPOSAL_UUID_TYPE).unwrap();
     let (template_doc, template_doc_id, template_doc_ver) =
-        common::create_dummy_doc(doc_types::COMMENT_TEMPLATE_UUID_TYPE).unwrap();
+        common::create_dummy_doc(doc_types::deprecated::COMMENT_TEMPLATE_UUID_TYPE).unwrap();
 
     let uuid_v7 = UuidV7::new();
     let (doc, ..) = common::create_dummy_signed_doc(
         serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": doc_types::COMMENT_DOCUMENT_UUID_TYPE,
+            "type": doc_types::PROPOSAL_COMMENT_DOC.clone(),
+            "id": uuid_v7.to_string(),
+            "ver": uuid_v7.to_string(),
+            "template": {
+              "id": template_doc_id,
+              "ver": template_doc_ver
+            },
+            "ref": {
+                "id": proposal_doc_id,
+                "ver": proposal_doc_ver
+            }
+        }),
+        serde_json::to_vec(&serde_json::Value::Null).unwrap(),
+        RoleId::Role0,
+    )
+    .unwrap();
+
+    let mut provider = TestCatalystSignedDocumentProvider::default();
+    provider.add_document(template_doc).unwrap();
+    provider.add_document(proposal_doc).unwrap();
+
+    let is_valid = validator::validate(&doc, &provider).await.unwrap();
+
+    assert!(is_valid);
+}
+
+#[tokio::test]
+async fn test_valid_comment_doc_old_type() {
+    let (proposal_doc, proposal_doc_id, proposal_doc_ver) =
+        common::create_dummy_doc(doc_types::PROPOSAL_UUID_TYPE).unwrap();
+    let (template_doc, template_doc_id, template_doc_ver) =
+        common::create_dummy_doc(doc_types::deprecated::COMMENT_TEMPLATE_UUID_TYPE).unwrap();
+
+    let uuid_v7 = UuidV7::new();
+    let (doc, ..) = common::create_dummy_signed_doc(
+        serde_json::json!({
+            "content-type": ContentType::Json.to_string(),
+            "content-encoding": ContentEncoding::Brotli.to_string(),
+            // Using old (single uuid)
+            "type": doc_types::deprecated::COMMENT_DOCUMENT_UUID_TYPE,
             "id": uuid_v7.to_string(),
             "ver": uuid_v7.to_string(),
             "template": {
@@ -48,9 +87,9 @@ async fn test_valid_comment_doc_with_reply() {
     let empty_json = serde_json::to_vec(&serde_json::json!({})).unwrap();
 
     let (proposal_doc, proposal_doc_id, proposal_doc_ver) =
-        common::create_dummy_doc(doc_types::PROPOSAL_DOCUMENT_UUID_TYPE).unwrap();
+        common::create_dummy_doc(doc_types::PROPOSAL_UUID_TYPE).unwrap();
     let (template_doc, template_doc_id, template_doc_ver) =
-        common::create_dummy_doc(doc_types::COMMENT_TEMPLATE_UUID_TYPE).unwrap();
+        common::create_dummy_doc(doc_types::deprecated::COMMENT_TEMPLATE_UUID_TYPE).unwrap();
 
     let comment_doc_id = UuidV7::new();
     let comment_doc_ver = UuidV7::new();
@@ -58,7 +97,7 @@ async fn test_valid_comment_doc_with_reply() {
         .with_json_metadata(serde_json::json!({
             "id": comment_doc_id,
             "ver": comment_doc_ver,
-            "type": doc_types::COMMENT_DOCUMENT_UUID_TYPE,
+            "type": doc_types::PROPOSAL_COMMENT_DOC.clone(),
             "content-type": ContentType::Json.to_string(),
             "template": { "id": template_doc_id.to_string(), "ver": template_doc_ver.to_string() },
             "ref": {
@@ -75,7 +114,7 @@ async fn test_valid_comment_doc_with_reply() {
         serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": doc_types::COMMENT_DOCUMENT_UUID_TYPE,
+            "type": doc_types::PROPOSAL_COMMENT_DOC.clone(),
             "id": uuid_v7.to_string(),
             "ver": uuid_v7.to_string(),
             "template": {
@@ -108,17 +147,16 @@ async fn test_valid_comment_doc_with_reply() {
 
 #[tokio::test]
 async fn test_invalid_comment_doc() {
-    let (proposal_doc, ..) =
-        common::create_dummy_doc(doc_types::PROPOSAL_DOCUMENT_UUID_TYPE).unwrap();
+    let (proposal_doc, ..) = common::create_dummy_doc(doc_types::PROPOSAL_UUID_TYPE).unwrap();
     let (template_doc, template_doc_id, template_doc_ver) =
-        common::create_dummy_doc(doc_types::COMMENT_TEMPLATE_UUID_TYPE).unwrap();
+        common::create_dummy_doc(doc_types::deprecated::COMMENT_TEMPLATE_UUID_TYPE).unwrap();
 
     let uuid_v7 = UuidV7::new();
     let (doc, ..) = common::create_dummy_signed_doc(
         serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": doc_types::COMMENT_DOCUMENT_UUID_TYPE,
+            "type": doc_types::PROPOSAL_COMMENT_DOC.clone(),
             "id": uuid_v7.to_string(),
             "ver": uuid_v7.to_string(),
             "template": {

--- a/rust/signed_doc/tests/common/mod.rs
+++ b/rust/signed_doc/tests/common/mod.rs
@@ -27,6 +27,29 @@ pub fn test_metadata() -> (UuidV7, UuidV4, serde_json::Value) {
     (uuid_v7, uuid_v4, metadata_fields)
 }
 
+pub fn test_metadata_specific_type(
+    uuid_v4: Option<UuidV4>, uuid_v7: Option<UuidV7>,
+) -> (UuidV7, UuidV4, serde_json::Value) {
+    let uuid_v7 = uuid_v7.unwrap_or_else(UuidV7::new);
+    let uuid_v4 = uuid_v4.unwrap_or_else(UuidV4::new);
+
+    let metadata_fields = serde_json::json!({
+        "content-type": ContentType::Json.to_string(),
+        "content-encoding": ContentEncoding::Brotli.to_string(),
+        "type": uuid_v4.to_string(),
+        "id": uuid_v7.to_string(),
+        "ver": uuid_v7.to_string(),
+        "ref": {"id": uuid_v7.to_string(), "ver": uuid_v7.to_string()},
+        "reply": {"id": uuid_v7.to_string(), "ver": uuid_v7.to_string()},
+        "template": {"id": uuid_v7.to_string(), "ver": uuid_v7.to_string()},
+        "section": "$".to_string(),
+        "collabs": vec!["Alex1".to_string(), "Alex2".to_string()],
+        "parameters": {"id": uuid_v7.to_string(), "ver": uuid_v7.to_string()},
+    });
+
+    (uuid_v7, uuid_v4, metadata_fields)
+}
+
 pub fn create_dummy_key_pair(
     role_index: RoleId,
 ) -> anyhow::Result<(

--- a/rust/signed_doc/tests/decoding.rs
+++ b/rust/signed_doc/tests/decoding.rs
@@ -9,34 +9,6 @@ use ed25519_dalek::ed25519::signature::Signer;
 mod common;
 
 #[test]
-fn catalyst_signed_doc_cbor_roundtrip_test() {
-    let (uuid_v7, uuid_v4, metadata_fields) = common::test_metadata();
-    let (sk, _, kid) = create_dummy_key_pair(RoleId::Role0).unwrap();
-
-    let content = serde_json::to_vec(&serde_json::Value::Null).unwrap();
-
-    let doc = Builder::new()
-        .with_json_metadata(metadata_fields.clone())
-        .unwrap()
-        .with_decoded_content(content.clone())
-        .add_signature(|m| sk.sign(&m).to_vec(), &kid)
-        .unwrap()
-        .build();
-
-    assert!(!doc.problem_report().is_problematic());
-
-    let bytes: Vec<u8> = doc.try_into().unwrap();
-    let decoded: CatalystSignedDocument = bytes.as_slice().try_into().unwrap();
-    let extra_fields: ExtraFields = serde_json::from_value(metadata_fields).unwrap();
-
-    assert_eq!(decoded.doc_type().unwrap(), uuid_v4);
-    assert_eq!(decoded.doc_id().unwrap(), uuid_v7);
-    assert_eq!(decoded.doc_ver().unwrap(), uuid_v7);
-    assert_eq!(decoded.doc_content().decoded_bytes().unwrap(), &content);
-    assert_eq!(decoded.doc_meta(), &extra_fields);
-}
-
-#[test]
 fn catalyst_signed_doc_cbor_roundtrip_kid_as_id_test() {
     let (_, _, metadata_fields) = common::test_metadata();
     let (sk, _, kid) = create_dummy_key_pair(RoleId::Role0).unwrap();
@@ -180,4 +152,134 @@ async fn catalyst_signed_doc_parameters_aliases_test() {
         .try_into()
         .unwrap();
     assert!(doc.problem_report().is_problematic());
+}
+
+type PostCheck = dyn Fn(&CatalystSignedDocument) -> bool;
+
+struct TestCase {
+    name: &'static str,
+    bytes_gen: Box<dyn Fn() -> Vec<u8>>,
+    // If the provided bytes can be even decoded without error (valid COSE or not).
+    // If set to `false` all further checks will not even happen.
+    can_decode: bool,
+    // If the decoded doc is a valid `CatalystSignedDocument`, underlying problem report is empty.
+    valid_doc: bool,
+    post_checks: Option<Box<PostCheck>>,
+}
+
+fn decoding_empty_bytes_case() -> TestCase {
+    TestCase {
+        name: "Decoding empty bytes",
+        bytes_gen: Box::new(Vec::new),
+        can_decode: false,
+        valid_doc: false,
+        post_checks: None,
+    }
+}
+
+#[allow(clippy::unwrap_used)]
+fn signed_doc_with_all_fields_case() -> TestCase {
+    let uuid_v7 = UuidV7::new();
+    let uuid_v4 = UuidV4::new();
+    let (sk, _, kid) = create_dummy_key_pair(RoleId::Role0).unwrap();
+
+    TestCase {
+        name: "Catalyst Signed Doc with ALL defined metadata fields and signatures",
+        bytes_gen: Box::new({
+            let kid = kid.clone();
+            move || {
+                Builder::new()
+                    .with_json_metadata(serde_json::json!({
+                        "content-type": ContentType::Json.to_string(),
+                        "content-encoding": ContentEncoding::Brotli.to_string(),
+                        "type": uuid_v4.to_string(),
+                        "id": uuid_v7.to_string(),
+                        "ver": uuid_v7.to_string(),
+                        "ref": {"id": uuid_v7.to_string(), "ver": uuid_v7.to_string()},
+                        "reply": {"id": uuid_v7.to_string(), "ver": uuid_v7.to_string()},
+                        "template": {"id": uuid_v7.to_string(), "ver": uuid_v7.to_string()},
+                        "section": "$".to_string(),
+                        "collabs": vec!["Alex1".to_string(), "Alex2".to_string()],
+                        "parameters": {"id": uuid_v7.to_string(), "ver": uuid_v7.to_string()},
+                    }))
+                    .unwrap()
+                    .with_decoded_content(serde_json::to_vec(&serde_json::Value::Null).unwrap())
+                    .add_signature(|m| sk.sign(&m).to_vec(), &kid)
+                    .unwrap()
+                    .build()
+                    .try_into()
+                    .unwrap()
+            }
+        }),
+        can_decode: true,
+        valid_doc: true,
+        post_checks: Some(Box::new({
+            move |doc| {
+                (doc.doc_type().unwrap() == uuid_v4)
+                    && (doc.doc_id().unwrap() == uuid_v7)
+                    && (doc.doc_ver().unwrap() == uuid_v7)
+                    && (doc.doc_content_type().unwrap() == ContentType::Json)
+                    && (doc.doc_content_encoding().unwrap() == ContentEncoding::Brotli)
+                    && (doc.doc_meta().doc_ref().unwrap()
+                        == DocumentRef {
+                            id: uuid_v7,
+                            ver: uuid_v7,
+                        })
+                    && (doc.doc_meta().reply().unwrap()
+                        == DocumentRef {
+                            id: uuid_v7,
+                            ver: uuid_v7,
+                        })
+                    && (doc.doc_meta().template().unwrap()
+                        == DocumentRef {
+                            id: uuid_v7,
+                            ver: uuid_v7,
+                        })
+                    && (doc.doc_meta().parameters().unwrap()
+                        == DocumentRef {
+                            id: uuid_v7,
+                            ver: uuid_v7,
+                        })
+                    && (doc.doc_meta().section().unwrap() == &"$".parse::<Section>().unwrap())
+                    && (doc.doc_meta().collabs() == ["Alex1".to_string(), "Alex2".to_string()])
+                    && (doc.doc_content().decoded_bytes().unwrap()
+                        == serde_json::to_vec(&serde_json::Value::Null).unwrap())
+                    && (doc.kids() == vec![kid.clone()])
+            }
+        })),
+    }
+}
+
+#[test]
+fn catalyst_signed_doc_decoding_test() {
+    let test_cases = [
+        decoding_empty_bytes_case(),
+        signed_doc_with_all_fields_case(),
+    ];
+
+    for case in test_cases {
+        let bytes = case.bytes_gen.as_ref()();
+        let doc_res = CatalystSignedDocument::try_from(bytes.as_slice());
+        assert_eq!(doc_res.is_ok(), case.can_decode, "Case: [{}]", case.name);
+        if let Ok(doc) = doc_res {
+            assert_eq!(
+                !doc.problem_report().is_problematic(),
+                case.valid_doc,
+                "Case: [{}]. Problem report: {:?}",
+                case.name,
+                doc.problem_report()
+            );
+
+            if let Some(post_checks) = &case.post_checks {
+                assert!((post_checks.as_ref())(&doc), "Case: [{}]", case.name);
+            }
+
+            assert_eq!(
+                bytes,
+                Vec::<u8>::try_from(doc).unwrap(),
+                "Case: [{}]. Asymmetric encoding and decoding procedure",
+                case.name
+            );
+        }
+    }
 }

--- a/rust/signed_doc/tests/decoding.rs
+++ b/rust/signed_doc/tests/decoding.rs
@@ -10,7 +10,16 @@ mod common;
 
 #[test]
 fn catalyst_signed_doc_cbor_roundtrip_kid_as_id_test() {
-    let (_, _, metadata_fields) = common::test_metadata();
+    catalyst_signed_doc_cbor_roundtrip_kid_as_id(common::test_metadata());
+    catalyst_signed_doc_cbor_roundtrip_kid_as_id(common::test_metadata_specific_type(
+        Some(doc_types::PROPOSAL_UUID_TYPE.try_into().unwrap()),
+        None,
+    ));
+}
+
+#[allow(clippy::unwrap_used)]
+fn catalyst_signed_doc_cbor_roundtrip_kid_as_id(data: (UuidV7, UuidV4, serde_json::Value)) {
+    let (_, _, metadata_fields) = data;
     let (sk, _, kid) = create_dummy_key_pair(RoleId::Role0).unwrap();
     // transform Catalyst ID URI form to the ID form
     let kid = kid.as_id();
@@ -29,9 +38,19 @@ fn catalyst_signed_doc_cbor_roundtrip_kid_as_id_test() {
 }
 
 #[tokio::test]
-#[allow(clippy::too_many_lines)]
 async fn catalyst_signed_doc_parameters_aliases_test() {
-    let (_, _, metadata_fields) = common::test_metadata();
+    catalyst_signed_doc_parameters_aliases(common::test_metadata()).await;
+    catalyst_signed_doc_parameters_aliases(common::test_metadata_specific_type(
+        Some(doc_types::PROPOSAL_UUID_TYPE.try_into().unwrap()),
+        None,
+    ))
+    .await;
+}
+
+#[allow(clippy::unwrap_used)]
+#[allow(clippy::too_many_lines)]
+async fn catalyst_signed_doc_parameters_aliases(data: (UuidV7, UuidV4, serde_json::Value)) {
+    let (_, _, metadata_fields) = data;
     let (sk, pk, kid) = common::create_dummy_key_pair(RoleId::Role0).unwrap();
     let mut provider = TestVerifyingKeyProvider::default();
     provider.add_pk(kid.clone(), pk);
@@ -215,7 +234,7 @@ fn signed_doc_with_all_fields_case() -> TestCase {
         valid_doc: true,
         post_checks: Some(Box::new({
             move |doc| {
-                (doc.doc_type().unwrap() == uuid_v4)
+                (doc.doc_type().unwrap() == &DocType::from(uuid_v4))
                     && (doc.doc_id().unwrap() == uuid_v7)
                     && (doc.doc_ver().unwrap() == uuid_v7)
                     && (doc.doc_content_type().unwrap() == ContentType::Json)

--- a/rust/signed_doc/tests/decoding.rs
+++ b/rust/signed_doc/tests/decoding.rs
@@ -1,6 +1,6 @@
 //! Integration test for COSE decoding part.
 
-use catalyst_signed_doc::{providers::tests::TestVerifyingKeyProvider, *};
+use catalyst_signed_doc::{doc_types::deprecated, providers::tests::TestVerifyingKeyProvider, *};
 use catalyst_types::catalyst_id::role_index::RoleId;
 use common::create_dummy_key_pair;
 use coset::TaggedCborSerializable;
@@ -12,7 +12,7 @@ mod common;
 fn catalyst_signed_doc_cbor_roundtrip_kid_as_id_test() {
     catalyst_signed_doc_cbor_roundtrip_kid_as_id(common::test_metadata());
     catalyst_signed_doc_cbor_roundtrip_kid_as_id(common::test_metadata_specific_type(
-        Some(doc_types::PROPOSAL_UUID_TYPE.try_into().unwrap()),
+        Some(deprecated::PROPOSAL_DOCUMENT_UUID_TYPE.try_into().unwrap()),
         None,
     ));
 }
@@ -41,7 +41,7 @@ fn catalyst_signed_doc_cbor_roundtrip_kid_as_id(data: (UuidV7, UuidV4, serde_jso
 async fn catalyst_signed_doc_parameters_aliases_test() {
     catalyst_signed_doc_parameters_aliases(common::test_metadata()).await;
     catalyst_signed_doc_parameters_aliases(common::test_metadata_specific_type(
-        Some(doc_types::PROPOSAL_UUID_TYPE.try_into().unwrap()),
+        Some(deprecated::PROPOSAL_DOCUMENT_UUID_TYPE.try_into().unwrap()),
         None,
     ))
     .await;

--- a/rust/signed_doc/tests/proposal.rs
+++ b/rust/signed_doc/tests/proposal.rs
@@ -15,7 +15,7 @@ async fn test_valid_proposal_doc() {
         serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": doc_types::PROPOSAL_DOC_TYPE.clone(),
+            "type": doc_types::PROPOSAL.clone(),
             "id": uuid_v7.to_string(),
             "ver": uuid_v7.to_string(),
             "template": {
@@ -79,7 +79,7 @@ async fn test_valid_proposal_doc_with_empty_provider() {
         serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": doc_types::PROPOSAL_DOC_TYPE.clone(),
+            "type": doc_types::PROPOSAL.clone(),
             "id": uuid_v7.to_string(),
             "ver": uuid_v7.to_string(),
             "template": {
@@ -106,7 +106,7 @@ async fn test_invalid_proposal_doc() {
         serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": doc_types::PROPOSAL_DOC_TYPE.clone(),
+            "type": doc_types::PROPOSAL.clone(),
             "id": uuid_v7.to_string(),
             "ver": uuid_v7.to_string(),
             // without specifying template id

--- a/rust/signed_doc/tests/proposal.rs
+++ b/rust/signed_doc/tests/proposal.rs
@@ -8,14 +8,46 @@ mod common;
 #[tokio::test]
 async fn test_valid_proposal_doc() {
     let (template_doc, template_doc_id, template_doc_ver) =
-        common::create_dummy_doc(doc_types::PROPOSAL_TEMPLATE_UUID_TYPE).unwrap();
+        common::create_dummy_doc(doc_types::deprecated::PROPOSAL_TEMPLATE_UUID_TYPE).unwrap();
 
     let uuid_v7 = UuidV7::new();
     let (doc, ..) = common::create_dummy_signed_doc(
         serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": doc_types::PROPOSAL_DOCUMENT_UUID_TYPE,
+            "type": doc_types::PROPOSAL_DOC_TYPE.clone(),
+            "id": uuid_v7.to_string(),
+            "ver": uuid_v7.to_string(),
+            "template": {
+              "id": template_doc_id,
+              "ver": template_doc_ver
+            },
+        }),
+        serde_json::to_vec(&serde_json::Value::Null).unwrap(),
+        RoleId::Proposer,
+    )
+    .unwrap();
+
+    let mut provider = TestCatalystSignedDocumentProvider::default();
+    provider.add_document(template_doc).unwrap();
+
+    let is_valid = validator::validate(&doc, &provider).await.unwrap();
+
+    assert!(is_valid);
+}
+
+#[tokio::test]
+async fn test_valid_proposal_doc_old_type() {
+    let (template_doc, template_doc_id, template_doc_ver) =
+        common::create_dummy_doc(doc_types::deprecated::PROPOSAL_TEMPLATE_UUID_TYPE).unwrap();
+
+    let uuid_v7 = UuidV7::new();
+    let (doc, ..) = common::create_dummy_signed_doc(
+        serde_json::json!({
+            "content-type": ContentType::Json.to_string(),
+            "content-encoding": ContentEncoding::Brotli.to_string(),
+            // Using old (single uuid)
+            "type": doc_types::deprecated::PROPOSAL_DOCUMENT_UUID_TYPE,
             "id": uuid_v7.to_string(),
             "ver": uuid_v7.to_string(),
             "template": {
@@ -47,7 +79,7 @@ async fn test_valid_proposal_doc_with_empty_provider() {
         serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": doc_types::PROPOSAL_DOCUMENT_UUID_TYPE,
+            "type": doc_types::PROPOSAL_DOC_TYPE.clone(),
             "id": uuid_v7.to_string(),
             "ver": uuid_v7.to_string(),
             "template": {
@@ -74,7 +106,7 @@ async fn test_invalid_proposal_doc() {
         serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": doc_types::PROPOSAL_DOCUMENT_UUID_TYPE,
+            "type": doc_types::PROPOSAL_DOC_TYPE.clone(),
             "id": uuid_v7.to_string(),
             "ver": uuid_v7.to_string(),
             // without specifying template id

--- a/rust/signed_doc/tests/submission.rs
+++ b/rust/signed_doc/tests/submission.rs
@@ -8,14 +8,47 @@ mod common;
 #[tokio::test]
 async fn test_valid_submission_action() {
     let (proposal_doc, proposal_doc_id, proposal_doc_ver) =
-        common::create_dummy_doc(doc_types::PROPOSAL_DOCUMENT_UUID_TYPE).unwrap();
+        common::create_dummy_doc(doc_types::PROPOSAL_UUID_TYPE).unwrap();
 
     let uuid_v7 = UuidV7::new();
     let (doc, ..) = common::create_dummy_signed_doc(
         serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": doc_types::PROPOSAL_ACTION_DOCUMENT_UUID_TYPE,
+            "type": doc_types::PROPOSAL_ACTION_DOC.clone(),
+            "id": uuid_v7.to_string(),
+            "ver": uuid_v7.to_string(),
+            "ref": {
+                "id": proposal_doc_id,
+                "ver": proposal_doc_ver
+            },
+        }),
+        serde_json::to_vec(&serde_json::json!({
+            "action": "final"
+        }))
+        .unwrap(),
+        RoleId::Proposer,
+    )
+    .unwrap();
+
+    let mut provider = TestCatalystSignedDocumentProvider::default();
+    provider.add_document(proposal_doc).unwrap();
+    let is_valid = validator::validate(&doc, &provider).await.unwrap();
+    assert!(is_valid, "{:?}", doc.problem_report());
+}
+
+#[tokio::test]
+async fn test_valid_submission_action_old_type() {
+    let (proposal_doc, proposal_doc_id, proposal_doc_ver) =
+        common::create_dummy_doc(doc_types::PROPOSAL_UUID_TYPE).unwrap();
+
+    let uuid_v7 = UuidV7::new();
+    let (doc, ..) = common::create_dummy_signed_doc(
+        serde_json::json!({
+            "content-type": ContentType::Json.to_string(),
+            "content-encoding": ContentEncoding::Brotli.to_string(),
+            // Using old (single uuid)
+            "type": doc_types::deprecated::PROPOSAL_ACTION_DOCUMENT_UUID_TYPE,
             "id": uuid_v7.to_string(),
             "ver": uuid_v7.to_string(),
             "ref": {
@@ -47,7 +80,7 @@ async fn test_valid_submission_action_with_empty_provider() {
         serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": doc_types::PROPOSAL_ACTION_DOCUMENT_UUID_TYPE,
+            "type": doc_types::PROPOSAL_ACTION_DOC.clone(),
             "id": uuid_v7.to_string(),
             "ver": uuid_v7.to_string(),
             "ref": {
@@ -78,7 +111,7 @@ async fn test_invalid_submission_action() {
         serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": doc_types::PROPOSAL_ACTION_DOCUMENT_UUID_TYPE,
+            "type": doc_types::PROPOSAL_ACTION_DOC.clone(),
             "id": uuid_v7.to_string(),
             "ver": uuid_v7.to_string(),
             // without specifying ref
@@ -98,13 +131,13 @@ async fn test_invalid_submission_action() {
 
     // corrupted JSON
     let (proposal_doc, proposal_doc_id, proposal_doc_ver) =
-        common::create_dummy_doc(doc_types::PROPOSAL_DOCUMENT_UUID_TYPE).unwrap();
+        common::create_dummy_doc(doc_types::PROPOSAL_UUID_TYPE).unwrap();
     let uuid_v7 = UuidV7::new();
     let (doc, ..) = common::create_dummy_signed_doc(
         serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": doc_types::PROPOSAL_ACTION_DOCUMENT_UUID_TYPE,
+            "type": doc_types::ACTION_UUID_TYPE,
             "id": uuid_v7.to_string(),
             "ver": uuid_v7.to_string(),
             "ref": {
@@ -124,13 +157,13 @@ async fn test_invalid_submission_action() {
 
     // empty content
     let (proposal_doc, proposal_doc_id, proposal_doc_ver) =
-        common::create_dummy_doc(doc_types::PROPOSAL_DOCUMENT_UUID_TYPE).unwrap();
+        common::create_dummy_doc(doc_types::PROPOSAL_UUID_TYPE).unwrap();
     let uuid_v7 = UuidV7::new();
     let (doc, ..) = common::create_dummy_signed_doc(
         serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": doc_types::PROPOSAL_ACTION_DOCUMENT_UUID_TYPE,
+            "type": doc_types::PROPOSAL_ACTION_DOC.clone(),
             "id": uuid_v7.to_string(),
             "ver": uuid_v7.to_string(),
             "ref": {

--- a/rust/signed_doc/tests/submission.rs
+++ b/rust/signed_doc/tests/submission.rs
@@ -1,6 +1,8 @@
 //! Test for proposal submission action.
 
-use catalyst_signed_doc::{providers::tests::TestCatalystSignedDocumentProvider, *};
+use catalyst_signed_doc::{
+    doc_types::deprecated, providers::tests::TestCatalystSignedDocumentProvider, *,
+};
 use catalyst_types::catalyst_id::role_index::RoleId;
 
 mod common;
@@ -8,14 +10,14 @@ mod common;
 #[tokio::test]
 async fn test_valid_submission_action() {
     let (proposal_doc, proposal_doc_id, proposal_doc_ver) =
-        common::create_dummy_doc(doc_types::PROPOSAL_UUID_TYPE).unwrap();
+        common::create_dummy_doc(deprecated::PROPOSAL_DOCUMENT_UUID_TYPE).unwrap();
 
     let uuid_v7 = UuidV7::new();
     let (doc, ..) = common::create_dummy_signed_doc(
         serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": doc_types::PROPOSAL_ACTION_DOC.clone(),
+            "type": doc_types::PROPOSAL_SUBMISSION_ACTION.clone(),
             "id": uuid_v7.to_string(),
             "ver": uuid_v7.to_string(),
             "ref": {
@@ -40,7 +42,7 @@ async fn test_valid_submission_action() {
 #[tokio::test]
 async fn test_valid_submission_action_old_type() {
     let (proposal_doc, proposal_doc_id, proposal_doc_ver) =
-        common::create_dummy_doc(doc_types::PROPOSAL_UUID_TYPE).unwrap();
+        common::create_dummy_doc(deprecated::PROPOSAL_DOCUMENT_UUID_TYPE).unwrap();
 
     let uuid_v7 = UuidV7::new();
     let (doc, ..) = common::create_dummy_signed_doc(
@@ -48,7 +50,7 @@ async fn test_valid_submission_action_old_type() {
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
             // Using old (single uuid)
-            "type": doc_types::deprecated::PROPOSAL_ACTION_DOCUMENT_UUID_TYPE,
+            "type": deprecated::PROPOSAL_ACTION_DOCUMENT_UUID_TYPE,
             "id": uuid_v7.to_string(),
             "ver": uuid_v7.to_string(),
             "ref": {
@@ -80,7 +82,7 @@ async fn test_valid_submission_action_with_empty_provider() {
         serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": doc_types::PROPOSAL_ACTION_DOC.clone(),
+            "type": doc_types::PROPOSAL_SUBMISSION_ACTION.clone(),
             "id": uuid_v7.to_string(),
             "ver": uuid_v7.to_string(),
             "ref": {
@@ -111,7 +113,7 @@ async fn test_invalid_submission_action() {
         serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": doc_types::PROPOSAL_ACTION_DOC.clone(),
+            "type": doc_types::PROPOSAL_SUBMISSION_ACTION.clone(),
             "id": uuid_v7.to_string(),
             "ver": uuid_v7.to_string(),
             // without specifying ref
@@ -131,13 +133,13 @@ async fn test_invalid_submission_action() {
 
     // corrupted JSON
     let (proposal_doc, proposal_doc_id, proposal_doc_ver) =
-        common::create_dummy_doc(doc_types::PROPOSAL_UUID_TYPE).unwrap();
+        common::create_dummy_doc(deprecated::PROPOSAL_DOCUMENT_UUID_TYPE).unwrap();
     let uuid_v7 = UuidV7::new();
     let (doc, ..) = common::create_dummy_signed_doc(
         serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": doc_types::ACTION_UUID_TYPE,
+            "type": deprecated::PROPOSAL_ACTION_DOCUMENT_UUID_TYPE,
             "id": uuid_v7.to_string(),
             "ver": uuid_v7.to_string(),
             "ref": {
@@ -157,13 +159,13 @@ async fn test_invalid_submission_action() {
 
     // empty content
     let (proposal_doc, proposal_doc_id, proposal_doc_ver) =
-        common::create_dummy_doc(doc_types::PROPOSAL_UUID_TYPE).unwrap();
+        common::create_dummy_doc(deprecated::PROPOSAL_DOCUMENT_UUID_TYPE).unwrap();
     let uuid_v7 = UuidV7::new();
     let (doc, ..) = common::create_dummy_signed_doc(
         serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": doc_types::PROPOSAL_ACTION_DOC.clone(),
+            "type": doc_types::PROPOSAL_SUBMISSION_ACTION.clone(),
             "id": uuid_v7.to_string(),
             "ver": uuid_v7.to_string(),
             "ref": {


### PR DESCRIPTION
# Description

New implementation of `DocType`

Commit pick from https://github.com/input-output-hk/catalyst-libs/pull/338

# Changes
Additional modifications were introduced beyond what was originally approved.
- `rust/signed_doc/src/validator/mod.rs` -> Rule should be backward compatible. Confirm with frontend that single  UUIDv4 is now changing to list of UUIDv4 eg. `7808d2ba-d511-40af-84e8-c0d1625fdfdc` to `[7808d2ba-d511-40af-84e8-c0d1625fdfdc]`
- Rename + Restructure `doc_types/mod` because the old one is confusing

## Related Issue(s)
- Frontend - https://github.com/input-output-hk/catalyst-voices/pull/2571
- Catgateway - https://github.com/input-output-hk/catalyst-voices/pull/2716
- Original PR #328 

## Breaking Changes

Must not be any breaking change, should be compatible with the old implementation

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
