### PR TITLE
feat(rust/signed-doc): Add tests for minimal and full metadata fields

### DIFF
--- a/rust/signed_doc/tests/decoding.rs
+++ b/rust/signed_doc/tests/decoding.rs
@@ -498,7 +498,6 @@ fn decoding_empty_bytes_case() -> TestCase {
     }
 }
 
-#[allow(dead_code)]
 fn signed_doc_with_minimal_metadata_fields_case() -> TestCase {
     let uuid_v7 = UuidV7::new();
     let uuid_v4 = UuidV4::new();
@@ -564,7 +563,6 @@ fn signed_doc_with_minimal_metadata_fields_case() -> TestCase {
     }
 }
 
-#[allow(dead_code)]
 fn signed_doc_with_complete_metadata_fields_case() -> TestCase {
     let uuid_v7 = UuidV7::new();
     let uuid_v4 = UuidV4::new();
@@ -640,7 +638,6 @@ fn signed_doc_with_complete_metadata_fields_case() -> TestCase {
     }
 }
 
-#[allow(clippy::unwrap_used)]
 fn minimally_valid_tagged_signed_doc() -> TestCase {
     let uuid_v7 = UuidV7::new();
     let uuid_v4 = UuidV4::new();
@@ -681,16 +678,16 @@ fn minimally_valid_tagged_signed_doc() -> TestCase {
         valid_doc: true,
         post_checks: Some(Box::new({
             move |doc| {
-                anyhow::ensure!(doc.doc_type().unwrap() == &DocType::from(uuid_v4));
-                anyhow::ensure!(doc.doc_id().unwrap() == uuid_v7);
-                anyhow::ensure!(doc.doc_ver().unwrap() == uuid_v7);
-                anyhow::ensure!(doc.doc_content_type().unwrap() == ContentType::Json);
+                anyhow::ensure!(doc.doc_type()? == &DocType::from(uuid_v4));
+                anyhow::ensure!(doc.doc_id()? == uuid_v7);
+                anyhow::ensure!(doc.doc_ver()? == uuid_v7);
+                anyhow::ensure!(doc.doc_content_type()? == ContentType::Json);
                 anyhow::ensure!(doc.doc_meta().doc_ref().is_none());
                 anyhow::ensure!(doc.doc_meta().template().is_none());
                 anyhow::ensure!(doc.doc_meta().reply().is_none());
                 anyhow::ensure!(doc.doc_meta().parameters().is_none());
                 anyhow::ensure!(
-                    doc.encoded_content() == serde_json::to_vec(&serde_json::Value::Null).unwrap()
+                    doc.encoded_content() == serde_json::to_vec(&serde_json::Value::Null)?
                 );
                 Ok(())
             }
@@ -698,7 +695,6 @@ fn minimally_valid_tagged_signed_doc() -> TestCase {
     }
 }
 
-#[allow(clippy::unwrap_used)]
 fn minimally_valid_untagged_signed_doc() -> TestCase {
     let uuid_v7 = UuidV7::new();
     let uuid_v4 = UuidV4::new();
@@ -738,16 +734,16 @@ fn minimally_valid_untagged_signed_doc() -> TestCase {
         valid_doc: true,
         post_checks: Some(Box::new({
             move |doc| {
-                anyhow::ensure!(doc.doc_type().unwrap() == &DocType::from(uuid_v4));
-                anyhow::ensure!(doc.doc_id().unwrap() == uuid_v7);
-                anyhow::ensure!(doc.doc_ver().unwrap() == uuid_v7);
-                anyhow::ensure!(doc.doc_content_type().unwrap() == ContentType::Json);
+                anyhow::ensure!(doc.doc_type()? == &DocType::from(uuid_v4));
+                anyhow::ensure!(doc.doc_id()? == uuid_v7);
+                anyhow::ensure!(doc.doc_ver()? == uuid_v7);
+                anyhow::ensure!(doc.doc_content_type()? == ContentType::Json);
                 anyhow::ensure!(doc.doc_meta().doc_ref().is_none());
                 anyhow::ensure!(doc.doc_meta().template().is_none());
                 anyhow::ensure!(doc.doc_meta().reply().is_none());
                 anyhow::ensure!(doc.doc_meta().parameters().is_none());
                 anyhow::ensure!(
-                    doc.encoded_content() == serde_json::to_vec(&serde_json::Value::Null).unwrap()
+                    doc.encoded_content() == serde_json::to_vec(&serde_json::Value::Null)?
                 );
                 Ok(())
             }

--- a/rust/signed_doc/tests/decoding.rs
+++ b/rust/signed_doc/tests/decoding.rs
@@ -599,7 +599,7 @@ fn signed_doc_with_complete_metadata_fields_case() -> TestCase {
                     .encode_with(doc_ref.clone(), &mut ())?;
                 p_headers.str("section")?.encode("$")?;
 
-                p_headers.str("collabs")?.encode(["collab 1", "collab 2"])?;
+                p_headers.str("collabs")?.encode(["collaborator 1", "collaborator 2"])?;
                 p_headers.str("parameters")?.encode_with(uuid_v7, &mut catalyst_types::uuid::CborContext::Tagged)?;
 
                 e.bytes(p_headers.into_writer().as_slice())?;

--- a/rust/signed_doc/tests/decoding.rs
+++ b/rust/signed_doc/tests/decoding.rs
@@ -498,7 +498,8 @@ fn decoding_empty_bytes_case() -> TestCase {
     }
 }
 
-fn signed_doc_with_all_fields_case() -> TestCase {
+#[allow(dead_code)]
+fn signed_doc_with_minimal_metadata_fields_case() -> TestCase {
     let uuid_v7 = UuidV7::new();
     let uuid_v4 = UuidV4::new();
 
@@ -512,13 +513,94 @@ fn signed_doc_with_all_fields_case() -> TestCase {
                 e.tag(Tag::new(98))?;
                 e.array(4)?;
                 // protected headers (metadata fields)
+                e.bytes({
+                    let mut p_headers = Encoder::new(Vec::new());
+
+                    p_headers.map(4)?;
+                    p_headers.u8(3)?.encode(ContentType::Json)?;
+                    p_headers
+                        .str("type")?
+                        .encode_with(uuid_v4, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                    p_headers
+                        .str("id")?
+                        .encode_with(uuid_v7, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                    p_headers
+                        .str("ver")?
+                        .encode_with(uuid_v7, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                    p_headers.into_writer().as_slice()
+                })?;
+                // empty unprotected headers
+                e.map(0)?;
+                // content
+                e.bytes(serde_json::to_vec(&serde_json::Value::Null)?.as_slice())?;
+                // signatures
+                // one signature
+                e.array(1)?;
+                e.array(3)?;
+                // protected headers (kid field)
+                let mut p_headers = minicbor::Encoder::new(Vec::new());
+                p_headers.map(1)?.u8(4)?.bytes(Vec::<u8>::from(&kid).as_slice())?;
+                e.bytes(p_headers.into_writer().as_slice())?;
+                e.map(0)?;
+                e.bytes(&[1, 2, 3])?;
+                Ok(e)
+            }
+        }),
+        can_decode: true,
+        valid_doc: true,
+        post_checks: Some(Box::new({
+            move |doc| {
+                anyhow::ensure!(doc.doc_type()? == &DocType::from(uuid_v4));
+                anyhow::ensure!(doc.doc_id()? == uuid_v7);
+                anyhow::ensure!(doc.doc_ver()? == uuid_v7);
+                anyhow::ensure!(doc.doc_content_type()? == ContentType::Json);
+                anyhow::ensure!(
+                    doc.encoded_content() == serde_json::to_vec(&serde_json::Value::Null)?
+                );
+                anyhow::ensure!(doc.kids().len() == 1);
+                Ok(())
+            }
+        })),
+    }
+}
+
+#[allow(dead_code)]
+fn signed_doc_with_complete_metadata_fields_case() -> TestCase {
+    let uuid_v7 = UuidV7::new();
+    let uuid_v4 = UuidV4::new();
+    let doc_ref = DocumentRef::new(UuidV7::new(), UuidV7::new(), DocLocator::default());
+    let doc_ref_cloned = doc_ref.clone();
+
+    TestCase {
+        name: "Catalyst Signed Doc with all metadata fields defined, signed (one signature), CBOR tagged.".to_string(),
+        bytes_gen: Box::new({
+            move || {
+                let (_, _, kid) = create_dummy_key_pair(RoleId::Role0)?;
+
+                let mut e = Encoder::new(Vec::new());
+                e.tag(Tag::new(98))?;
+                e.array(4)?;
+                // protected headers (metadata fields)
                 let mut p_headers = Encoder::new(Vec::new());
 
-                p_headers.map(4)?;
+                p_headers.map(9)?;
                 p_headers.u8(3)?.encode(ContentType::Json)?;
                 p_headers.str("type")?.encode_with(uuid_v4, &mut catalyst_types::uuid::CborContext::Tagged)?;
                 p_headers.str("id")?.encode_with(uuid_v7, &mut catalyst_types::uuid::CborContext::Tagged)?;
                 p_headers.str("ver")?.encode_with(uuid_v7, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                p_headers
+                    .str("ref")?
+                    .encode_with(doc_ref.clone(), &mut ())?;
+                p_headers
+                    .str("template")?
+                    .encode_with(doc_ref.clone(), &mut ())?;
+                p_headers
+                    .str("reply")?
+                    .encode_with(doc_ref.clone(), &mut ())?;
+                p_headers.str("section")?.encode("$")?;
+
+                p_headers.str("collabs")?.encode(["collab 1", "collab 2"])?;
+                p_headers.str("parameters")?.encode_with(uuid_v7, &mut catalyst_types::uuid::CborContext::Tagged)?;
 
                 e.bytes(p_headers.into_writer().as_slice())?;
                 // empty unprotected headers
@@ -542,9 +624,13 @@ fn signed_doc_with_all_fields_case() -> TestCase {
         valid_doc: true,
         post_checks: Some(Box::new({
             move |doc| {
+                let refs = DocumentRefs::from(vec![doc_ref_cloned.clone()]);
                 anyhow::ensure!(doc.doc_type()? == &DocType::from(uuid_v4));
                 anyhow::ensure!(doc.doc_id()? == uuid_v7);
                 anyhow::ensure!(doc.doc_ver()? == uuid_v7);
+                anyhow::ensure!(doc.doc_meta().doc_ref() == Some(&refs));
+                anyhow::ensure!(doc.doc_meta().template() == Some(&refs));
+                anyhow::ensure!(doc.doc_meta().reply() == Some(&refs));
                 anyhow::ensure!(doc.doc_content_type()? == ContentType::Json);
                 anyhow::ensure!(doc.encoded_content() == serde_json::to_vec(&serde_json::Value::Null)?);
                 anyhow::ensure!(doc.kids().len() == 1);
@@ -673,7 +759,8 @@ fn minimally_valid_untagged_signed_doc() -> TestCase {
 fn catalyst_signed_doc_decoding_test() {
     let test_cases = [
         decoding_empty_bytes_case(),
-        signed_doc_with_all_fields_case(),
+        signed_doc_with_minimal_metadata_fields_case(),
+        signed_doc_with_complete_metadata_fields_case(),
         signed_doc_with_random_kid_case(),
         signed_doc_with_wrong_cose_tag_case(),
         signed_doc_with_content_encoding_case(true),
@@ -681,6 +768,7 @@ fn catalyst_signed_doc_decoding_test() {
         signed_doc_with_valid_alias_case("category_id"),
         signed_doc_with_valid_alias_case("brand_id"),
         signed_doc_with_valid_alias_case("campaign_id"),
+        signed_doc_with_valid_alias_case("parameters"),
         signed_doc_with_missing_header_field_case("content-type"),
         signed_doc_with_missing_header_field_case("type"),
         signed_doc_with_missing_header_field_case("id"),


### PR DESCRIPTION
# Description

Adds test cases for Catalyst Signed Docs:

* Valid minimal metadata fields in document.
* Valid complete metadata fields in document.

This is part of #336 

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
