### PR TITLE
fix(rust): Newest `nightly` `1.90` lint `mismatched_lifetime_syntaxes`

### DIFF
--- a/rust/cardano-blockchain-types/src/multi_era_block_data.rs
+++ b/rust/cardano-blockchain-types/src/multi_era_block_data.rs
@@ -163,7 +163,7 @@ impl MultiEraBlock {
     /// The decoded block data, which can easily be processed by a consumer.
     #[must_use]
     #[allow(clippy::missing_panics_doc)]
-    pub fn decode(&self) -> &pallas::ledger::traverse::MultiEraBlock {
+    pub fn decode(&self) -> &pallas::ledger::traverse::MultiEraBlock<'_> {
         self.inner.data.borrow_block()
     }
 
@@ -275,12 +275,12 @@ impl MultiEraBlock {
 
     /// Returns a list of transactions withing this block.
     #[must_use]
-    pub fn txs(&self) -> Vec<MultiEraTx> {
+    pub fn txs(&self) -> Vec<MultiEraTx<'_>> {
         self.decode().txs()
     }
 
     /// Returns an iterator over `(TxnIndex, MultiEraTx)` pair.
-    pub fn enumerate_txs(&self) -> impl Iterator<Item = (TxnIndex, MultiEraTx)> {
+    pub fn enumerate_txs(&self) -> impl Iterator<Item = (TxnIndex, MultiEraTx<'_>)> {
         self.txs()
             .into_iter()
             .enumerate()


### PR DESCRIPTION
# Description

Fixing a newest nightly` 1.90` lint [`mismatched_lifetime_syntaxes`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint/lifetime_syntax/static.MISMATCHED_LIFETIME_SYNTAXES.html) which fails our earthly builds on the empty freshed cache.

```shell
 cat-libs-rust+build *failed* |   . error: lifetime flowing from input to output with different syntax can be 
 cat-libs-rust+build *failed* | confusing
 cat-libs-rust+build *failed* |   .    --> cardano-blockchain-types/src/multi_era_block_data.rs:166:19
 cat-libs-rust+build *failed* |   .     |
 cat-libs-rust+build *failed* |   . 166 |     pub fn decode(&self) -> &pallas::ledger::traverse::MultiEraBlock {
 cat-libs-rust+build *failed* |   .     |                   ^^^^^     ----------------------------------------
 cat-libs-rust+build *failed* |   .     |                   |         ||
 cat-libs-rust+build *failed* |   .     |                   |         |the lifetimes get resolved as `'_`
 cat-libs-rust+build *failed* |   .     |                   |         the lifetimes get resolved as `'_`
 cat-libs-rust+build *failed* |   .     |                   this lifetime flows to the output
 cat-libs-rust+build *failed* |   .     |
 cat-libs-rust+build *failed* |   .     = note: `-D mismatched-lifetime-syntaxes` implied by `-D warnings`
 cat-libs-rust+build *failed* |   .     = help: to override `-D warnings` add 
 cat-libs-rust+build *failed* | `#[allow(mismatched_lifetime_syntaxes)]`
 cat-libs-rust+build *failed* |   . help: one option is to remove the lifetime for references and use the 
 cat-libs-rust+build *failed* | anonymous lifetime for paths
 cat-libs-rust+build *failed* |   .     |
 cat-libs-rust+build *failed* |   . 166 |     pub fn decode(&self) -> 
 cat-libs-rust+build *failed* | &pallas::ledger::traverse::MultiEraBlock<'_> {
 cat-libs-rust+build *failed* |   .     |                                                                     
 cat-libs-rust+build *failed* | ++++

 cat-libs-rust+build *failed* |   . error: lifetime flowing from input to output with different syntax can be 
 cat-libs-rust+build *failed* | confusing
 cat-libs-rust+build *failed* |   .    --> cardano-blockchain-types/src/multi_era_block_data.rs:278:16
 cat-libs-rust+build *failed* |   .     |
 cat-libs-rust+build *failed* |   . 278 |     pub fn txs(&self) -> Vec<MultiEraTx> {
 cat-libs-rust+build *failed* |   .     |                ^^^^^         ---------- the lifetime gets resolved as 
 cat-libs-rust+build *failed* | `'_`
 cat-libs-rust+build *failed* |   .     |                |
 cat-libs-rust+build *failed* |   .     |                this lifetime flows to the output
 cat-libs-rust+build *failed* |   .     |
 cat-libs-rust+build *failed* |   . help: one option is to remove the lifetime for references and use the 
 cat-libs-rust+build *failed* | anonymous lifetime for paths
 cat-libs-rust+build *failed* |   .     |
 cat-libs-rust+build *failed* |   . 278 |     pub fn txs(&self) -> Vec<MultiEraTx<'_>> {
 cat-libs-rust+build *failed* |   .     |                                        ++++

 cat-libs-rust+build *failed* |   . error: lifetime flowing from input to output with different syntax can be 
 cat-libs-rust+build *failed* | confusing
 cat-libs-rust+build *failed* |   .    --> cardano-blockchain-types/src/multi_era_block_data.rs:283:26
 cat-libs-rust+build *failed* |   .     |
 cat-libs-rust+build *failed* |   . 283 |     pub fn enumerate_txs(&self) -> impl Iterator<Item = (TxnIndex, 
 cat-libs-rust+build *failed* | MultiEraTx)> {
 cat-libs-rust+build *failed* |   .     |                          ^^^^^ this lifetime flows to the output   
 cat-libs-rust+build *failed* | ---------- the lifetime gets resolved as `'_`
 cat-libs-rust+build *failed* |   .     |
 cat-libs-rust+build *failed* |   . help: one option is to remove the lifetime for references and use the 
 cat-libs-rust+build *failed* | anonymous lifetime for paths
 cat-libs-rust+build *failed* |   .     |
 cat-libs-rust+build *failed* |   . 283 |     pub fn enumerate_txs(&self) -> impl Iterator<Item = (TxnIndex, 
 cat-libs-rust+build *failed* | MultiEraTx<'_>)> {
 cat-libs-rust+build *failed* |   .     |                                                                       
 cat-libs-rust+build *failed* | ++++
```