### PR TITLE
fix(rust/cardano-chain-follower): Mithril downloader log error

### DIFF
--- a/rust/cardano-chain-follower/src/mithril_turbo_downloader.rs
+++ b/rust/cardano-chain-follower/src/mithril_turbo_downloader.rs
@@ -169,7 +169,10 @@ impl Inner {
                 }
             } else {
                 // No dedup, just extract it into the tmp directory as-is.
-                entry.unpack_in(&tmp_dir)?;
+                entry.unpack_in(&tmp_dir).inspect_err(|e| {
+                    // Logging IO error, ErrorKind
+                    error!("{}", e.kind());
+                })?;
                 debug!(chain = %self.cfg.chain, "DeDup: Extracted file {rel_file:?}:{entry_size}");
             }
             new_file!(self, rel_file, abs_file, entry_size);


### PR DESCRIPTION
# Description

Logging IO error, specifically for Mithril downloader

## Related Issue(s)

https://github.com/input-output-hk/catalyst-voices/issues/1379

## Screenshots

Test by limiting the size of the folder. When the disk is full, it will log an error [StorageFull](https://doc.rust-lang.org/std/io/enum.ErrorKind.html#variant.StorageFull) . Other error if any, may be log too
![Screenshot 2568-06-12 at 13 39 00](https://github.com/user-attachments/assets/dd44602c-fd75-4d3f-80c2-9e74d1a06e05)

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
