### PR TITLE
chore(rust/signed-doc): Cleanup Catalyst Signed Document `Builder`, make it type safe, add special test builder (2).

### DIFF
--- a/rust/signed_doc/tests/comment.rs
+++ b/rust/signed_doc/tests/comment.rs
@@ -2,12 +2,95 @@
 //! Require fields: type, id, ver, ref, template, parameters
 //! <https://input-output-hk.github.io/catalyst-libs/architecture/08_concepts/signed_doc/docs/proposal_comment/>
 
+use std::sync::LazyLock;
+
 use catalyst_signed_doc::{
     doc_types::deprecated, providers::tests::TestCatalystSignedDocumentProvider, *,
 };
-use catalyst_types::catalyst_id::role_index::RoleId;
 
-mod common;
+#[allow(clippy::unwrap_used)]
+static DUMMY_PROPOSAL_DOC: LazyLock<CatalystSignedDocument> = LazyLock::new(|| {
+    Builder::new()
+        .with_json_metadata(serde_json::json!({
+            "content-type": ContentType::Json.to_string(),
+            "id": UuidV7::new(),
+            "ver": UuidV7::new(),
+            "type": doc_types::PROPOSAL.clone(),
+        }))
+        .unwrap()
+        .with_json_content(&serde_json::json!({}))
+        .unwrap()
+        .build()
+});
+
+#[allow(clippy::unwrap_used)]
+static DUMMY_BRAND_DOC: LazyLock<CatalystSignedDocument> = LazyLock::new(|| {
+    Builder::new()
+        .with_json_metadata(serde_json::json!({
+            "content-type": ContentType::Json.to_string(),
+            "id": UuidV7::new(),
+            "ver": UuidV7::new(),
+            "type": doc_types::BRAND_PARAMETERS.clone(),
+        }))
+        .unwrap()
+        .with_json_content(&serde_json::json!({}))
+        .unwrap()
+        .build()
+});
+
+#[allow(clippy::unwrap_used)]
+static COMMENT_TEMPLATE_DOC: LazyLock<CatalystSignedDocument> = LazyLock::new(|| {
+    Builder::new()
+        .with_json_metadata(serde_json::json!({
+            "content-type": ContentType::Json.to_string(),
+            "content-encoding": ContentEncoding::Brotli.to_string(),
+            "type": doc_types::PROPOSAL_COMMENT_TEMPLATE.clone(),
+            "id": UuidV7::new(),
+            "ver": UuidV7::new(),
+            "parameters": {
+                "id": DUMMY_BRAND_DOC.doc_id().unwrap(),
+                "ver": DUMMY_BRAND_DOC.doc_ver().unwrap(),
+            }
+        }))
+        .unwrap()
+        .with_json_content(&serde_json::json!({
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {},
+            "required": [],
+            "additionalProperties": false
+        }))
+        .unwrap()
+        .build()
+});
+
+#[allow(clippy::unwrap_used)]
+static COMMENT_REF_DOC: LazyLock<CatalystSignedDocument> = LazyLock::new(|| {
+    Builder::new()
+        .with_json_metadata(serde_json::json!({
+            "content-type": ContentType::Json.to_string(),
+            "content-encoding": ContentEncoding::Brotli.to_string(),
+            "type": doc_types::PROPOSAL_COMMENT.clone(),
+            "id": UuidV7::new(),
+            "ver": UuidV7::new(),
+            "ref": {
+                "id": DUMMY_PROPOSAL_DOC.doc_id().unwrap(),
+                "ver": DUMMY_PROPOSAL_DOC.doc_ver().unwrap(),
+            },
+            "template": {
+                "id": COMMENT_TEMPLATE_DOC.doc_id().unwrap(),
+                "ver": COMMENT_TEMPLATE_DOC.doc_ver().unwrap(),
+            },
+            "parameters": {
+                "id": DUMMY_BRAND_DOC.doc_id().unwrap(),
+                "ver": DUMMY_BRAND_DOC.doc_ver().unwrap(),
+            }
+        }))
+        .unwrap()
+        .with_json_content(&serde_json::json!({}))
+        .unwrap()
+        .build()
+});
 
 // Given a proposal comment document `doc`:
 //
@@ -22,97 +105,42 @@ mod common;
 // The rule requires that the `ref` field in `ref_doc` must match the `ref` field in `doc`
 #[tokio::test]
 async fn test_valid_comment_doc() {
-    let (proposal_doc, proposal_doc_id, proposal_doc_ver) =
-        common::create_dummy_doc(&doc_types::PROPOSAL.clone()).unwrap();
-    let (brand_doc, brand_doc_id, brand_doc_ver) =
-        common::create_dummy_doc(&doc_types::BRAND_PARAMETERS.clone()).unwrap();
-
-    let ref_doc_id = UuidV7::new();
-    let ref_doc_ver = UuidV7::new();
-
-    let template_doc_id = UuidV7::new();
-    let template_doc_ver = UuidV7::new();
-
-    // Create a ref document, which is a proposal comment type
-    let (ref_doc, ..) = common::create_dummy_signed_doc(
-        serde_json::json!(serde_json::json!({
-            "content-type": ContentType::Json.to_string(),
-            "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": doc_types::PROPOSAL_COMMENT.clone(),
-            "id": ref_doc_id.to_string(),
-            "ver": ref_doc_ver.to_string(),
-            "ref": {
-                "id": proposal_doc_id,
-                "ver": proposal_doc_ver
-            },
-            "template": {
-              "id": template_doc_id,
-              "ver": template_doc_ver
-            },
-            "parameters": { "id": brand_doc_id, "ver": brand_doc_ver }})),
-        serde_json::to_vec(&serde_json::Value::Null).unwrap(),
-        RoleId::Role0,
-    )
-    .unwrap();
-
-    // Create a template document
-    let (template_doc, ..) = common::create_dummy_signed_doc(
-        serde_json::json!(serde_json::json!({
-            "content-type": ContentType::Json.to_string(),
-            "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": doc_types::PROPOSAL_COMMENT_TEMPLATE.clone(),
-            "id": template_doc_id.to_string(),
-            "ver": template_doc_ver.to_string(),
-            "parameters": { "id": brand_doc_id, "ver": brand_doc_ver }
-        })),
-        serde_json::to_vec(&serde_json::json!({
-            "$schema": "http://json-schema.org/draft-07/schema#",
-            "type": "object",
-            "properties": {},
-            "required": [],
-            "additionalProperties": false
-        }))
-        .unwrap(),
-        RoleId::Role0,
-    )
-    .unwrap();
-
-    let comment_doc_id = UuidV7::new();
-    let comment_doc_ver = UuidV7::new();
     // Create a main comment doc, contain all fields mention in the document (except
     // revocations and section)
-    let (doc, ..) = common::create_dummy_signed_doc(
-        serde_json::json!(serde_json::json!({
+    let doc = Builder::new()
+        .with_json_metadata(serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
             "type": doc_types::PROPOSAL_COMMENT.clone(),
-            "id": comment_doc_id.to_string(),
-            "ver": comment_doc_ver.to_string(),
+            "id": UuidV7::new(),
+            "ver": UuidV7::new(),
             "ref": {
-                "id": proposal_doc_id,
-                "ver": proposal_doc_ver
+                "id": DUMMY_PROPOSAL_DOC.doc_id().unwrap(),
+                "ver": DUMMY_PROPOSAL_DOC.doc_ver().unwrap(),
             },
             "template": {
-              "id": template_doc_id,
-              "ver": template_doc_ver
+                "id": COMMENT_TEMPLATE_DOC.doc_id().unwrap(),
+                "ver": COMMENT_TEMPLATE_DOC.doc_ver().unwrap(),
             },
             "reply": {
-                "id": ref_doc_id,
-                "ver": ref_doc_ver
+                "id": COMMENT_REF_DOC.doc_id().unwrap(),
+                "ver": COMMENT_REF_DOC.doc_ver().unwrap()
             },
-            "parameters": { "id": brand_doc_id, "ver": brand_doc_ver }
-        })),
-        // Validate against the ref template
-        serde_json::to_vec(&serde_json::json!({})).unwrap(),
-        RoleId::Role0,
-    )
-    .unwrap();
-    let mut provider = TestCatalystSignedDocumentProvider::default();
+            "parameters": {
+                "id": DUMMY_BRAND_DOC.doc_id().unwrap(),
+                "ver": DUMMY_BRAND_DOC.doc_ver().unwrap(),
+            }
+        }))
+        .unwrap()
+        .with_json_content(&serde_json::json!({}))
+        .unwrap()
+        .build();
 
-    provider.add_document(None, &brand_doc).unwrap();
-    provider.add_document(None, &proposal_doc).unwrap();
-    provider.add_document(None, &ref_doc).unwrap();
-    provider.add_document(None, &template_doc).unwrap();
+    let mut provider = TestCatalystSignedDocumentProvider::default();
+    provider.add_document(None, &DUMMY_BRAND_DOC).unwrap();
+    provider.add_document(None, &DUMMY_PROPOSAL_DOC).unwrap();
+    provider.add_document(None, &COMMENT_REF_DOC).unwrap();
+    provider.add_document(None, &COMMENT_TEMPLATE_DOC).unwrap();
 
     let is_valid = validator::validate(&doc, &provider).await.unwrap();
     assert!(is_valid, "{:?}", doc.problem_report());
@@ -121,137 +149,164 @@ async fn test_valid_comment_doc() {
 // The same as above but test with the old type
 #[tokio::test]
 async fn test_valid_comment_doc_old_type() {
-    let (proposal_doc, proposal_doc_id, proposal_doc_ver) =
-        common::create_dummy_doc(&deprecated::PROPOSAL_DOCUMENT_UUID_TYPE.try_into().unwrap())
-            .unwrap();
-    let (brand_doc, brand_doc_id, brand_doc_ver) =
-        common::create_dummy_doc(&doc_types::BRAND_PARAMETERS.clone()).unwrap();
-
-    let ref_doc_id = UuidV7::new();
-    let ref_doc_ver = UuidV7::new();
-
-    let template_doc_id = UuidV7::new();
-    let template_doc_ver = UuidV7::new();
-
-    // Create a ref document, which is a proposal comment type
-    let (ref_doc, ..) = common::create_dummy_signed_doc(
-        serde_json::json!(serde_json::json!({
+    let doc = Builder::new()
+        .with_json_metadata(serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
             "type": deprecated::COMMENT_DOCUMENT_UUID_TYPE,
-            "id": ref_doc_id.to_string(),
-            "ver": ref_doc_ver.to_string(),
+            "id": UuidV7::new(),
+            "ver": UuidV7::new(),
             "ref": {
-                "id": proposal_doc_id,
-                "ver": proposal_doc_ver
+                "id": DUMMY_PROPOSAL_DOC.doc_id().unwrap(),
+                "ver": DUMMY_PROPOSAL_DOC.doc_ver().unwrap(),
             },
             "template": {
-              "id": template_doc_id,
-              "ver": template_doc_ver
-            },
-            "parameters": { "id": brand_doc_id, "ver": brand_doc_ver }})),
-        serde_json::to_vec(&serde_json::Value::Null).unwrap(),
-        RoleId::Role0,
-    )
-    .unwrap();
-
-    // Create a template document
-    let (template_doc, ..) = common::create_dummy_signed_doc(
-        serde_json::json!(serde_json::json!({
-            "content-type": ContentType::Json.to_string(),
-            "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": doc_types::PROPOSAL_COMMENT_TEMPLATE.clone(),
-            "id": template_doc_id.to_string(),
-            "ver": template_doc_ver.to_string(),
-            "parameters": { "id": brand_doc_id, "ver": brand_doc_ver }
-        })),
-        serde_json::to_vec(&serde_json::json!({
-            "$schema": "http://json-schema.org/draft-07/schema#",
-            "type": "object",
-            "properties": {},
-            "required": [],
-            "additionalProperties": false
-        }))
-        .unwrap(),
-        RoleId::Role0,
-    )
-    .unwrap();
-
-    let comment_doc_id = UuidV7::new();
-    let comment_doc_ver = UuidV7::new();
-    // Create a main comment doc, Contain all fields mention in the document (except
-    // revocations and section)
-    let (doc, ..) = common::create_dummy_signed_doc(
-        serde_json::json!(serde_json::json!({
-            "content-type": ContentType::Json.to_string(),
-            "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": deprecated::COMMENT_DOCUMENT_UUID_TYPE.clone(),
-            "id": comment_doc_id.to_string(),
-            "ver": comment_doc_ver.to_string(),
-            "ref": {
-                "id": proposal_doc_id,
-                "ver": proposal_doc_ver
-            },
-            "template": {
-              "id": template_doc_id,
-              "ver": template_doc_ver
+                "id": COMMENT_TEMPLATE_DOC.doc_id().unwrap(),
+                "ver": COMMENT_TEMPLATE_DOC.doc_ver().unwrap(),
             },
             "reply": {
-                "id": ref_doc_id,
-                "ver": ref_doc_ver
+                "id": COMMENT_REF_DOC.doc_id().unwrap(),
+                "ver": COMMENT_REF_DOC.doc_ver().unwrap()
             },
-            "parameters": { "id": brand_doc_id, "ver": brand_doc_ver }
-        })),
-        // Validate against the ref template
-        serde_json::to_vec(&serde_json::json!({})).unwrap(),
-        RoleId::Role0,
-    )
-    .unwrap();
-    let mut provider = TestCatalystSignedDocumentProvider::default();
+            "parameters": {
+                "id": DUMMY_BRAND_DOC.doc_id().unwrap(),
+                "ver": DUMMY_BRAND_DOC.doc_ver().unwrap(),
+            }
+        }))
+        .unwrap()
+        .with_json_content(&serde_json::json!({}))
+        .unwrap()
+        .build();
 
-    provider.add_document(None, &brand_doc).unwrap();
-    provider.add_document(None, &proposal_doc).unwrap();
-    provider.add_document(None, &ref_doc).unwrap();
-    provider.add_document(None, &template_doc).unwrap();
+    let mut provider = TestCatalystSignedDocumentProvider::default();
+    provider.add_document(None, &DUMMY_BRAND_DOC).unwrap();
+    provider.add_document(None, &DUMMY_PROPOSAL_DOC).unwrap();
+    provider.add_document(None, &COMMENT_REF_DOC).unwrap();
+    provider.add_document(None, &COMMENT_TEMPLATE_DOC).unwrap();
 
     let is_valid = validator::validate(&doc, &provider).await.unwrap();
     assert!(is_valid, "{:?}", doc.problem_report());
 }
 
 #[tokio::test]
-async fn test_invalid_comment_doc() {
-    let (proposal_doc, ..) =
-        common::create_dummy_doc(&deprecated::PROPOSAL_DOCUMENT_UUID_TYPE.try_into().unwrap())
-            .unwrap();
-    let (template_doc, template_doc_id, template_doc_ver) =
-        common::create_dummy_doc(&deprecated::COMMENT_TEMPLATE_UUID_TYPE.try_into().unwrap())
-            .unwrap();
-
-    let uuid_v7 = UuidV7::new();
-    // Missing parameters field
-    let (doc, ..) = common::create_dummy_signed_doc(
-        serde_json::json!({
+async fn test_invalid_comment_doc_missing_parameters() {
+    let doc = Builder::new()
+        .with_json_metadata(serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
             "type": doc_types::PROPOSAL_COMMENT.clone(),
-            "id": uuid_v7.to_string(),
-            "ver": uuid_v7.to_string(),
-            "template": {
-              "id": template_doc_id,
-              "ver": template_doc_ver
+            "id": UuidV7::new(),
+            "ver": UuidV7::new(),
+            "ref": {
+                "id": DUMMY_PROPOSAL_DOC.doc_id().unwrap(),
+                "ver": DUMMY_PROPOSAL_DOC.doc_ver().unwrap(),
             },
-            "ref": serde_json::Value::Null
-        }),
-        serde_json::to_vec(&serde_json::Value::Null).unwrap(),
-        RoleId::Role0,
-    )
-    .unwrap();
+            "template": {
+                "id": COMMENT_TEMPLATE_DOC.doc_id().unwrap(),
+                "ver": COMMENT_TEMPLATE_DOC.doc_ver().unwrap(),
+            },
+            "reply": {
+                "id": COMMENT_REF_DOC.doc_id().unwrap(),
+                "ver": COMMENT_REF_DOC.doc_ver().unwrap()
+            },
+            // "parameters": {
+            //     "id": DUMMY_BRAND_DOC.doc_id().unwrap(),
+            //     "ver": DUMMY_BRAND_DOC.doc_ver().unwrap(),
+            // }
+        }))
+        .unwrap()
+        .with_json_content(&serde_json::json!({}))
+        .unwrap()
+        .build();
 
     let mut provider = TestCatalystSignedDocumentProvider::default();
-    provider.add_document(None, &template_doc).unwrap();
-    provider.add_document(None, &proposal_doc).unwrap();
+    provider.add_document(None, &DUMMY_BRAND_DOC).unwrap();
+    provider.add_document(None, &DUMMY_PROPOSAL_DOC).unwrap();
+    provider.add_document(None, &COMMENT_REF_DOC).unwrap();
+    provider.add_document(None, &COMMENT_TEMPLATE_DOC).unwrap();
 
     let is_valid = validator::validate(&doc, &provider).await.unwrap();
+    assert!(!is_valid);
+}
 
+#[tokio::test]
+async fn test_invalid_comment_doc_missing_template() {
+    let doc = Builder::new()
+        .with_json_metadata(serde_json::json!({
+            "content-type": ContentType::Json.to_string(),
+            "content-encoding": ContentEncoding::Brotli.to_string(),
+            "type": doc_types::PROPOSAL_COMMENT.clone(),
+            "id": UuidV7::new(),
+            "ver": UuidV7::new(),
+            "ref": {
+                "id": DUMMY_PROPOSAL_DOC.doc_id().unwrap(),
+                "ver": DUMMY_PROPOSAL_DOC.doc_ver().unwrap(),
+            },
+            // "template": {
+            //     "id": COMMENT_TEMPLATE_DOC.doc_id().unwrap(),
+            //     "ver": COMMENT_TEMPLATE_DOC.doc_ver().unwrap(),
+            // },
+            "reply": {
+                "id": COMMENT_REF_DOC.doc_id().unwrap(),
+                "ver": COMMENT_REF_DOC.doc_ver().unwrap()
+            },
+            "parameters": {
+                "id": DUMMY_BRAND_DOC.doc_id().unwrap(),
+                "ver": DUMMY_BRAND_DOC.doc_ver().unwrap(),
+            }
+        }))
+        .unwrap()
+        .with_json_content(&serde_json::json!({}))
+        .unwrap()
+        .build();
+
+    let mut provider = TestCatalystSignedDocumentProvider::default();
+    provider.add_document(None, &DUMMY_BRAND_DOC).unwrap();
+    provider.add_document(None, &DUMMY_PROPOSAL_DOC).unwrap();
+    provider.add_document(None, &COMMENT_REF_DOC).unwrap();
+    provider.add_document(None, &COMMENT_TEMPLATE_DOC).unwrap();
+
+    let is_valid = validator::validate(&doc, &provider).await.unwrap();
+    assert!(!is_valid);
+}
+
+#[tokio::test]
+async fn test_invalid_comment_doc_missing_ref() {
+    let doc = Builder::new()
+        .with_json_metadata(serde_json::json!({
+            "content-type": ContentType::Json.to_string(),
+            "content-encoding": ContentEncoding::Brotli.to_string(),
+            "type": doc_types::PROPOSAL_COMMENT.clone(),
+            "id": UuidV7::new(),
+            "ver": UuidV7::new(),
+            // "ref": {
+            //     "id": DUMMY_PROPOSAL_DOC.doc_id().unwrap(),
+            //     "ver": DUMMY_PROPOSAL_DOC.doc_ver().unwrap(),
+            // },
+            "template": {
+                "id": COMMENT_TEMPLATE_DOC.doc_id().unwrap(),
+                "ver": COMMENT_TEMPLATE_DOC.doc_ver().unwrap(),
+            },
+            "reply": {
+                "id": COMMENT_REF_DOC.doc_id().unwrap(),
+                "ver": COMMENT_REF_DOC.doc_ver().unwrap()
+            },
+            "parameters": {
+                "id": DUMMY_BRAND_DOC.doc_id().unwrap(),
+                "ver": DUMMY_BRAND_DOC.doc_ver().unwrap(),
+            }
+        }))
+        .unwrap()
+        .with_json_content(&serde_json::json!({}))
+        .unwrap()
+        .build();
+
+    let mut provider = TestCatalystSignedDocumentProvider::default();
+    provider.add_document(None, &DUMMY_BRAND_DOC).unwrap();
+    provider.add_document(None, &DUMMY_PROPOSAL_DOC).unwrap();
+    provider.add_document(None, &COMMENT_REF_DOC).unwrap();
+    provider.add_document(None, &COMMENT_TEMPLATE_DOC).unwrap();
+
+    let is_valid = validator::validate(&doc, &provider).await.unwrap();
     assert!(!is_valid);
 }

--- a/rust/signed_doc/tests/proposal.rs
+++ b/rust/signed_doc/tests/proposal.rs
@@ -7,9 +7,6 @@ use std::sync::LazyLock;
 use catalyst_signed_doc::{
     doc_types::deprecated, providers::tests::TestCatalystSignedDocumentProvider, *,
 };
-use catalyst_types::catalyst_id::role_index::RoleId;
-
-mod common;
 
 #[allow(clippy::unwrap_used)]
 static DUMMY_BRAND_DOC: LazyLock<CatalystSignedDocument> = LazyLock::new(|| {
@@ -123,37 +120,6 @@ async fn test_valid_proposal_doc_old_type() {
 
     let is_valid = validator::validate(&doc, &provider).await.unwrap();
     assert!(is_valid);
-}
-
-#[tokio::test]
-async fn test_valid_proposal_doc_with_empty_provider() {
-    // dummy template doc to dummy provider
-    let template_doc_id = UuidV7::new();
-    let template_doc_ver = UuidV7::new();
-
-    let uuid_v7 = UuidV7::new();
-    let (doc, ..) = common::create_dummy_signed_doc(
-        serde_json::json!({
-            "content-type": ContentType::Json.to_string(),
-            "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": doc_types::PROPOSAL.clone(),
-            "id": uuid_v7.to_string(),
-            "ver": uuid_v7.to_string(),
-            "template": {
-              "id": template_doc_id,
-              "ver": template_doc_ver
-            },
-        }),
-        serde_json::to_vec(&serde_json::Value::Null).unwrap(),
-        RoleId::Proposer,
-    )
-    .unwrap();
-
-    let provider = TestCatalystSignedDocumentProvider::default();
-
-    let is_valid = validator::validate(&doc, &provider).await.unwrap();
-
-    assert!(!is_valid);
 }
 
 #[tokio::test]

--- a/rust/signed_doc/tests/proposal.rs
+++ b/rust/signed_doc/tests/proposal.rs
@@ -2,12 +2,55 @@
 //! Require fields: type, id, ver, template, parameters
 //! <https://input-output-hk.github.io/catalyst-libs/architecture/08_concepts/signed_doc/docs/proposal/#front-end>
 
+use std::sync::LazyLock;
+
 use catalyst_signed_doc::{
     doc_types::deprecated, providers::tests::TestCatalystSignedDocumentProvider, *,
 };
 use catalyst_types::catalyst_id::role_index::RoleId;
 
 mod common;
+
+#[allow(clippy::unwrap_used)]
+static DUMMY_BRAND_DOC: LazyLock<CatalystSignedDocument> = LazyLock::new(|| {
+    Builder::new()
+        .with_json_metadata(serde_json::json!({
+            "content-type": ContentType::Json.to_string(),
+            "id": UuidV7::new(),
+            "ver": UuidV7::new(),
+            "type": doc_types::BRAND_PARAMETERS.clone(),
+        }))
+        .unwrap()
+        .with_json_content(&serde_json::json!({}))
+        .unwrap()
+        .build()
+});
+
+#[allow(clippy::unwrap_used)]
+static PROPOSAL_TEMPLATE_DOC: LazyLock<CatalystSignedDocument> = LazyLock::new(|| {
+    Builder::new()
+        .with_json_metadata(serde_json::json!({
+            "content-type": ContentType::Json.to_string(),
+            "content-encoding": ContentEncoding::Brotli.to_string(),
+            "type": doc_types::PROPOSAL_TEMPLATE.clone(),
+            "id": UuidV7::new(),
+            "ver": UuidV7::new(),
+            "parameters": {
+                "id": DUMMY_BRAND_DOC.doc_id().unwrap(),
+                "ver": DUMMY_BRAND_DOC.doc_ver().unwrap(),
+            }
+        }))
+        .unwrap()
+        .with_json_content(&serde_json::json!({
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {},
+            "required": [],
+            "additionalProperties": false
+        }))
+        .unwrap()
+        .build()
+});
 
 // Given a proposal document `doc`:
 //
@@ -18,130 +61,67 @@ mod common;
 // `parameters` value as `doc`.
 #[tokio::test]
 async fn test_valid_proposal_doc() {
-    let (brand_doc, brand_doc_id, brand_doc_ver) =
-        common::create_dummy_doc(&doc_types::BRAND_PARAMETERS.clone()).unwrap();
-
-    let template_doc_id = UuidV7::new();
-    let template_doc_ver = UuidV7::new();
-    // Create a template document
-    let (template_doc, ..) = common::create_dummy_signed_doc(
-        serde_json::json!(serde_json::json!({
-            "content-type": ContentType::Json.to_string(),
-            "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": doc_types::PROPOSAL_TEMPLATE.clone(),
-            "id": template_doc_id.to_string(),
-            "ver": template_doc_ver.to_string(),
-            "parameters": { "id": brand_doc_id, "ver": brand_doc_ver }
-        })),
-        serde_json::to_vec(&serde_json::json!({
-            "$schema": "http://json-schema.org/draft-07/schema#",
-            "type": "object",
-            "properties": {},
-            "required": [],
-            "additionalProperties": false
-        }))
-        .unwrap(),
-        RoleId::Role0,
-    )
-    .unwrap();
-
-    let proposal_doc_id = UuidV7::new();
-    let proposal_doc_ver = UuidV7::new();
     // Create a main proposal doc, contain all fields mention in the document (except
     // collaborations and revocations)
-    let (doc, ..) = common::create_dummy_signed_doc(
-        serde_json::json!({
+    let doc = Builder::new()
+        .with_json_metadata(serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
             "type": doc_types::PROPOSAL.clone(),
-            "id": proposal_doc_id.to_string(),
-            "ver": proposal_doc_ver.to_string(),
+            "id": UuidV7::new(),
+            "ver": UuidV7::new(),
             "template": {
-              "id": template_doc_id,
-              "ver": template_doc_ver
+                "id": PROPOSAL_TEMPLATE_DOC.doc_id().unwrap(),
+                "ver": PROPOSAL_TEMPLATE_DOC.doc_ver().unwrap(),
             },
             "parameters": {
-                "id": brand_doc_id,
-                "ver": brand_doc_ver
+                "id": DUMMY_BRAND_DOC.doc_id().unwrap(),
+                "ver": DUMMY_BRAND_DOC.doc_ver().unwrap(),
             }
-        }),
-        // Validate against the ref template
-        serde_json::to_vec(&serde_json::json!({})).unwrap(),
-        RoleId::Proposer,
-    )
-    .unwrap();
+        }))
+        .unwrap()
+        .with_json_content(&serde_json::json!({}))
+        .unwrap()
+        .build();
 
     let mut provider = TestCatalystSignedDocumentProvider::default();
 
-    provider.add_document(None, &template_doc).unwrap();
-    provider.add_document(None, &brand_doc).unwrap();
+    provider.add_document(None, &PROPOSAL_TEMPLATE_DOC).unwrap();
+    provider.add_document(None, &DUMMY_BRAND_DOC).unwrap();
 
     let is_valid = validator::validate(&doc, &provider).await.unwrap();
-
     assert!(is_valid);
 }
 
 #[tokio::test]
 async fn test_valid_proposal_doc_old_type() {
-    let (brand_doc, brand_doc_id, brand_doc_ver) =
-        common::create_dummy_doc(&doc_types::BRAND_PARAMETERS.clone()).unwrap();
-
-    let template_doc_id = UuidV7::new();
-    let template_doc_ver = UuidV7::new();
-    // Create a template document
-    let (template_doc, ..) = common::create_dummy_signed_doc(
-        serde_json::json!(serde_json::json!({
+    let doc = Builder::new()
+        .with_json_metadata(serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": doc_types::PROPOSAL_TEMPLATE.clone(),
-            "id": template_doc_id.to_string(),
-            "ver": template_doc_ver.to_string(),
-            "parameters": { "id": brand_doc_id, "ver": brand_doc_ver }
-        })),
-        serde_json::to_vec(&serde_json::json!({
-            "$schema": "http://json-schema.org/draft-07/schema#",
-            "type": "object",
-            "properties": {},
-            "required": [],
-            "additionalProperties": false
-        }))
-        .unwrap(),
-        RoleId::Role0,
-    )
-    .unwrap();
-
-    let proposal_doc_id = UuidV7::new();
-    let proposal_doc_ver = UuidV7::new();
-    // Create a main proposal doc, contain all fields mention in the document (except
-    // collaborations and revocations)
-    let (doc, ..) = common::create_dummy_signed_doc(
-        serde_json::json!({
-            "content-type": ContentType::Json.to_string(),
-            "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": deprecated::PROPOSAL_DOCUMENT_UUID_TYPE.clone(),
-            "id": proposal_doc_id.to_string(),
-            "ver": proposal_doc_ver.to_string(),
+            "type": deprecated::PROPOSAL_DOCUMENT_UUID_TYPE,
+            "id": UuidV7::new(),
+            "ver": UuidV7::new(),
             "template": {
-              "id": template_doc_id,
-              "ver": template_doc_ver
+                "id": PROPOSAL_TEMPLATE_DOC.doc_id().unwrap(),
+                "ver": PROPOSAL_TEMPLATE_DOC.doc_ver().unwrap(),
             },
             "parameters": {
-                "id": brand_doc_id,
-                "ver": brand_doc_ver
+                "id": DUMMY_BRAND_DOC.doc_id().unwrap(),
+                "ver": DUMMY_BRAND_DOC.doc_ver().unwrap(),
             }
-        }),
-        serde_json::to_vec(&serde_json::json!({})).unwrap(),
-        RoleId::Proposer,
-    )
-    .unwrap();
+        }))
+        .unwrap()
+        .with_json_content(&serde_json::json!({}))
+        .unwrap()
+        .build();
 
     let mut provider = TestCatalystSignedDocumentProvider::default();
 
-    provider.add_document(None, &template_doc).unwrap();
-    provider.add_document(None, &brand_doc).unwrap();
+    provider.add_document(None, &PROPOSAL_TEMPLATE_DOC).unwrap();
+    provider.add_document(None, &DUMMY_BRAND_DOC).unwrap();
 
     let is_valid = validator::validate(&doc, &provider).await.unwrap();
-
     assert!(is_valid);
 }
 
@@ -177,26 +157,65 @@ async fn test_valid_proposal_doc_with_empty_provider() {
 }
 
 #[tokio::test]
-async fn test_invalid_proposal_doc() {
-    let uuid_v7 = UuidV7::new();
-    let (doc, ..) = common::create_dummy_signed_doc(
-        serde_json::json!({
+async fn test_invalid_proposal_doc_missing_template() {
+    let doc = Builder::new()
+        .with_json_metadata(serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": doc_types::PROPOSAL.clone(),
-            "id": uuid_v7.to_string(),
-            "ver": uuid_v7.to_string(),
-            // without specifying template id
-            "template": serde_json::Value::Null,
-        }),
-        serde_json::to_vec(&serde_json::Value::Null).unwrap(),
-        RoleId::Proposer,
-    )
-    .unwrap();
+            "type": deprecated::PROPOSAL_DOCUMENT_UUID_TYPE,
+            "id": UuidV7::new(),
+            "ver": UuidV7::new(),
+            // "template": {
+            //     "id": PROPOSAL_TEMPLATE_DOC.doc_id().unwrap(),
+            //     "ver": PROPOSAL_TEMPLATE_DOC.doc_ver().unwrap(),
+            // },
+            "parameters": {
+                "id": DUMMY_BRAND_DOC.doc_id().unwrap(),
+                "ver": DUMMY_BRAND_DOC.doc_ver().unwrap(),
+            }
+        }))
+        .unwrap()
+        .with_json_content(&serde_json::json!({}))
+        .unwrap()
+        .build();
 
-    let provider = TestCatalystSignedDocumentProvider::default();
+    let mut provider = TestCatalystSignedDocumentProvider::default();
+
+    provider.add_document(None, &PROPOSAL_TEMPLATE_DOC).unwrap();
+    provider.add_document(None, &DUMMY_BRAND_DOC).unwrap();
 
     let is_valid = validator::validate(&doc, &provider).await.unwrap();
+    assert!(!is_valid);
+}
 
+#[tokio::test]
+async fn test_invalid_proposal_doc_missing_parameters() {
+    let doc = Builder::new()
+        .with_json_metadata(serde_json::json!({
+            "content-type": ContentType::Json.to_string(),
+            "content-encoding": ContentEncoding::Brotli.to_string(),
+            "type": deprecated::PROPOSAL_DOCUMENT_UUID_TYPE,
+            "id": UuidV7::new(),
+            "ver": UuidV7::new(),
+            "template": {
+                "id": PROPOSAL_TEMPLATE_DOC.doc_id().unwrap(),
+                "ver": PROPOSAL_TEMPLATE_DOC.doc_ver().unwrap(),
+            },
+            // "parameters": {
+            //     "id": DUMMY_BRAND_DOC.doc_id().unwrap(),
+            //     "ver": DUMMY_BRAND_DOC.doc_ver().unwrap(),
+            // }
+        }))
+        .unwrap()
+        .with_json_content(&serde_json::json!({}))
+        .unwrap()
+        .build();
+
+    let mut provider = TestCatalystSignedDocumentProvider::default();
+
+    provider.add_document(None, &PROPOSAL_TEMPLATE_DOC).unwrap();
+    provider.add_document(None, &DUMMY_BRAND_DOC).unwrap();
+
+    let is_valid = validator::validate(&doc, &provider).await.unwrap();
     assert!(!is_valid);
 }

--- a/rust/signed_doc/tests/signature.rs
+++ b/rust/signed_doc/tests/signature.rs
@@ -2,20 +2,41 @@
 
 use catalyst_signed_doc::{providers::tests::TestVerifyingKeyProvider, *};
 use catalyst_types::catalyst_id::role_index::RoleId;
-use common::test_metadata;
 use ed25519_dalek::ed25519::signature::Signer;
+
+use crate::common::create_dummy_key_pair;
 
 mod common;
 
+fn metadata() -> serde_json::Value {
+    serde_json::json!({
+        "content-type": ContentType::Json.to_string(),
+        "content-encoding": ContentEncoding::Brotli.to_string(),
+        "type": UuidV4::new(),
+        "id":  UuidV7::new(),
+        "ver":  UuidV7::new(),
+        "ref": {"id":  UuidV7::new(), "ver":  UuidV7::new()},
+        "reply": {"id":  UuidV7::new(), "ver":  UuidV7::new()},
+        "template": {"id":  UuidV7::new(), "ver":  UuidV7::new()},
+        "section": "$",
+        "collabs": vec!["Alex1", "Alex2"],
+        "parameters": {"id":  UuidV7::new(), "ver":  UuidV7::new()},
+    })
+}
+
 #[tokio::test]
 async fn single_signature_validation_test() {
-    let (_, _, metadata) = test_metadata();
-    let (signed_doc, pk, kid) = common::create_dummy_signed_doc(
-        metadata,
-        serde_json::to_vec(&serde_json::Value::Null).unwrap(),
-        RoleId::Role0,
-    )
-    .unwrap();
+    let (sk, pk, kid) = create_dummy_key_pair(RoleId::Role0).unwrap();
+
+    let signed_doc = Builder::new()
+        .with_json_metadata(metadata())
+        .unwrap()
+        .with_json_content(&serde_json::Value::Null)
+        .unwrap()
+        .add_signature(|m| sk.sign(&m).to_vec(), kid.clone())
+        .unwrap()
+        .build();
+
     assert!(!signed_doc.problem_report().is_problematic());
 
     // case: has key
@@ -32,8 +53,29 @@ async fn single_signature_validation_test() {
             .unwrap()
     );
 
+    // case: signed with different key
+    let (another_sk, ..) = create_dummy_key_pair(RoleId::Role0).unwrap();
+    let invalid_doc = signed_doc
+        .into_builder()
+        .add_signature(|m| another_sk.sign(&m).to_vec(), kid.clone())
+        .unwrap()
+        .build();
+    assert!(!validator::validate_signatures(&invalid_doc, &provider)
+        .await
+        .unwrap());
+
     // case: missing signatures
-    let (unsigned_doc, ..) = common::create_dummy_doc(&UuidV4::new().into()).unwrap();
+    let unsigned_doc = Builder::new()
+        .with_json_metadata(serde_json::json!({
+            "content-type": ContentType::Json.to_string(),
+            "id": UuidV7::new(),
+            "ver": UuidV7::new(),
+            "type": UuidV4::new(),
+        }))
+        .unwrap()
+        .with_json_content(&serde_json::json!({}))
+        .unwrap()
+        .build();
     assert!(!validator::validate_signatures(&unsigned_doc, &provider)
         .await
         .unwrap());
@@ -47,9 +89,9 @@ async fn multiple_signatures_validation_test() {
     let (_, pk_n, kid_n) = common::create_dummy_key_pair(RoleId::Role0).unwrap();
 
     let signed_doc = Builder::new()
-        .with_json_metadata(common::test_metadata().2)
+        .with_json_metadata(metadata())
         .unwrap()
-        .with_decoded_content(serde_json::to_vec(&serde_json::Value::Null).unwrap())
+        .with_json_content(&serde_json::Value::Null)
         .unwrap()
         .add_signature(|m| sk1.sign(&m).to_vec(), kid1.clone())
         .unwrap()
@@ -68,27 +110,27 @@ async fn multiple_signatures_validation_test() {
     provider.add_pk(kid3.clone(), pk3);
     assert!(validator::validate_signatures(&signed_doc, &provider)
         .await
-        .is_ok_and(|v| v));
+        .unwrap());
 
     // case: partially available signatures
     let mut provider = TestVerifyingKeyProvider::default();
     provider.add_pk(kid1.clone(), pk1);
     provider.add_pk(kid2.clone(), pk2);
-    assert!(validator::validate_signatures(&signed_doc, &provider)
+    assert!(!validator::validate_signatures(&signed_doc, &provider)
         .await
-        .is_ok_and(|v| !v));
+        .unwrap());
 
     // case: with unrecognized provider
     let mut provider = TestVerifyingKeyProvider::default();
     provider.add_pk(kid_n.clone(), pk_n);
-    assert!(validator::validate_signatures(&signed_doc, &provider)
+    assert!(!validator::validate_signatures(&signed_doc, &provider)
         .await
-        .is_ok_and(|v| !v));
+        .unwrap());
 
     // case: no valid signatures available
     assert!(
-        validator::validate_signatures(&signed_doc, &TestVerifyingKeyProvider::default())
+        !validator::validate_signatures(&signed_doc, &TestVerifyingKeyProvider::default())
             .await
-            .is_ok_and(|v| !v)
+            .unwrap()
     );
 }

--- a/rust/signed_doc/tests/submission.rs
+++ b/rust/signed_doc/tests/submission.rs
@@ -2,12 +2,49 @@
 //! Require fields: type, id, ver, ref, parameters
 //! <https://input-output-hk.github.io/catalyst-libs/architecture/08_concepts/signed_doc/docs/proposal_submission_action/>
 
+use std::sync::LazyLock;
+
 use catalyst_signed_doc::{
     doc_types::deprecated, providers::tests::TestCatalystSignedDocumentProvider, *,
 };
-use catalyst_types::catalyst_id::role_index::RoleId;
 
-mod common;
+#[allow(clippy::unwrap_used)]
+static DUMMY_PROPOSAL_DOC: LazyLock<CatalystSignedDocument> = LazyLock::new(|| {
+    Builder::new()
+        .with_json_metadata(serde_json::json!({
+            "content-type": ContentType::Json.to_string(),
+            "id": UuidV7::new(),
+            "ver": UuidV7::new(),
+            "type": doc_types::PROPOSAL.clone(),
+            "ref": {
+                "id": UuidV7::new(),
+                "ver": UuidV7::new(),
+            },
+            "parameters": {
+                "id": DUMMY_BRAND_DOC.doc_id().unwrap(),
+                "ver": DUMMY_BRAND_DOC.doc_ver().unwrap(),
+            }
+        }))
+        .unwrap()
+        .with_json_content(&serde_json::json!({}))
+        .unwrap()
+        .build()
+});
+
+#[allow(clippy::unwrap_used)]
+static DUMMY_BRAND_DOC: LazyLock<CatalystSignedDocument> = LazyLock::new(|| {
+    Builder::new()
+        .with_json_metadata(serde_json::json!({
+            "content-type": ContentType::Json.to_string(),
+            "id": UuidV7::new(),
+            "ver": UuidV7::new(),
+            "type": doc_types::BRAND_PARAMETERS.clone(),
+        }))
+        .unwrap()
+        .with_json_content(&serde_json::json!({}))
+        .unwrap()
+        .build()
+});
 
 // Given a proposal comment document `doc`:
 //
@@ -18,60 +55,34 @@ mod common;
 // `parameters` value as `doc`.
 #[tokio::test]
 async fn test_valid_submission_action() {
-    let (brand_doc, brand_doc_id, brand_doc_ver) =
-        common::create_dummy_doc(&doc_types::BRAND_PARAMETERS.clone()).unwrap();
-
-    let proposal_doc_id = UuidV7::new();
-    let proposal_doc_ver = UuidV7::new();
-    let (proposal_doc, ..) = common::create_dummy_signed_doc(
-        serde_json::json!({
-            "content-type": ContentType::Json.to_string(),
-            "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": doc_types::PROPOSAL.clone(),
-            "id": proposal_doc_id.to_string(),
-            "ver": proposal_doc_ver.to_string(),
-            "ref": {
-                "id": UuidV7::new(),
-                "ver": UuidV7::new()
-            },
-            "parameters": { "id": brand_doc_id, "ver": brand_doc_ver }
-        }),
-        serde_json::to_vec(&serde_json::json!({
-            "action": "final"
-        }))
-        .unwrap(),
-        RoleId::Proposer,
-    )
-    .unwrap();
-
-    let doc_id = UuidV7::new();
-    let doc_ver = UuidV7::new();
     // Create a main proposal submission doc, contain all fields mention in the document
-    let (doc, ..) = common::create_dummy_signed_doc(
-        serde_json::json!({
+    let doc = Builder::new()
+        .with_json_metadata(serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
             "type": doc_types::PROPOSAL_SUBMISSION_ACTION.clone(),
-            "id": doc_id.to_string(),
-            "ver": doc_ver.to_string(),
+            "id": UuidV7::new(),
+            "ver": UuidV7::new(),
             "ref": {
-                "id": proposal_doc_id,
-                "ver": proposal_doc_ver
+                "id": DUMMY_PROPOSAL_DOC.doc_id().unwrap(),
+                "ver": DUMMY_PROPOSAL_DOC.doc_ver().unwrap(),
             },
-            "parameters": { "id": brand_doc_id, "ver": brand_doc_ver }
-        }),
-        serde_json::to_vec(&serde_json::json!({
+            "parameters": {
+                "id": DUMMY_BRAND_DOC.doc_id().unwrap(),
+                "ver": DUMMY_BRAND_DOC.doc_ver().unwrap(),
+            }
+        }))
+        .unwrap()
+        .with_json_content(&serde_json::json!({
             "action": "final"
         }))
-        .unwrap(),
-        RoleId::Proposer,
-    )
-    .unwrap();
+        .unwrap()
+        .build();
 
     let mut provider = TestCatalystSignedDocumentProvider::default();
 
-    provider.add_document(None, &proposal_doc).unwrap();
-    provider.add_document(None, &brand_doc).unwrap();
+    provider.add_document(None, &DUMMY_PROPOSAL_DOC).unwrap();
+    provider.add_document(None, &DUMMY_BRAND_DOC).unwrap();
 
     let is_valid = validator::validate(&doc, &provider).await.unwrap();
     assert!(is_valid, "{:?}", doc.problem_report());
@@ -79,176 +90,133 @@ async fn test_valid_submission_action() {
 
 #[tokio::test]
 async fn test_valid_submission_action_old_type() {
-    let (brand_doc, brand_doc_id, brand_doc_ver) =
-        common::create_dummy_doc(&doc_types::BRAND_PARAMETERS.clone()).unwrap();
-
-    let proposal_doc_id = UuidV7::new();
-    let proposal_doc_ver = UuidV7::new();
-    let (proposal_doc, ..) = common::create_dummy_signed_doc(
-        serde_json::json!({
+    let doc = Builder::new()
+        .with_json_metadata(serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": deprecated::PROPOSAL_DOCUMENT_UUID_TYPE.clone(),
-            "id": proposal_doc_id.to_string(),
-            "ver": proposal_doc_ver.to_string(),
+            "type": deprecated::PROPOSAL_ACTION_DOCUMENT_UUID_TYPE,
+            "id": UuidV7::new(),
+            "ver": UuidV7::new(),
             "ref": {
-                "id": UuidV7::new(),
-                "ver": UuidV7::new()
+                "id": DUMMY_PROPOSAL_DOC.doc_id().unwrap(),
+                "ver": DUMMY_PROPOSAL_DOC.doc_ver().unwrap(),
             },
-            "parameters": { "id": brand_doc_id, "ver": brand_doc_ver }
-        }),
-        serde_json::to_vec(&serde_json::json!({
+            "parameters": {
+                "id": DUMMY_BRAND_DOC.doc_id().unwrap(),
+                "ver": DUMMY_BRAND_DOC.doc_ver().unwrap(),
+            }
+        }))
+        .unwrap()
+        .with_json_content(&serde_json::json!({
             "action": "final"
         }))
-        .unwrap(),
-        RoleId::Proposer,
-    )
-    .unwrap();
-
-    let doc_id = UuidV7::new();
-    let doc_ver = UuidV7::new();
-    // Create a main proposal submission doc, contain all fields mention in the document
-    let (doc, ..) = common::create_dummy_signed_doc(
-        serde_json::json!({
-            "content-type": ContentType::Json.to_string(),
-            "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": deprecated::PROPOSAL_ACTION_DOCUMENT_UUID_TYPE.clone(),
-            "id": doc_id.to_string(),
-            "ver": doc_ver.to_string(),
-            "ref": {
-                "id": proposal_doc_id,
-                "ver": proposal_doc_ver
-            },
-            "parameters": { "id": brand_doc_id, "ver": brand_doc_ver }
-        }),
-        serde_json::to_vec(&serde_json::json!({
-            "action": "final"
-        }))
-        .unwrap(),
-        RoleId::Proposer,
-    )
-    .unwrap();
+        .unwrap()
+        .build();
 
     let mut provider = TestCatalystSignedDocumentProvider::default();
 
-    provider.add_document(None, &proposal_doc).unwrap();
-    provider.add_document(None, &brand_doc).unwrap();
+    provider.add_document(None, &DUMMY_PROPOSAL_DOC).unwrap();
+    provider.add_document(None, &DUMMY_BRAND_DOC).unwrap();
 
     let is_valid = validator::validate(&doc, &provider).await.unwrap();
     assert!(is_valid, "{:?}", doc.problem_report());
 }
 
 #[tokio::test]
-async fn test_valid_submission_action_with_empty_provider() {
-    let proposal_doc_id = UuidV7::new();
-    let proposal_doc_ver = UuidV7::new();
-
-    let uuid_v7 = UuidV7::new();
-    let (doc, ..) = common::create_dummy_signed_doc(
-        serde_json::json!({
+async fn test_invalid_submission_action_corrupted_json() {
+    let doc = Builder::new()
+        .with_json_metadata(serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
             "type": doc_types::PROPOSAL_SUBMISSION_ACTION.clone(),
-            "id": uuid_v7.to_string(),
-            "ver": uuid_v7.to_string(),
+            "id": UuidV7::new(),
+            "ver": UuidV7::new(),
             "ref": {
-                "id": proposal_doc_id,
-                "ver": proposal_doc_ver
+                "id": DUMMY_PROPOSAL_DOC.doc_id().unwrap(),
+                "ver": DUMMY_PROPOSAL_DOC.doc_ver().unwrap(),
             },
-        }),
-        serde_json::to_vec(&serde_json::json!({
-            "action": "final"
+            "parameters": {
+                "id": DUMMY_BRAND_DOC.doc_id().unwrap(),
+                "ver": DUMMY_BRAND_DOC.doc_ver().unwrap(),
+            }
         }))
-        .unwrap(),
-        RoleId::Proposer,
-    )
-    .unwrap();
+        .unwrap()
+        .with_json_content(&serde_json::Value::Null)
+        .unwrap()
+        .build();
 
-    let provider = TestCatalystSignedDocumentProvider::default();
+    let mut provider = TestCatalystSignedDocumentProvider::default();
+
+    provider.add_document(None, &DUMMY_PROPOSAL_DOC).unwrap();
+    provider.add_document(None, &DUMMY_BRAND_DOC).unwrap();
 
     let is_valid = validator::validate(&doc, &provider).await.unwrap();
     assert!(!is_valid);
 }
 
 #[tokio::test]
-async fn test_invalid_submission_action() {
-    let uuid_v7 = UuidV7::new();
-    // missing `ref` field
-    let (doc, ..) = common::create_dummy_signed_doc(
-        serde_json::json!({
+async fn test_invalid_submission_action_missing_ref() {
+    let doc = Builder::new()
+        .with_json_metadata(serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
             "type": doc_types::PROPOSAL_SUBMISSION_ACTION.clone(),
-            "id": uuid_v7.to_string(),
-            "ver": uuid_v7.to_string(),
-            "ref": serde_json::Value::Null,
-        }),
-        serde_json::to_vec(&serde_json::json!({
+            "id": UuidV7::new(),
+            "ver": UuidV7::new(),
+            // "ref": {
+            //     "id": DUMMY_PROPOSAL_DOC.doc_id().unwrap(),
+            //     "ver": DUMMY_PROPOSAL_DOC.doc_ver().unwrap(),
+            // },
+            "parameters": {
+                "id": DUMMY_BRAND_DOC.doc_id().unwrap(),
+                "ver": DUMMY_BRAND_DOC.doc_ver().unwrap(),
+            }
+        }))
+        .unwrap()
+        .with_json_content(&serde_json::json!({
             "action": "final"
         }))
-        .unwrap(),
-        RoleId::Proposer,
-    )
-    .unwrap();
-
-    let provider = TestCatalystSignedDocumentProvider::default();
-    let is_valid = validator::validate(&doc, &provider).await.unwrap();
-    assert!(!is_valid);
-
-    // corrupted JSON
-    let (proposal_doc, proposal_doc_id, proposal_doc_ver) =
-        common::create_dummy_doc(&deprecated::PROPOSAL_DOCUMENT_UUID_TYPE.try_into().unwrap())
-            .unwrap();
-    let uuid_v7 = UuidV7::new();
-    let (doc, ..) = common::create_dummy_signed_doc(
-        serde_json::json!({
-            "content-type": ContentType::Json.to_string(),
-            "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": deprecated::PROPOSAL_ACTION_DOCUMENT_UUID_TYPE,
-            "id": uuid_v7.to_string(),
-            "ver": uuid_v7.to_string(),
-            "ref": {
-                "id": proposal_doc_id,
-                "ver": proposal_doc_ver
-            },
-        }),
-        serde_json::to_vec(&serde_json::Value::Null).unwrap(),
-        RoleId::Proposer,
-    )
-    .unwrap();
+        .unwrap()
+        .build();
 
     let mut provider = TestCatalystSignedDocumentProvider::default();
 
-    provider.add_document(None, &proposal_doc).unwrap();
+    provider.add_document(None, &DUMMY_PROPOSAL_DOC).unwrap();
+    provider.add_document(None, &DUMMY_BRAND_DOC).unwrap();
 
     let is_valid = validator::validate(&doc, &provider).await.unwrap();
     assert!(!is_valid);
+}
 
-    // empty content
-    let (proposal_doc, proposal_doc_id, proposal_doc_ver) =
-        common::create_dummy_doc(&deprecated::PROPOSAL_DOCUMENT_UUID_TYPE.try_into().unwrap())
-            .unwrap();
-    let uuid_v7 = UuidV7::new();
-    let (doc, ..) = common::create_dummy_signed_doc(
-        serde_json::json!({
+#[tokio::test]
+async fn test_invalid_submission_action_missing_parameters() {
+    let doc = Builder::new()
+        .with_json_metadata(serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
             "type": doc_types::PROPOSAL_SUBMISSION_ACTION.clone(),
-            "id": uuid_v7.to_string(),
-            "ver": uuid_v7.to_string(),
+            "id": UuidV7::new(),
+            "ver": UuidV7::new(),
             "ref": {
-                "id": proposal_doc_id,
-                "ver": proposal_doc_ver
+                "id": DUMMY_PROPOSAL_DOC.doc_id().unwrap(),
+                "ver": DUMMY_PROPOSAL_DOC.doc_ver().unwrap(),
             },
-        }),
-        vec![],
-        RoleId::Proposer,
-    )
-    .unwrap();
+            // "parameters": {
+            //     "id": DUMMY_BRAND_DOC.doc_id().unwrap(),
+            //     "ver": DUMMY_BRAND_DOC.doc_ver().unwrap(),
+            // }
+        }))
+        .unwrap()
+        .with_json_content(&serde_json::json!({
+            "action": "final"
+        }))
+        .unwrap()
+        .build();
 
     let mut provider = TestCatalystSignedDocumentProvider::default();
 
-    provider.add_document(None, &proposal_doc).unwrap();
+    provider.add_document(None, &DUMMY_PROPOSAL_DOC).unwrap();
+    provider.add_document(None, &DUMMY_BRAND_DOC).unwrap();
 
     let is_valid = validator::validate(&doc, &provider).await.unwrap();
     assert!(!is_valid);


### PR DESCRIPTION
# Description

Port of https://github.com/input-output-hk/catalyst-libs/pull/373

- Split current `Builder` into the sequence of three builders `MetadataBuilder`, `ContentBuilder`, `SignaturesBuilder`. Which makes the building process type safe.
- Added a new `tests::Builder` based on the safe builder, to be more flexible in tests.
- Updated and cleanup tests

# Related Issue

Part of https://github.com/input-output-hk/catalyst-libs/issues/330
