### PR TITLE
feat(rust/signed-doc): Added more decoding test cases, cleaned up `DecodeContext`

### DIFF
--- a/rust/signed_doc/bins/mk_signed_doc.rs
+++ b/rust/signed_doc/bins/mk_signed_doc.rs
@@ -129,7 +129,7 @@ fn save_signed_doc(signed_doc: CatalystSignedDocument, path: &PathBuf) -> anyhow
 }
 
 fn signed_doc_from_bytes(cose_bytes: &[u8]) -> anyhow::Result<CatalystSignedDocument> {
-    minicbor::decode(cose_bytes).context("Invalid Catalyst Document")
+    cose_bytes.try_into().context("Invalid Catalyst Document")
 }
 
 fn load_json_from_file<T>(path: &PathBuf) -> anyhow::Result<T>

--- a/rust/signed_doc/src/decode_context.rs
+++ b/rust/signed_doc/src/decode_context.rs
@@ -3,9 +3,8 @@
 use catalyst_types::problem_report::ProblemReport;
 
 /// Compatibility policy
-#[allow(dead_code)]
 #[derive(Copy, Clone)]
-pub(crate) enum CompatibilityPolicy {
+pub enum CompatibilityPolicy {
     /// Silently allow obsoleted type conversions or non deterministic encoding.
     Accept,
     /// Allow but log Warnings for all obsoleted type conversions or non deterministic
@@ -17,9 +16,30 @@ pub(crate) enum CompatibilityPolicy {
 }
 
 /// A context use to pass to decoder.
-pub(crate) struct DecodeContext<'r> {
+pub(crate) struct DecodeContext {
     /// Compatibility policy.
-    pub compatibility_policy: CompatibilityPolicy,
+    compatibility_policy: CompatibilityPolicy,
     /// Problem report.
-    pub report: &'r mut ProblemReport,
+    report: ProblemReport,
+}
+
+impl DecodeContext {
+    pub(crate) fn new(compatibility_policy: CompatibilityPolicy, report: ProblemReport) -> Self {
+        Self {
+            compatibility_policy,
+            report,
+        }
+    }
+
+    pub(crate) fn policy(&self) -> &CompatibilityPolicy {
+        &self.compatibility_policy
+    }
+
+    pub(crate) fn report(&mut self) -> &mut ProblemReport {
+        &mut self.report
+    }
+
+    pub(crate) fn into_report(self) -> ProblemReport {
+        self.report
+    }
 }

--- a/rust/signed_doc/src/decode_context.rs
+++ b/rust/signed_doc/src/decode_context.rs
@@ -24,6 +24,7 @@ pub(crate) struct DecodeContext {
 }
 
 impl DecodeContext {
+    /// Creates a new instance of the `DecodeContext`
     pub(crate) fn new(compatibility_policy: CompatibilityPolicy, report: ProblemReport) -> Self {
         Self {
             compatibility_policy,
@@ -31,14 +32,18 @@ impl DecodeContext {
         }
     }
 
+    /// Returns `CompatibilityPolicy`
     pub(crate) fn policy(&self) -> &CompatibilityPolicy {
         &self.compatibility_policy
     }
 
+    /// Returns `ProblemReport`
     pub(crate) fn report(&mut self) -> &mut ProblemReport {
         &mut self.report
     }
 
+    /// Consuming the current `DecodeContext` by returning the underlying `ProblemReport`
+    /// instance
     pub(crate) fn into_report(self) -> ProblemReport {
         self.report
     }

--- a/rust/signed_doc/src/lib.rs
+++ b/rust/signed_doc/src/lib.rs
@@ -2,7 +2,7 @@
 
 mod builder;
 mod content;
-mod decode_context;
+pub mod decode_context;
 pub mod doc_types;
 mod metadata;
 pub mod providers;
@@ -210,11 +210,10 @@ impl CatalystSignedDocument {
 
 impl Decode<'_, ()> for CatalystSignedDocument {
     fn decode(d: &mut Decoder<'_>, _ctx: &mut ()) -> Result<Self, decode::Error> {
-        let mut report = ProblemReport::new("Catalyst Signed Document Decoding");
-        let mut ctx = DecodeContext {
-            compatibility_policy: CompatibilityPolicy::Accept,
-            report: &mut report,
-        };
+        let mut ctx = DecodeContext::new(
+            CompatibilityPolicy::Accept,
+            ProblemReport::new("Catalyst Signed Document Decoding"),
+        );
 
         let p = d.position();
         if let Ok(tag) = d.tag() {
@@ -246,7 +245,7 @@ impl Decode<'_, ()> for CatalystSignedDocument {
         )?
         .into_iter();
         if map.next().is_some() {
-            ctx.report.unknown_field(
+            ctx.report().unknown_field(
                 "unprotected headers",
                 "non empty unprotected headers",
                 "COSE unprotected headers must be empty",
@@ -260,7 +259,7 @@ impl Decode<'_, ()> for CatalystSignedDocument {
             metadata,
             content,
             signatures,
-            report,
+            report: ctx.into_report(),
         }
         .into())
     }

--- a/rust/signed_doc/src/lib.rs
+++ b/rust/signed_doc/src/lib.rs
@@ -208,10 +208,10 @@ impl CatalystSignedDocument {
     }
 }
 
-impl Decode<'_, ()> for CatalystSignedDocument {
-    fn decode(d: &mut Decoder<'_>, _ctx: &mut ()) -> Result<Self, decode::Error> {
+impl Decode<'_, CompatibilityPolicy> for CatalystSignedDocument {
+    fn decode(d: &mut Decoder<'_>, ctx: &mut CompatibilityPolicy) -> Result<Self, decode::Error> {
         let mut ctx = DecodeContext::new(
-            CompatibilityPolicy::Accept,
+            *ctx,
             ProblemReport::new("Catalyst Signed Document Decoding"),
         );
 
@@ -293,7 +293,10 @@ impl TryFrom<&[u8]> for CatalystSignedDocument {
     type Error = anyhow::Error;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(minicbor::decode(value)?)
+        Ok(minicbor::decode_with(
+            value,
+            &mut CompatibilityPolicy::Accept,
+        )?)
     }
 }
 

--- a/rust/signed_doc/src/metadata/document_refs/doc_ref.rs
+++ b/rust/signed_doc/src/metadata/document_refs/doc_ref.rs
@@ -62,21 +62,21 @@ impl Display for DocumentRef {
     }
 }
 
-impl Decode<'_, DecodeContext<'_>> for DocumentRef {
+impl Decode<'_, DecodeContext> for DocumentRef {
     fn decode(
-        d: &mut minicbor::Decoder<'_>, decode_context: &mut DecodeContext<'_>,
+        d: &mut minicbor::Decoder<'_>, decode_context: &mut DecodeContext,
     ) -> Result<Self, minicbor::decode::Error> {
         const CONTEXT: &str = "DocumentRef decoding";
         let parse_uuid = |d: &mut Decoder| UuidV7::decode(d, &mut CborContext::Tagged);
 
         let arr = d.array()?.ok_or_else(|| {
             decode_context
-                .report
+                .report()
                 .other("Unable to decode array length", CONTEXT);
             minicbor::decode::Error::message(format!("{CONTEXT}: Unable to decode array length"))
         })?;
         if arr != DOC_REF_ARR_ITEM {
-            decode_context.report.invalid_value(
+            decode_context.report().invalid_value(
                 "Array length",
                 &arr.to_string(),
                 &DOC_REF_ARR_ITEM.to_string(),
@@ -88,21 +88,21 @@ impl Decode<'_, DecodeContext<'_>> for DocumentRef {
         }
         let id = parse_uuid(d).map_err(|e| {
             decode_context
-                .report
+                .report()
                 .other(&format!("Invalid ID UUIDv7: {e}"), CONTEXT);
             e.with_message("Invalid ID UUIDv7")
         })?;
 
         let ver = parse_uuid(d).map_err(|e| {
             decode_context
-                .report
+                .report()
                 .other(&format!("Invalid Ver UUIDv7: {e}"), CONTEXT);
             e.with_message("Invalid Ver UUIDv7")
         })?;
 
-        let locator = DocLocator::decode(d, decode_context.report).map_err(|e| {
+        let locator = DocLocator::decode(d, decode_context.report()).map_err(|e| {
             decode_context
-                .report
+                .report()
                 .other(&format!("Failed to decode locator {e}"), CONTEXT);
             e.with_message("Failed to decode locator")
         })?;

--- a/rust/signed_doc/src/metadata/mod.rs
+++ b/rust/signed_doc/src/metadata/mod.rs
@@ -239,7 +239,7 @@ impl minicbor::Encode<()> for Metadata {
     }
 }
 
-impl minicbor::Decode<'_, crate::decode_context::DecodeContext<'_>> for Metadata {
+impl minicbor::Decode<'_, crate::decode_context::DecodeContext> for Metadata {
     /// Decode from a CBOR map.
     ///
     /// Note that this won't decode an [RFC 8152] protected header as is.
@@ -250,9 +250,9 @@ impl minicbor::Decode<'_, crate::decode_context::DecodeContext<'_>> for Metadata
     ///
     /// [RFC 8152]: https://datatracker.ietf.org/doc/html/rfc8152#autoid-8
     fn decode(
-        d: &mut Decoder<'_>, ctx: &mut crate::decode_context::DecodeContext<'_>,
+        d: &mut Decoder<'_>, ctx: &mut crate::decode_context::DecodeContext,
     ) -> Result<Self, minicbor::decode::Error> {
-        let mut map_ctx = match ctx.compatibility_policy {
+        let mut map_ctx = match ctx.policy() {
             CompatibilityPolicy::Accept => {
                 cbork_utils::decode_context::DecodeCtx::non_deterministic()
             },
@@ -268,7 +268,7 @@ impl minicbor::Decode<'_, crate::decode_context::DecodeContext<'_>> for Metadata
             CompatibilityPolicy::Fail => cbork_utils::decode_context::DecodeCtx::Deterministic,
         };
 
-        let report = ctx.report.clone();
+        let report = ctx.report().clone();
         let fields = cbork_utils::map::Map::decode(d, &mut map_ctx)?
             .into_iter()
             .map(|e| {

--- a/rust/signed_doc/src/metadata/supported_field.rs
+++ b/rust/signed_doc/src/metadata/supported_field.rs
@@ -180,9 +180,9 @@ impl<'de> serde::de::DeserializeSeed<'de> for SupportedLabel {
     }
 }
 
-impl minicbor::Decode<'_, crate::decode_context::DecodeContext<'_>> for Option<SupportedField> {
+impl minicbor::Decode<'_, crate::decode_context::DecodeContext> for Option<SupportedField> {
     fn decode(
-        d: &mut minicbor::Decoder<'_>, ctx: &mut crate::decode_context::DecodeContext<'_>,
+        d: &mut minicbor::Decoder<'_>, ctx: &mut crate::decode_context::DecodeContext,
     ) -> Result<Self, minicbor::decode::Error> {
         const REPORT_CONTEXT: &str = "Metadata field decoding";
 
@@ -197,7 +197,7 @@ impl minicbor::Decode<'_, crate::decode_context::DecodeContext<'_>> for Option<S
                 d.input().get(value_start..value_end).unwrap_or_default(),
             )
             .to_string();
-            ctx.report
+            ctx.report()
                 .unknown_field(&label.to_string(), &value, REPORT_CONTEXT);
             return Ok(None);
         };
@@ -225,7 +225,7 @@ impl minicbor::Decode<'_, crate::decode_context::DecodeContext<'_>> for Option<S
             SupportedLabel::ContentEncoding => d.decode().map(SupportedField::ContentEncoding),
         }
         .inspect_err(|e| {
-            ctx.report.invalid_value(
+            ctx.report().invalid_value(
                 &format!("CBOR COSE protected header {key}"),
                 &hex::encode(cbor_bytes),
                 &format!("{e}"),

--- a/rust/signed_doc/tests/decoding.rs
+++ b/rust/signed_doc/tests/decoding.rs
@@ -3,7 +3,7 @@
 use catalyst_signed_doc::*;
 use catalyst_types::catalyst_id::role_index::RoleId;
 use common::create_dummy_key_pair;
-use minicbor::{data::Tag, Encoder};
+use minicbor::{data::Tag, Decode, Encoder};
 use rand::Rng;
 
 mod common;
@@ -1088,7 +1088,7 @@ fn catalyst_signed_doc_decoding_test() {
             bytes_res.err()
         );
         let bytes = bytes_res.unwrap().into_writer();
-        let doc_res = CatalystSignedDocument::try_from(bytes.as_slice());
+        let doc_res = CatalystSignedDocument::decode(&mut minicbor::Decoder::new(&bytes), &mut ());
         assert_eq!(
             doc_res.is_ok(),
             case.can_decode,

--- a/rust/signed_doc/tests/decoding.rs
+++ b/rust/signed_doc/tests/decoding.rs
@@ -1046,6 +1046,193 @@ fn signed_doc_with_signatures_non_empty_unprotected_headers() -> TestCase {
     }
 }
 
+fn signed_doc_with_strict_deterministic_decoding_correct_order() -> TestCase {
+    let uuid_v7 = UuidV7::new();
+    let uuid_v4 = UuidV4::new();
+
+    TestCase {
+        name: "Catalyst Signed Doc with minimally defined metadata fields, with enabled strictly decoded rules, metadata field in the correct order".to_string(),
+        bytes_gen: Box::new({
+            move || {
+                let (_, _, kid) = create_dummy_key_pair(RoleId::Role0)?;
+
+                let mut e = Encoder::new(Vec::new());
+                e.tag(Tag::new(98))?;
+                e.array(4)?;
+                // protected headers (metadata fields)
+                e.bytes({
+                    let mut p_headers = Encoder::new(Vec::new());
+
+                    p_headers.map(4)?;
+                    p_headers.u8(3)?.encode(ContentType::Json)?;
+                    p_headers
+                        .str("id")?
+                        .encode_with(uuid_v7, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                    p_headers
+                        .str("ver")?
+                        .encode_with(uuid_v7, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                    p_headers
+                        .str("type")?
+                        .array(1)?
+                        .encode_with(uuid_v4, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                    p_headers.into_writer().as_slice()
+                })?;
+                // empty unprotected headers
+                e.map(0)?;
+                // content
+                e.bytes(serde_json::to_vec(&serde_json::Value::Null)?.as_slice())?;
+                // signatures
+                // one signature
+                e.array(1)?;
+                e.array(3)?;
+                // protected headers (kid field)
+                let mut p_headers = minicbor::Encoder::new(Vec::new());
+                p_headers.map(1)?.u8(4)?.bytes(Vec::<u8>::from(&kid).as_slice())?;
+                e.bytes(p_headers.into_writer().as_slice())?;
+                e.map(0)?;
+                e.bytes(&[1, 2, 3])?;
+                Ok(e)
+            }
+        }),
+        policy: CompatibilityPolicy::Fail,
+        can_decode: true,
+        valid_doc: true,
+        post_checks: Some(Box::new({
+            move |doc| {
+                anyhow::ensure!(doc.doc_type()? == &DocType::from(uuid_v4));
+                anyhow::ensure!(doc.doc_id()? == uuid_v7);
+                anyhow::ensure!(doc.doc_ver()? == uuid_v7);
+                anyhow::ensure!(doc.doc_content_type()? == ContentType::Json);
+                anyhow::ensure!(
+                    doc.encoded_content() == serde_json::to_vec(&serde_json::Value::Null)?
+                );
+                anyhow::ensure!(doc.kids().len() == 1);
+                Ok(())
+            }
+        })),
+    }
+}
+
+fn signed_doc_with_strict_deterministic_decoding_wrong_order() -> TestCase {
+    let uuid_v7 = UuidV7::new();
+    let uuid_v4 = UuidV4::new();
+
+    TestCase {
+        name: "Catalyst Signed Doc with minimally defined metadata fields, with enabled strictly decoded rules, metadata field in the wrong order".to_string(),
+        bytes_gen: Box::new({
+            move || {
+                let (_, _, kid) = create_dummy_key_pair(RoleId::Role0)?;
+
+                let mut e = Encoder::new(Vec::new());
+                e.tag(Tag::new(98))?;
+                e.array(4)?;
+                // protected headers (metadata fields)
+                e.bytes({
+                    let mut p_headers = Encoder::new(Vec::new());
+
+                    p_headers.map(4)?;
+                    p_headers.u8(3)?.encode(ContentType::Json)?;
+                    p_headers
+                        .str("type")?.array(1)?
+                        .encode_with(uuid_v4, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                    p_headers
+                        .str("id")?
+                        .encode_with(uuid_v7, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                    p_headers
+                        .str("ver")?
+                        .encode_with(uuid_v7, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                    p_headers.into_writer().as_slice()
+                })?;
+                // empty unprotected headers
+                e.map(0)?;
+                // content
+                e.bytes(serde_json::to_vec(&serde_json::Value::Null)?.as_slice())?;
+                // signatures
+                // one signature
+                e.array(1)?;
+                e.array(3)?;
+                // protected headers (kid field)
+                let mut p_headers = minicbor::Encoder::new(Vec::new());
+                p_headers.map(1)?.u8(4)?.bytes(Vec::<u8>::from(&kid).as_slice())?;
+                e.bytes(p_headers.into_writer().as_slice())?;
+                e.map(0)?;
+                e.bytes(&[1, 2, 3])?;
+                Ok(e)
+            }
+        }),
+        policy: CompatibilityPolicy::Fail,
+        can_decode: false,
+        valid_doc: false,
+        post_checks: None,
+    }
+}
+
+fn signed_doc_with_non_strict_deterministic_decoding_wrong_order() -> TestCase {
+    let uuid_v7 = UuidV7::new();
+    let uuid_v4 = UuidV4::new();
+
+    TestCase {
+        name: "Catalyst Signed Doc with minimally defined metadata fields, with enabled non strictly (warn) decoded rules, metadata field in the wrong order".to_string(),
+        bytes_gen: Box::new({
+            move || {
+                let (_, _, kid) = create_dummy_key_pair(RoleId::Role0)?;
+
+                let mut e = Encoder::new(Vec::new());
+                e.tag(Tag::new(98))?;
+                e.array(4)?;
+                // protected headers (metadata fields)
+                e.bytes({
+                    let mut p_headers = Encoder::new(Vec::new());
+
+                    p_headers.map(4)?;
+                    p_headers.u8(3)?.encode(ContentType::Json)?;
+                    p_headers
+                        .str("type")?.array(1)?
+                        .encode_with(uuid_v4, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                    p_headers
+                        .str("id")?
+                        .encode_with(uuid_v7, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                    p_headers
+                        .str("ver")?
+                        .encode_with(uuid_v7, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                    p_headers.into_writer().as_slice()
+                })?;
+                // empty unprotected headers
+                e.map(0)?;
+                // content
+                e.bytes(serde_json::to_vec(&serde_json::Value::Null)?.as_slice())?;
+                // signatures
+                // one signature
+                e.array(1)?;
+                e.array(3)?;
+                // protected headers (kid field)
+                let mut p_headers = minicbor::Encoder::new(Vec::new());
+                p_headers.map(1)?.u8(4)?.bytes(Vec::<u8>::from(&kid).as_slice())?;
+                e.bytes(p_headers.into_writer().as_slice())?;
+                e.map(0)?;
+                e.bytes(&[1, 2, 3])?;
+                Ok(e)
+            }
+        }),
+        policy: CompatibilityPolicy::Warn,
+        can_decode: true,
+        valid_doc: true,
+        post_checks: Some(Box::new({
+            move |doc| {
+                anyhow::ensure!(doc.doc_type()? == &DocType::from(uuid_v4));
+                anyhow::ensure!(doc.doc_id()? == uuid_v7);
+                anyhow::ensure!(doc.doc_ver()? == uuid_v7);
+                anyhow::ensure!(doc.doc_content_type()? == ContentType::Json);
+                anyhow::ensure!(
+                    doc.encoded_content() == serde_json::to_vec(&serde_json::Value::Null)?
+                );
+                anyhow::ensure!(doc.kids().len() == 1);
+                Ok(())
+            }
+        })),
+    }
+}
+
 #[test]
 fn catalyst_signed_doc_decoding_test() {
     let test_cases = [
@@ -1096,6 +1283,9 @@ fn catalyst_signed_doc_decoding_test() {
         minimally_valid_untagged_signed_doc(),
         signed_doc_with_non_empty_unprotected_headers(),
         signed_doc_with_signatures_non_empty_unprotected_headers(),
+        signed_doc_with_strict_deterministic_decoding_correct_order(),
+        signed_doc_with_strict_deterministic_decoding_wrong_order(),
+        signed_doc_with_non_strict_deterministic_decoding_wrong_order(),
     ];
 
     for mut case in test_cases {


### PR DESCRIPTION
# Description

- Added `signed_doc_with_strict_deterministic_decoding_wrong_order` and `signed_doc_with_non_strict_deterministic_decoding_wrong_order` test cases.
- Added `signed_doc_with_signatures_non_empty_unprotected_headers` and `signed_doc_with_non_empty_unprotected_headers` test cases.
- Update `CatalystSignedDocument::decode` trait implementation, added `CompatibilityPolicy` as an context argument.

## Related Issue(s)

Part of 