### PR TITLE
feat(rust/signed-doc): `*_wrong_role` Catalyst Signed Documents integration tests

### DIFF
--- a/rust/signed_doc/tests/comment.rs
+++ b/rust/signed_doc/tests/comment.rs
@@ -5,8 +5,16 @@
 use std::sync::LazyLock;
 
 use catalyst_signed_doc::{
-    doc_types::deprecated, providers::tests::TestCatalystSignedDocumentProvider, *,
+    doc_types::deprecated,
+    providers::tests::{TestCatalystSignedDocumentProvider, TestVerifyingKeyProvider},
+    *,
 };
+use catalyst_types::catalyst_id::role_index::RoleId;
+use ed25519_dalek::ed25519::signature::Signer;
+
+use crate::common::create_dummy_key_pair;
+
+mod common;
 
 #[allow(clippy::unwrap_used)]
 static DUMMY_PROPOSAL_DOC: LazyLock<CatalystSignedDocument> = LazyLock::new(|| {
@@ -107,6 +115,10 @@ static COMMENT_REF_DOC: LazyLock<CatalystSignedDocument> = LazyLock::new(|| {
 // The rule requires that the `ref` field in `ref_doc` must match the `ref` field in `doc`
 #[tokio::test]
 async fn test_valid_comment_doc() {
+    let (sk, pk, kid) = create_dummy_key_pair(RoleId::Role0).unwrap();
+    let mut key_provider = TestVerifyingKeyProvider::default();
+    key_provider.add_pk(kid.clone(), pk);
+
     // Create a main comment doc, contain all fields mention in the document (except
     // revocations and section)
     let doc = Builder::new()
@@ -136,6 +148,8 @@ async fn test_valid_comment_doc() {
         .unwrap()
         .with_json_content(&serde_json::json!({}))
         .unwrap()
+        .add_signature(|m| sk.sign(&m).to_vec(), kid)
+        .unwrap()
         .build()
         .unwrap();
 
@@ -147,6 +161,59 @@ async fn test_valid_comment_doc() {
 
     let is_valid = validator::validate(&doc, &provider).await.unwrap();
     assert!(is_valid, "{:?}", doc.problem_report());
+
+    let is_valid = validator::validate_signatures(&doc, &key_provider)
+        .await
+        .unwrap();
+    assert!(is_valid);
+}
+
+#[tokio::test]
+async fn test_invalid_comment_doc_wrong_role() {
+    let (sk, _pk, kid) = create_dummy_key_pair(RoleId::Proposer).unwrap();
+
+    // Create a main comment doc, contain all fields mention in the document (except
+    // revocations and section)
+    let doc = Builder::new()
+        .with_json_metadata(serde_json::json!({
+            "content-type": ContentType::Json.to_string(),
+            "content-encoding": ContentEncoding::Brotli.to_string(),
+            "type": doc_types::PROPOSAL_COMMENT.clone(),
+            "id": UuidV7::new(),
+            "ver": UuidV7::new(),
+            "ref": {
+                "id": DUMMY_PROPOSAL_DOC.doc_id().unwrap(),
+                "ver": DUMMY_PROPOSAL_DOC.doc_ver().unwrap(),
+            },
+            "template": {
+                "id": COMMENT_TEMPLATE_DOC.doc_id().unwrap(),
+                "ver": COMMENT_TEMPLATE_DOC.doc_ver().unwrap(),
+            },
+            "reply": {
+                "id": COMMENT_REF_DOC.doc_id().unwrap(),
+                "ver": COMMENT_REF_DOC.doc_ver().unwrap()
+            },
+            "parameters": {
+                "id": DUMMY_BRAND_DOC.doc_id().unwrap(),
+                "ver": DUMMY_BRAND_DOC.doc_ver().unwrap(),
+            }
+        }))
+        .unwrap()
+        .with_json_content(&serde_json::json!({}))
+        .unwrap()
+        .add_signature(|m| sk.sign(&m).to_vec(), kid)
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let mut provider = TestCatalystSignedDocumentProvider::default();
+    provider.add_document(None, &DUMMY_BRAND_DOC).unwrap();
+    provider.add_document(None, &DUMMY_PROPOSAL_DOC).unwrap();
+    provider.add_document(None, &COMMENT_REF_DOC).unwrap();
+    provider.add_document(None, &COMMENT_TEMPLATE_DOC).unwrap();
+
+    let is_valid = validator::validate(&doc, &provider).await.unwrap();
+    assert!(!is_valid, "{:?}", doc.problem_report());
 }
 
 // The same as above but test with the old type

--- a/rust/signed_doc/tests/proposal.rs
+++ b/rust/signed_doc/tests/proposal.rs
@@ -112,7 +112,7 @@ async fn test_valid_proposal_doc() {
 }
 
 #[tokio::test]
-async fn test_ivalid_proposal_doc_wrong_role() {
+async fn test_invalid_proposal_doc_wrong_role() {
     let (sk, _pk, kid) = create_dummy_key_pair(RoleId::Role0).unwrap();
 
     // Create a main proposal doc, contain all fields mention in the document (except

--- a/rust/signed_doc/tests/proposal.rs
+++ b/rust/signed_doc/tests/proposal.rs
@@ -5,8 +5,16 @@
 use std::sync::LazyLock;
 
 use catalyst_signed_doc::{
-    doc_types::deprecated, providers::tests::TestCatalystSignedDocumentProvider, *,
+    doc_types::deprecated,
+    providers::tests::{TestCatalystSignedDocumentProvider, TestVerifyingKeyProvider},
+    *,
 };
+use catalyst_types::catalyst_id::role_index::RoleId;
+use ed25519_dalek::ed25519::signature::Signer;
+
+use crate::common::create_dummy_key_pair;
+
+mod common;
 
 #[allow(clippy::unwrap_used)]
 static DUMMY_BRAND_DOC: LazyLock<CatalystSignedDocument> = LazyLock::new(|| {
@@ -59,6 +67,10 @@ static PROPOSAL_TEMPLATE_DOC: LazyLock<CatalystSignedDocument> = LazyLock::new(|
 // `parameters` value as `doc`.
 #[tokio::test]
 async fn test_valid_proposal_doc() {
+    let (sk, pk, kid) = create_dummy_key_pair(RoleId::Proposer).unwrap();
+    let mut key_provider = TestVerifyingKeyProvider::default();
+    key_provider.add_pk(kid.clone(), pk);
+
     // Create a main proposal doc, contain all fields mention in the document (except
     // collaborations and revocations)
     let doc = Builder::new()
@@ -80,6 +92,8 @@ async fn test_valid_proposal_doc() {
         .unwrap()
         .with_json_content(&serde_json::json!({}))
         .unwrap()
+        .add_signature(|m| sk.sign(&m).to_vec(), kid)
+        .unwrap()
         .build()
         .unwrap();
 
@@ -90,6 +104,50 @@ async fn test_valid_proposal_doc() {
 
     let is_valid = validator::validate(&doc, &provider).await.unwrap();
     assert!(is_valid);
+
+    let is_valid = validator::validate_signatures(&doc, &key_provider)
+        .await
+        .unwrap();
+    assert!(is_valid);
+}
+
+#[tokio::test]
+async fn test_ivalid_proposal_doc_wrong_role() {
+    let (sk, _pk, kid) = create_dummy_key_pair(RoleId::Role0).unwrap();
+
+    // Create a main proposal doc, contain all fields mention in the document (except
+    // collaborations and revocations)
+    let doc = Builder::new()
+        .with_json_metadata(serde_json::json!({
+            "content-type": ContentType::Json.to_string(),
+            "content-encoding": ContentEncoding::Brotli.to_string(),
+            "type": doc_types::PROPOSAL.clone(),
+            "id": UuidV7::new(),
+            "ver": UuidV7::new(),
+            "template": {
+                "id": PROPOSAL_TEMPLATE_DOC.doc_id().unwrap(),
+                "ver": PROPOSAL_TEMPLATE_DOC.doc_ver().unwrap(),
+            },
+            "parameters": {
+                "id": DUMMY_BRAND_DOC.doc_id().unwrap(),
+                "ver": DUMMY_BRAND_DOC.doc_ver().unwrap(),
+            }
+        }))
+        .unwrap()
+        .with_json_content(&serde_json::json!({}))
+        .unwrap()
+        .add_signature(|m| sk.sign(&m).to_vec(), kid)
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let mut provider = TestCatalystSignedDocumentProvider::default();
+
+    provider.add_document(None, &PROPOSAL_TEMPLATE_DOC).unwrap();
+    provider.add_document(None, &DUMMY_BRAND_DOC).unwrap();
+
+    let is_valid = validator::validate(&doc, &provider).await.unwrap();
+    assert!(!is_valid);
 }
 
 #[tokio::test]

--- a/rust/signed_doc/tests/submission.rs
+++ b/rust/signed_doc/tests/submission.rs
@@ -5,8 +5,16 @@
 use std::sync::LazyLock;
 
 use catalyst_signed_doc::{
-    doc_types::deprecated, providers::tests::TestCatalystSignedDocumentProvider, *,
+    doc_types::deprecated,
+    providers::tests::{TestCatalystSignedDocumentProvider, TestVerifyingKeyProvider},
+    *,
 };
+use catalyst_types::catalyst_id::role_index::RoleId;
+use ed25519_dalek::ed25519::signature::Signer;
+
+use crate::common::create_dummy_key_pair;
+
+mod common;
 
 #[allow(clippy::unwrap_used)]
 static DUMMY_PROPOSAL_DOC: LazyLock<CatalystSignedDocument> = LazyLock::new(|| {
@@ -51,6 +59,10 @@ static DUMMY_BRAND_DOC: LazyLock<CatalystSignedDocument> = LazyLock::new(|| {
 // `parameters` value as `doc`.
 #[tokio::test]
 async fn test_valid_submission_action() {
+    let (sk, pk, kid) = create_dummy_key_pair(RoleId::Proposer).unwrap();
+    let mut key_provider = TestVerifyingKeyProvider::default();
+    key_provider.add_pk(kid.clone(), pk);
+
     // Create a main proposal submission doc, contain all fields mention in the document
     let doc = Builder::new()
         .with_json_metadata(serde_json::json!({
@@ -73,6 +85,8 @@ async fn test_valid_submission_action() {
             "action": "final"
         }))
         .unwrap()
+        .add_signature(|m| sk.sign(&m).to_vec(), kid)
+        .unwrap()
         .build()
         .unwrap();
 
@@ -83,6 +97,51 @@ async fn test_valid_submission_action() {
 
     let is_valid = validator::validate(&doc, &provider).await.unwrap();
     assert!(is_valid, "{:?}", doc.problem_report());
+
+    let is_valid = validator::validate_signatures(&doc, &key_provider)
+        .await
+        .unwrap();
+    assert!(is_valid);
+}
+
+#[tokio::test]
+async fn test_invalid_submission_action_wrong_role() {
+    let (sk, _pk, kid) = create_dummy_key_pair(RoleId::Role0).unwrap();
+
+    // Create a main proposal submission doc, contain all fields mention in the document
+    let doc = Builder::new()
+        .with_json_metadata(serde_json::json!({
+            "content-type": ContentType::Json.to_string(),
+            "content-encoding": ContentEncoding::Brotli.to_string(),
+            "type": doc_types::PROPOSAL_SUBMISSION_ACTION.clone(),
+            "id": UuidV7::new(),
+            "ver": UuidV7::new(),
+            "ref": {
+                "id": DUMMY_PROPOSAL_DOC.doc_id().unwrap(),
+                "ver": DUMMY_PROPOSAL_DOC.doc_ver().unwrap(),
+            },
+            "parameters": {
+                "id": DUMMY_BRAND_DOC.doc_id().unwrap(),
+                "ver": DUMMY_BRAND_DOC.doc_ver().unwrap(),
+            }
+        }))
+        .unwrap()
+        .with_json_content(&serde_json::json!({
+            "action": "final"
+        }))
+        .unwrap()
+        .add_signature(|m| sk.sign(&m).to_vec(), kid)
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let mut provider = TestCatalystSignedDocumentProvider::default();
+
+    provider.add_document(None, &DUMMY_PROPOSAL_DOC).unwrap();
+    provider.add_document(None, &DUMMY_BRAND_DOC).unwrap();
+
+    let is_valid = validator::validate(&doc, &provider).await.unwrap();
+    assert!(!is_valid);
 }
 
 #[tokio::test]


### PR DESCRIPTION
# Description

- Added `*_wrong_role` integration test cases. Validate signature validation to the existing one

## Related Issue(s)

Part of https://github.com/input-output-hk/catalyst-libs/issues/330