### PR TITLE
fix(rust/signed-doc): Properly export `map_doc_type`, `to_deprecated_doc_type`

### DIFF
--- a/rust/signed_doc/src/lib.rs
+++ b/rust/signed_doc/src/lib.rs
@@ -24,7 +24,9 @@ use cbork_utils::{array::Array, decode_context::DecodeCtx, with_cbor_bytes::With
 pub use content::Content;
 use decode_context::{CompatibilityPolicy, DecodeContext};
 pub use metadata::{
-    ContentEncoding, ContentType, DocLocator, DocType, DocumentRef, DocumentRefs, Metadata, Section,
+    doc_type::{map_doc_type, to_deprecated_doc_type},
+    ContentEncoding, ContentType, DocLocator, DocType, DocumentRef, DocumentRefs, Metadata,
+    Section,
 };
 use minicbor::{decode, encode, Decode, Decoder, Encode};
 pub use signature::{CatalystId, Signatures};


### PR DESCRIPTION
# Description

Properly export `map_doc_type`, `to_deprecated_doc_type`

## Related Pull Requests

#426

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
