### PR TITLE
fix(docs): Fixing python linting issues

### DIFF
--- a/specs/generators/src/docs/graphviz_doc_diagram.py
+++ b/specs/generators/src/docs/graphviz_doc_diagram.py
@@ -373,14 +373,7 @@ class DotLink(BaseModel):
 
     def __hash__(self) -> int:
         """Hash."""
-        return hash(
-            (
-                self.src,
-                self.dst,
-                self.directed,
-                self.theme
-            )
-        )
+        return hash((self.src, self.dst, self.directed, self.theme))
 
     def __repr__(self) -> str:
         """Repr."""


### PR DESCRIPTION
# Description

- Fixing some python linting issues

```
(PLW1641),file=/work/specs/generators/src/docs/graphviz_doc_diagram.py,line=165,col=7,endLine=165,endColumn=14::specs/generators/src/docs/graphviz_doc_diagram.py:165:7: PLW1641 Object does not implement `__hash__` method
         +check-python *failed* | ::error title=Ruff (PLW1641),file=/work/specs/generators/src/docs/graphviz_doc_diagram.py,line=291,col=7,endLine=291,endColumn=17::specs/generators/src/docs/graphviz_doc_diagram.py:291:7: PLW1641 Object does not implement `__hash__` method
         +check-python *failed* | ::error title=Ruff (PLW1641),file=/work/specs/generators/src/docs/graphviz_doc_diagram.py,line=336,col=7,endLine=336,endColumn=14::specs/generators/src/docs/graphviz_doc_diagram.py:336:7: PLW1641 Object does not implement `__hash__` method
```