### PR TITLE
feat(rust/signed-doc): signed doc metadata serde refactoring

### DIFF
--- a/rust/signed_doc/src/builder.rs
+++ b/rust/signed_doc/src/builder.rs
@@ -1,5 +1,5 @@
 //! Catalyst Signed Document Builder.
-use catalyst_types::{catalyst_id::CatalystId, problem_report::ProblemReport};
+use catalyst_types::catalyst_id::CatalystId;
 
 use crate::{
     signature::{tbs_data, Signature},
@@ -40,8 +40,7 @@ impl Builder {
     /// # Errors
     /// - Fails if it is invalid metadata fields JSON object.
     pub fn with_json_metadata(mut self, json: serde_json::Value) -> anyhow::Result<Self> {
-        let metadata = serde_json::from_value(json)?;
-        self.metadata = Metadata::from_metadata_fields(metadata, &ProblemReport::new(""));
+        self.metadata = serde_json::from_value(json)?;
         Ok(self)
     }
 

--- a/rust/signed_doc/src/builder.rs
+++ b/rust/signed_doc/src/builder.rs
@@ -1,5 +1,5 @@
 //! Catalyst Signed Document Builder.
-use catalyst_types::catalyst_id::CatalystId;
+use catalyst_types::{catalyst_id::CatalystId, problem_report::ProblemReport};
 
 use crate::{
     signature::{tbs_data, Signature},
@@ -40,7 +40,7 @@ impl Builder {
     /// # Errors
     /// - Fails if it is invalid metadata fields JSON object.
     pub fn with_json_metadata(mut self, json: serde_json::Value) -> anyhow::Result<Self> {
-        self.metadata = serde_json::from_value(json)?;
+        self.metadata = Metadata::from_json(json, &ProblemReport::new(""));
         Ok(self)
     }
 

--- a/rust/signed_doc/src/metadata/supported_field.rs
+++ b/rust/signed_doc/src/metadata/supported_field.rs
@@ -1,6 +1,9 @@
 //! Catalyst Signed Document unified metadata field.
 
-use std::fmt::{self, Display};
+use std::{
+    borrow::Cow,
+    fmt::{self, Display},
+};
 #[cfg(test)]
 use std::{cmp, convert::Infallible};
 
@@ -14,8 +17,7 @@ use crate::{
 };
 
 /// COSE label. May be either a signed integer or a string.
-#[derive(Copy, Clone, Eq, PartialEq, serde::Deserialize)]
-#[serde(untagged, expecting = "8bit unsigned integer or text")]
+#[derive(Copy, Clone, Eq, PartialEq)]
 enum Label<'a> {
     /// Integer label.
     ///
@@ -46,10 +48,12 @@ impl<'a, C> minicbor::Decode<'a, C> for Label<'a> {
         match d.datatype()? {
             minicbor::data::Type::U8 => d.u8().map(Self::U8),
             minicbor::data::Type::String => d.str().map(Self::Str),
-            _ => Err(minicbor::decode::Error::message(
-                "Datatype is neither 8bit unsigned integer nor text",
-            )
-            .at(d.position())),
+            _ => {
+                Err(minicbor::decode::Error::message(
+                    "Datatype is neither 8bit unsigned integer nor text",
+                )
+                .at(d.position()))
+            },
         }
     }
 }
@@ -168,8 +172,8 @@ impl Display for SupportedLabel {
 
 impl<'de> serde::Deserialize<'de> for SupportedLabel {
     fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
-        let l = Label::deserialize(d)?;
-        Self::from_cose(l).ok_or_else(|| {
+        let l = Cow::deserialize(d)?;
+        Self::from_cose(Label::Str(&l)).ok_or_else(|| {
             serde::de::Error::custom(format!("Not a supported metadata label ({l})"))
         })
     }
@@ -230,13 +234,15 @@ impl minicbor::Decode<'_, crate::decode_context::DecodeContext<'_>> for Supporte
 
         let field = match key {
             SupportedLabel::ContentType => todo!(),
-            SupportedLabel::Id => d
-                .decode_with(&mut catalyst_types::uuid::CborContext::Tagged)
-                .map(Self::Id),
+            SupportedLabel::Id => {
+                d.decode_with(&mut catalyst_types::uuid::CborContext::Tagged)
+                    .map(Self::Id)
+            },
             SupportedLabel::Ref => todo!(),
-            SupportedLabel::Ver => d
-                .decode_with(&mut catalyst_types::uuid::CborContext::Tagged)
-                .map(Self::Ver),
+            SupportedLabel::Ver => {
+                d.decode_with(&mut catalyst_types::uuid::CborContext::Tagged)
+                    .map(Self::Ver)
+            },
             SupportedLabel::Type => d.decode_with(ctx).map(Self::Type),
             SupportedLabel::Reply => todo!(),
             SupportedLabel::Collabs => todo!(),


### PR DESCRIPTION
# Description

Removes `InnerMetdata`. Maintains `serde::Deserialize` impl. Extends `Metadata` api with `from_fields` constructor.  

## Related Issue(s)

Closes #366

## Description of Changes

- Remove `InnerMetadata`.
- Implement `Serialize` for `supported_field` types.
- Implement `Metadata::from_json` – replacing previous impl with `InnerMetadata`.
- Add `Metadata::from_fields` that does the same as `Metadata::from_metadata_fields` used to do, but accepts a vector of `SupportedField`.

## Breaking Changes

No.

## Related Pull Requests

#338 

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
