### PR TITLE
fix(rust/rbac-registration): Fix `validate_txn_inputs_hash` error message 

### DIFF
--- a/rust/rbac-registration/src/cardano/cip509/validation.rs
+++ b/rust/rbac-registration/src/cardano/cip509/validation.rs
@@ -75,7 +75,7 @@ pub fn validate_txn_inputs_hash(
         report.invalid_value(
             "txn_inputs_hash",
             &format!("{hash:?}"),
-            &format!("Must be equal to the value in Cip509 ({hash:?})"),
+            &format!("Must be equal to the value in Cip509 ({calculated_hash:?})"),
             context,
         );
     }


### PR DESCRIPTION
# Description

Fixed `validate_txn_inputs_hash` problem report messaging