### PR TITLE
feat(rust/catalyst-types): Wrap Catalyst ID fields into Arc

### DIFF
--- a/rust/catalyst-types/src/catalyst_id/mod.rs
+++ b/rust/catalyst-types/src/catalyst_id/mod.rs
@@ -29,8 +29,11 @@ use role_index::RoleId;
 /// Catalyst ID
 /// <https://input-output-hk.github.io/catalyst-libs/architecture/08_concepts/rbac_id_uri/catalyst-id-uri/>
 ///
-/// Identity of Catalyst Registration.
-/// Optionally also identifies a specific Signed Document Key
+/// Identity of Catalyst Registration. Optionally also identifies a specific Signed
+/// Document Key.
+///
+/// `CatalystId` is an immutable data type: all modifying methods create a new instance.
+/// Also, this structure uses [`Arc`] internally, so it is cheap to clone.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[allow(clippy::module_name_repetitions)]
 pub struct CatalystId {

--- a/rust/rbac-registration/src/registration/cardano/mod.rs
+++ b/rust/rbac-registration/src/registration/cardano/mod.rs
@@ -29,6 +29,8 @@ use crate::cardano::cip509::{
 };
 
 /// Registration chains.
+///
+/// This structure uses [`Arc`] internally, so it is cheap to clone.
 #[derive(Debug, Clone)]
 pub struct RegistrationChain {
     /// Inner part of the registration chain.


### PR DESCRIPTION
# Description

Wrap `CatalystId` fields into `Arc`. This type is relatively "heavy" and often stored or passed around, so it makes sense to use `Arc` internally.

## Related Issue(s)

Related to https://github.com/input-output-hk/catalyst-voices/issues/2980.
