### PR TITLE
feat(rust/signed-doc): Add a function to convert back `DocType` to deprecated UUID

### DIFF
--- a/rust/signed_doc/src/metadata/doc_type.rs
+++ b/rust/signed_doc/src/metadata/doc_type.rs
@@ -239,7 +239,6 @@ pub fn map_doc_type(uuid: UuidV4) -> DocType {
 }
 
 /// Maps `DocType` to the deprecated corresponding doc type.
-#[allow(dead_code)]
 pub fn to_deprecated_doc_type(doc_type: &DocType) -> Option<UuidV4> {
     if doc_type == &*PROPOSAL {
         UuidV4::try_from(deprecated::PROPOSAL_DOCUMENT_UUID_TYPE).ok()

--- a/rust/signed_doc/src/metadata/doc_type.rs
+++ b/rust/signed_doc/src/metadata/doc_type.rs
@@ -208,7 +208,7 @@ impl Decode<'_, CompatibilityPolicy> for DocType {
 
 /// Map single UUID doc type to new list of doc types
 /// <https://github.com/input-output-hk/catalyst-libs/blob/main/docs/src/architecture/08_concepts/signed_doc/types.md#document-types>
-fn map_doc_type(uuid: UuidV4) -> DocType {
+pub fn map_doc_type(uuid: UuidV4) -> DocType {
     match uuid {
         id if Uuid::from(id) == deprecated::PROPOSAL_DOCUMENT_UUID_TYPE => PROPOSAL.clone(),
         id if Uuid::from(id) == deprecated::COMMENT_DOCUMENT_UUID_TYPE => PROPOSAL_COMMENT.clone(),
@@ -216,6 +216,20 @@ fn map_doc_type(uuid: UuidV4) -> DocType {
             PROPOSAL_SUBMISSION_ACTION.clone()
         },
         id => DocType(vec![id]),
+    }
+}
+
+/// Maps `DocType` to the deprecated corresponding doc type.
+#[allow(dead_code)]
+pub fn to_deprecated_doc_type(doc_type: &DocType) -> Option<UuidV4> {
+    if doc_type == &*PROPOSAL {
+        UuidV4::try_from(deprecated::PROPOSAL_DOCUMENT_UUID_TYPE).ok()
+    } else if doc_type == &*PROPOSAL_COMMENT {
+        UuidV4::try_from(deprecated::COMMENT_DOCUMENT_UUID_TYPE).ok()
+    } else if doc_type == &*PROPOSAL_SUBMISSION_ACTION {
+        UuidV4::try_from(deprecated::PROPOSAL_ACTION_DOCUMENT_UUID_TYPE).ok()
+    } else {
+        doc_type.0.first().cloned()
     }
 }
 


### PR DESCRIPTION
# Description

Added a function to convert back `DocType` to deprecated UUID

## Related Pull Requests

[#3063](https://github.com/input-output-hk/catalyst-voices/pull/3063)

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
