### PR TITLE
feat(rust/signed-doc): Revert back to the original `DocType` format

### DIFF
--- a/rust/catalyst-types/src/uuid/mod.rs
+++ b/rust/catalyst-types/src/uuid/mod.rs
@@ -1,10 +1,10 @@
 //! `UUID` types.
 
-pub use uuid::Uuid;
+pub use uuid::{uuid, Uuid};
 #[allow(clippy::module_name_repetitions)]
-pub use uuid_v4::UuidV4;
+pub use uuid_v4::{InvalidUuidV4, ParsingError as UuidV4ParsingError, UuidV4};
 #[allow(clippy::module_name_repetitions)]
-pub use uuid_v7::UuidV7;
+pub use uuid_v7::{InvalidUuidV7, ParsingError as UuidV7ParsingError, UuidV7};
 
 mod uuid_v4;
 mod uuid_v7;
@@ -16,22 +16,6 @@ pub const INVALID_UUID: uuid::Uuid = uuid::Uuid::from_bytes([0x00; 16]);
 
 /// UUID CBOR tag <https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml/>.
 pub const UUID_CBOR_TAG: u64 = 37;
-
-/// Uuid validation errors, which could occur during decoding or converting to
-/// `UuidV4` or `UuidV7` types.
-#[derive(Debug, Clone, thiserror::Error)]
-#[allow(clippy::module_name_repetitions)]
-pub enum UuidError {
-    /// `UUIDv4` invalid error
-    #[error("'{0}' is not a valid UUIDv4")]
-    InvalidUuidV4(uuid::Uuid),
-    /// `UUIDv7` invalid error
-    #[error("'{0}' is not a valid UUIDv7")]
-    InvalidUuidV7(uuid::Uuid),
-    /// Invalid string conversion
-    #[error("Invalid string conversion: {0}")]
-    StringConversion(String),
-}
 
 /// Context for `CBOR` encoding and decoding
 pub enum CborContext {

--- a/rust/catalyst-types/src/uuid/uuid_v4.rs
+++ b/rust/catalyst-types/src/uuid/uuid_v4.rs
@@ -36,6 +36,9 @@ impl UuidV4 {
     }
 
     /// A const alternative impl of `TryFrom<Uuid>`
+    ///
+    /// # Errors
+    ///   - `InvalidUuidV4`
     pub const fn try_from_uuid(uuid: Uuid) -> Result<Self, InvalidUuidV4> {
         if is_valid(&uuid) {
             Ok(Self(uuid))

--- a/rust/catalyst-types/src/uuid/uuid_v4.rs
+++ b/rust/catalyst-types/src/uuid/uuid_v4.rs
@@ -7,11 +7,16 @@ use std::{
 use minicbor::{Decode, Decoder, Encode};
 use uuid::Uuid;
 
-use super::{decode_cbor_uuid, encode_cbor_uuid, CborContext, UuidError, INVALID_UUID};
+use super::{decode_cbor_uuid, encode_cbor_uuid, CborContext};
 
 /// Type representing a `UUIDv4`.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, serde::Serialize)]
 pub struct UuidV4(Uuid);
+
+/// `UUIDv4` invalid error
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("'{0}' is not a valid UUIDv4")]
+pub struct InvalidUuidV4(uuid::Uuid);
 
 impl UuidV4 {
     /// Version for `UUIDv4`.
@@ -24,28 +29,25 @@ impl UuidV4 {
         Self(Uuid::new_v4())
     }
 
-    /// Generates a zeroed out `UUIDv4` that can never be valid.
-    #[must_use]
-    pub fn invalid() -> Self {
-        Self(INVALID_UUID)
-    }
-
-    /// Check if this is a valid `UUIDv4`.
-    #[must_use]
-    pub fn is_valid(&self) -> bool {
-        is_valid(&self.uuid())
-    }
-
     /// Returns the `uuid::Uuid` type.
     #[must_use]
     pub fn uuid(&self) -> Uuid {
         self.0
     }
+
+    /// A const alternative impl of `TryFrom<Uuid>`
+    pub const fn try_from_uuid(uuid: Uuid) -> Result<Self, InvalidUuidV4> {
+        if is_valid(&uuid) {
+            Ok(Self(uuid))
+        } else {
+            Err(InvalidUuidV4(uuid))
+        }
+    }
 }
 
 /// Check if this is a valid `UUIDv4`.
-fn is_valid(uuid: &Uuid) -> bool {
-    uuid != &INVALID_UUID && uuid.get_version_num() == UuidV4::UUID_VERSION_NUMBER
+const fn is_valid(uuid: &Uuid) -> bool {
+    uuid.get_version_num() == UuidV4::UUID_VERSION_NUMBER
 }
 
 impl Display for UuidV4 {
@@ -57,13 +59,7 @@ impl Display for UuidV4 {
 impl Decode<'_, CborContext> for UuidV4 {
     fn decode(d: &mut Decoder<'_>, ctx: &mut CborContext) -> Result<Self, minicbor::decode::Error> {
         let uuid = decode_cbor_uuid(d, ctx)?;
-        if is_valid(&uuid) {
-            Ok(Self(uuid))
-        } else {
-            Err(minicbor::decode::Error::message(UuidError::InvalidUuidV4(
-                uuid,
-            )))
-        }
+        Self::try_from_uuid(uuid).map_err(minicbor::decode::Error::message)
     }
 }
 
@@ -77,14 +73,10 @@ impl Encode<CborContext> for UuidV4 {
 
 /// Returns a `UUIDv4` from `uuid::Uuid`.
 impl TryFrom<Uuid> for UuidV4 {
-    type Error = UuidError;
+    type Error = InvalidUuidV4;
 
     fn try_from(uuid: Uuid) -> Result<Self, Self::Error> {
-        if is_valid(&uuid) {
-            Ok(Self(uuid))
-        } else {
-            Err(UuidError::InvalidUuidV4(uuid))
-        }
+        Self::try_from_uuid(uuid)
     }
 }
 
@@ -101,52 +93,47 @@ impl<'de> serde::Deserialize<'de> for UuidV4 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where D: serde::Deserializer<'de> {
         let uuid = Uuid::deserialize(deserializer)?;
-        if is_valid(&uuid) {
-            Ok(Self(uuid))
-        } else {
-            Err(serde::de::Error::custom(UuidError::InvalidUuidV4(uuid)))
-        }
+        Self::try_from_uuid(uuid).map_err(serde::de::Error::custom)
     }
 }
 
+/// `FromStr` invalid error
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum ParsingError {
+    /// `UUIDv4` invalid error
+    #[error(transparent)]
+    InvalidUuidV4(#[from] InvalidUuidV4),
+    /// Invalid string conversion
+    #[error("Invalid string conversion: {0}")]
+    StringConversion(String),
+}
+
 impl FromStr for UuidV4 {
-    type Err = UuidError;
+    type Err = ParsingError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let uuid = Uuid::parse_str(s).map_err(|_| UuidError::StringConversion(s.to_string()))?;
-        UuidV4::try_from(uuid).map_err(|_| UuidError::InvalidUuidV4(uuid))
+        let uuid = Uuid::parse_str(s).map_err(|_| ParsingError::StringConversion(s.to_string()))?;
+        Ok(Self::try_from_uuid(uuid)?)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::uuid::INVALID_UUID;
 
     #[test]
     fn test_invalid_uuid() {
-        let invalid_uuid = UuidV4::invalid();
-        assert!(!invalid_uuid.is_valid(), "Invalid UUID should not be valid");
-        assert_eq!(
-            invalid_uuid.uuid(),
-            INVALID_UUID,
-            "Invalid UUID should match INVALID_UUID"
+        assert!(UuidV4::try_from(Uuid::now_v7()).is_err());
+
+        assert!(
+            UuidV4::try_from(INVALID_UUID).is_err(),
+            "Zero UUID should not be valid"
         );
     }
 
     #[test]
     fn test_valid_uuid() {
-        let valid_uuid = UuidV4::try_from(Uuid::new_v4()).unwrap();
-        assert!(valid_uuid.is_valid(), "Valid UUID should be valid");
-
-        let valid_uuid = UuidV4::new();
-        assert!(valid_uuid.is_valid(), "Valid UUID should be valid");
-    }
-
-    #[test]
-    fn test_invalid_version_uuid() {
-        assert!(
-            UuidV4::try_from(INVALID_UUID).is_err(),
-            "Zero UUID should not be valid"
-        );
+        assert!(UuidV4::try_from(Uuid::new_v4()).is_ok());
     }
 }

--- a/rust/catalyst-types/src/uuid/uuid_v7.rs
+++ b/rust/catalyst-types/src/uuid/uuid_v7.rs
@@ -7,11 +7,16 @@ use std::{
 use minicbor::{Decode, Decoder, Encode};
 use uuid::Uuid;
 
-use super::{decode_cbor_uuid, encode_cbor_uuid, CborContext, UuidError, INVALID_UUID};
+use super::{decode_cbor_uuid, encode_cbor_uuid, CborContext};
 
 /// Type representing a `UUIDv7`.
 #[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Hash, serde::Serialize)]
 pub struct UuidV7(Uuid);
+
+/// `UUIDv7` invalid error
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("'{0}' is not a valid UUIDv7")]
+pub struct InvalidUuidV7(uuid::Uuid);
 
 impl UuidV7 {
     /// Version for `UUIDv7`.
@@ -24,28 +29,25 @@ impl UuidV7 {
         Self(Uuid::now_v7())
     }
 
-    /// Generates a zeroed out `UUIDv7` that can never be valid.
-    #[must_use]
-    pub fn invalid() -> Self {
-        Self(INVALID_UUID)
-    }
-
-    /// Check if this is a valid `UUIDv7`.
-    #[must_use]
-    pub fn is_valid(&self) -> bool {
-        is_valid(&self.0)
-    }
-
     /// Returns the `uuid::Uuid` type.
     #[must_use]
     pub fn uuid(&self) -> Uuid {
         self.0
     }
+
+    /// A const alternative impl of `TryFrom<Uuid>`
+    pub const fn try_from_uuid(uuid: Uuid) -> Result<Self, InvalidUuidV7> {
+        if is_valid(&uuid) {
+            Ok(Self(uuid))
+        } else {
+            Err(InvalidUuidV7(uuid))
+        }
+    }
 }
 
 /// Check if this is a valid `UUIDv7`.
-fn is_valid(uuid: &Uuid) -> bool {
-    uuid != &INVALID_UUID && uuid.get_version_num() == UuidV7::UUID_VERSION_NUMBER
+const fn is_valid(uuid: &Uuid) -> bool {
+    uuid.get_version_num() == UuidV7::UUID_VERSION_NUMBER
 }
 
 impl Display for UuidV7 {
@@ -57,13 +59,7 @@ impl Display for UuidV7 {
 impl Decode<'_, CborContext> for UuidV7 {
     fn decode(d: &mut Decoder<'_>, ctx: &mut CborContext) -> Result<Self, minicbor::decode::Error> {
         let uuid = decode_cbor_uuid(d, ctx)?;
-        if is_valid(&uuid) {
-            Ok(Self(uuid))
-        } else {
-            Err(minicbor::decode::Error::message(UuidError::InvalidUuidV7(
-                uuid,
-            )))
-        }
+        Self::try_from_uuid(uuid).map_err(minicbor::decode::Error::message)
     }
 }
 
@@ -77,14 +73,10 @@ impl Encode<CborContext> for UuidV7 {
 
 /// Returns a `UUIDv7` from `uuid::Uuid`.
 impl TryFrom<Uuid> for UuidV7 {
-    type Error = UuidError;
+    type Error = InvalidUuidV7;
 
     fn try_from(uuid: Uuid) -> Result<Self, Self::Error> {
-        if is_valid(&uuid) {
-            Ok(Self(uuid))
-        } else {
-            Err(UuidError::InvalidUuidV7(uuid))
-        }
+        Self::try_from_uuid(uuid)
     }
 }
 
@@ -101,20 +93,27 @@ impl<'de> serde::Deserialize<'de> for UuidV7 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where D: serde::Deserializer<'de> {
         let uuid = Uuid::deserialize(deserializer)?;
-        if is_valid(&uuid) {
-            Ok(Self(uuid))
-        } else {
-            Err(serde::de::Error::custom(UuidError::InvalidUuidV7(uuid)))
-        }
+        Self::try_from_uuid(uuid).map_err(serde::de::Error::custom)
     }
 }
 
+/// `FromStr` invalid error
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum ParsingError {
+    /// `UUIDv7` invalid error
+    #[error(transparent)]
+    InvalidUuidV7(#[from] InvalidUuidV7),
+    /// Invalid string conversion
+    #[error("Invalid string conversion: {0}")]
+    StringConversion(String),
+}
+
 impl FromStr for UuidV7 {
-    type Err = UuidError;
+    type Err = ParsingError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let uuid = Uuid::parse_str(s).map_err(|_| UuidError::StringConversion(s.to_string()))?;
-        UuidV7::try_from(uuid).map_err(|_| UuidError::InvalidUuidV7(uuid))
+        let uuid = Uuid::parse_str(s).map_err(|_| ParsingError::StringConversion(s.to_string()))?;
+        Ok(Self::try_from_uuid(uuid)?)
     }
 }
 
@@ -123,32 +122,20 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
+    use crate::uuid::INVALID_UUID;
 
     #[test]
     fn test_invalid_uuid() {
-        let invalid_uuid = UuidV7::invalid();
-        assert!(!invalid_uuid.is_valid(), "Invalid UUID should not be valid");
-        assert_eq!(
-            invalid_uuid.uuid(),
-            INVALID_UUID,
-            "Invalid UUID should match INVALID_UUID"
+        assert!(UuidV7::try_from(Uuid::new_v4()).is_err());
+
+        assert!(
+            UuidV7::try_from(INVALID_UUID).is_err(),
+            "Zero UUID should not be valid"
         );
     }
 
     #[test]
     fn test_valid_uuid() {
-        let valid_uuid = UuidV7::try_from(Uuid::now_v7()).unwrap();
-        assert!(valid_uuid.is_valid(), "Valid UUID should be valid");
-
-        let valid_uuid = UuidV7::new();
-        assert!(valid_uuid.is_valid(), "Valid UUID should be valid");
-    }
-
-    #[test]
-    fn test_invalid_version_uuid() {
-        assert!(
-            UuidV7::try_from(INVALID_UUID).is_err(),
-            "Zero UUID should not be valid"
-        );
+        assert!(UuidV7::try_from(Uuid::now_v7()).is_ok());
     }
 }

--- a/rust/catalyst-types/src/uuid/uuid_v7.rs
+++ b/rust/catalyst-types/src/uuid/uuid_v7.rs
@@ -36,6 +36,9 @@ impl UuidV7 {
     }
 
     /// A const alternative impl of `TryFrom<Uuid>`
+    ///
+    /// # Errors
+    ///   - `InvalidUuidV7`
     pub const fn try_from_uuid(uuid: Uuid) -> Result<Self, InvalidUuidV7> {
         if is_valid(&uuid) {
             Ok(Self(uuid))

--- a/rust/signed_doc/src/doc_types/mod.rs
+++ b/rust/signed_doc/src/doc_types/mod.rs
@@ -1,7 +1,7 @@
 //! An implementation of different defined document types
 //! <https://input-output-hk.github.io/catalyst-libs/architecture/08_concepts/signed_doc/types/>
 
-use std::sync::LazyLock;
+use std::sync::{LazyLock, OnceLock};
 
 use catalyst_types::uuid::Uuid;
 
@@ -37,9 +37,8 @@ pub static CATEGORY_PARAMETERS: LazyLock<DocType> = LazyLock::new(|| {
 
 /// Proposal document type.
 #[allow(clippy::expect_used)]
-pub static PROPOSAL: LazyLock<DocType> = LazyLock::new(|| {
-    let ids = &[PROPOSAL_BASE_TYPE];
-    ids.to_vec()
+pub static PROPOSAL: OnceLock<DocType> = LazyLock::new(|| {
+    Uuid::from_u128(0x7808_D2BA_D511_40AF_84E8_C0D1_625F_DFDC)
         .try_into()
         .expect("Failed to convert proposal document Uuid to DocType")
 });

--- a/rust/signed_doc/src/doc_types/mod.rs
+++ b/rust/signed_doc/src/doc_types/mod.rs
@@ -3,6 +3,8 @@
 
 use crate::DocType;
 
+/// helper macro by evaluating `DocType::try_from_uuid(catalyst_types::uuid::uuid!())`
+/// expression
 macro_rules! doc_type_init {
     ($s:literal) => {
         match DocType::try_from_uuid(catalyst_types::uuid::uuid!($s)) {

--- a/rust/signed_doc/src/doc_types/mod.rs
+++ b/rust/signed_doc/src/doc_types/mod.rs
@@ -1,7 +1,7 @@
 //! An implementation of different defined document types
 //! <https://input-output-hk.github.io/catalyst-libs/architecture/08_concepts/signed_doc/types/>
 
-use std::sync::{LazyLock, OnceLock};
+use std::sync::LazyLock;
 
 use catalyst_types::uuid::Uuid;
 
@@ -11,8 +11,7 @@ use crate::DocType;
 /// Brand document type.
 #[allow(clippy::expect_used)]
 pub static BRAND_PARAMETERS: LazyLock<DocType> = LazyLock::new(|| {
-    let ids = &[BRAND_BASE_TYPE];
-    ids.to_vec()
+    Uuid::from_u128(0x3E48_08CC_C86E_467B_9702_D60B_AA9D_1FCA)
         .try_into()
         .expect("Failed to convert brand base types Uuid to DocType")
 });
@@ -20,8 +19,7 @@ pub static BRAND_PARAMETERS: LazyLock<DocType> = LazyLock::new(|| {
 /// Campaign Parameters document type.
 #[allow(clippy::expect_used)]
 pub static CAMPAIGN_PARAMETERS: LazyLock<DocType> = LazyLock::new(|| {
-    let ids = &[CAMPAIGN_BASE_TYPE];
-    ids.to_vec()
+    Uuid::from_u128(0x0110_EA96_A555_47CE_8408_36EF_E6ED_6F7C)
         .try_into()
         .expect("Failed to convert campaign base types Uuid to DocType")
 });
@@ -29,15 +27,14 @@ pub static CAMPAIGN_PARAMETERS: LazyLock<DocType> = LazyLock::new(|| {
 /// Category Parameters document type.
 #[allow(clippy::expect_used)]
 pub static CATEGORY_PARAMETERS: LazyLock<DocType> = LazyLock::new(|| {
-    let ids = &[CATEGORY_BASE_TYPE];
-    ids.to_vec()
+    Uuid::from_u128(0x48C2_0109_362A_4D32_9BBA_E0A9_CF8B_45BE)
         .try_into()
         .expect("Failed to convert category base types Uuid to DocType")
 });
 
 /// Proposal document type.
 #[allow(clippy::expect_used)]
-pub static PROPOSAL: OnceLock<DocType> = LazyLock::new(|| {
+pub static PROPOSAL: LazyLock<DocType> = LazyLock::new(|| {
     Uuid::from_u128(0x7808_D2BA_D511_40AF_84E8_C0D1_625F_DFDC)
         .try_into()
         .expect("Failed to convert proposal document Uuid to DocType")
@@ -46,8 +43,7 @@ pub static PROPOSAL: OnceLock<DocType> = LazyLock::new(|| {
 /// Proposal comment document type.
 #[allow(clippy::expect_used)]
 pub static PROPOSAL_COMMENT: LazyLock<DocType> = LazyLock::new(|| {
-    let ids = &[COMMENT_BASE_TYPE, PROPOSAL_BASE_TYPE];
-    ids.to_vec()
+    Uuid::from_u128(0xB679_DED3_0E7C_41BA_89F8_DA62_A178_98EA)
         .try_into()
         .expect("Failed to convert proposal comment document Uuid to DocType")
 });
@@ -55,124 +51,23 @@ pub static PROPOSAL_COMMENT: LazyLock<DocType> = LazyLock::new(|| {
 /// Proposal action document type.
 #[allow(clippy::expect_used)]
 pub static PROPOSAL_SUBMISSION_ACTION: LazyLock<DocType> = LazyLock::new(|| {
-    let ids = &[
-        ACTION_BASE_TYPE,
-        PROPOSAL_BASE_TYPE,
-        SUBMISSION_ACTION_BASE_TYPE,
-    ];
-    ids.to_vec()
+    Uuid::from_u128(0x5E60_E623_AD02_4A1B_A1AC_406D_B978_EE48)
         .try_into()
         .expect("Failed to convert proposal action document Uuid to DocType")
 });
 
-/// Proposal Comment Meta Template document type.
-#[allow(clippy::expect_used)]
-pub static PROPOSAL_COMMENT_META_TEMPLATE: LazyLock<DocType> = LazyLock::new(|| {
-    let ids = &[
-        TEMPLATE_BASE_TYPE,
-        TEMPLATE_BASE_TYPE,
-        COMMENT_BASE_TYPE,
-        PROPOSAL_BASE_TYPE,
-    ];
-    ids.to_vec()
-        .try_into()
-        .expect("Failed to convert proposal comment meta template document Uuid to DocType")
-});
-
 /// Proposal Comment Template document type.
 #[allow(clippy::expect_used)]
-pub static PROPOSAL_COMMENT_TEMPLATE: LazyLock<DocType> = LazyLock::new(|| {
-    let ids = &[TEMPLATE_BASE_TYPE, COMMENT_BASE_TYPE, PROPOSAL_BASE_TYPE];
-    ids.to_vec()
+pub static PROPOSAL_COMMENT_FORM_TEMPLATE: LazyLock<DocType> = LazyLock::new(|| {
+    Uuid::from_u128(0x0B84_24D4_EBFD_46E3_9577_1775_A69D_290C)
         .try_into()
         .expect("Failed to convert proposal comment template document Uuid to DocType")
 });
 
 /// Proposal Template document type.
 #[allow(clippy::expect_used)]
-pub static PROPOSAL_TEMPLATE: LazyLock<DocType> = LazyLock::new(|| {
-    let ids = &[TEMPLATE_BASE_TYPE, PROPOSAL_BASE_TYPE];
-    ids.to_vec()
+pub static PROPOSAL_FORM_TEMPLATE: LazyLock<DocType> = LazyLock::new(|| {
+    Uuid::from_u128(0x0CE8_AB38_9258_4FBC_A62E_7FAA_6E58_318F)
         .try_into()
         .expect("Failed to convert proposal template document Uuid to DocType")
 });
-
-/// -------------- Base Types --------------
-/// Action UUID base type.
-pub const ACTION_BASE_TYPE: Uuid = Uuid::from_u128(0x5E60_E623_AD02_4A1B_A1AC_406D_B978_EE48);
-/// Brand UUID base type.
-pub const BRAND_BASE_TYPE: Uuid = Uuid::from_u128(0xEBCA_BEEB_5BC5_4F95_91E8_CAB8_CA72_4172);
-/// Campaign UUID base type.
-pub const CAMPAIGN_BASE_TYPE: Uuid = Uuid::from_u128(0x5EF3_2D5D_F240_462C_A7A4_BA4A_F221_FA23);
-/// Category UUID base type.
-pub const CATEGORY_BASE_TYPE: Uuid = Uuid::from_u128(0x8189_38C3_3139_4DAA_AFE6_974C_7848_8E95);
-/// Comment UUID base type.
-pub const COMMENT_BASE_TYPE: Uuid = Uuid::from_u128(0xB679_DED3_0E7C_41BA_89F8_DA62_A178_98EA);
-/// Decision UUID base type.
-pub const DECISION_BASE_TYPE: Uuid = Uuid::from_u128(0x788F_F4C6_D65A_451F_BB33_575F_E056_B411);
-/// Moderation Action UUID base type.
-pub const MODERATION_ACTION_BASE_TYPE: Uuid =
-    Uuid::from_u128(0xA5D2_32B8_5E03_4117_9AFD_BE32_B878_FCDD);
-/// Proposal UUID base type.
-pub const PROPOSAL_BASE_TYPE: Uuid = Uuid::from_u128(0x7808_D2BA_D511_40AF_84E8_C0D1_625F_DFDC);
-/// Submission Action UUID base type.
-pub const SUBMISSION_ACTION_BASE_TYPE: Uuid =
-    Uuid::from_u128(0x7892_7329_CFD9_4EA1_9C71_0E01_9B12_6A65);
-/// Template UUID base type.
-pub const TEMPLATE_BASE_TYPE: Uuid = Uuid::from_u128(0x0CE8_AB38_9258_4FBC_A62E_7FAA_6E58_318F);
-
-/// Document type which will be deprecated.
-pub mod deprecated {
-    use catalyst_types::uuid::Uuid;
-
-    /// Proposal document `UuidV4` type.
-    pub const PROPOSAL_DOCUMENT_UUID_TYPE: Uuid =
-        Uuid::from_u128(0x7808_D2BA_D511_40AF_84E8_C0D1_625F_DFDC);
-    /// Proposal template `UuidV4` type.
-    pub const PROPOSAL_TEMPLATE_UUID_TYPE: Uuid =
-        Uuid::from_u128(0x0CE8_AB38_9258_4FBC_A62E_7FAA_6E58_318F);
-    /// Comment document `UuidV4` type.
-    pub const COMMENT_DOCUMENT_UUID_TYPE: Uuid =
-        Uuid::from_u128(0xB679_DED3_0E7C_41BA_89F8_DA62_A178_98EA);
-    /// Comment template `UuidV4` type.
-    pub const COMMENT_TEMPLATE_UUID_TYPE: Uuid =
-        Uuid::from_u128(0x0B84_24D4_EBFD_46E3_9577_1775_A69D_290C);
-    /// Review document `UuidV4` type.
-    pub const REVIEW_DOCUMENT_UUID_TYPE: Uuid =
-        Uuid::from_u128(0xE4CA_F5F0_098B_45FD_94F3_0702_A457_3DB5);
-    /// Review template `UuidV4` type.
-    pub const REVIEW_TEMPLATE_UUID_TYPE: Uuid =
-        Uuid::from_u128(0xEBE5_D0BF_5D86_4577_AF4D_008F_DDBE_2EDC);
-    /// Category document `UuidV4` type.
-    pub const CATEGORY_DOCUMENT_UUID_TYPE: Uuid =
-        Uuid::from_u128(0x48C2_0109_362A_4D32_9BBA_E0A9_CF8B_45BE);
-    /// Category template `UuidV4` type.
-    pub const CATEGORY_TEMPLATE_UUID_TYPE: Uuid =
-        Uuid::from_u128(0x65B1_E8B0_51F1_46A5_9970_72CD_F268_84BE);
-    /// Campaign parameters document `UuidV4` type.
-    pub const CAMPAIGN_DOCUMENT_UUID_TYPE: Uuid =
-        Uuid::from_u128(0x0110_EA96_A555_47CE_8408_36EF_E6ED_6F7C);
-    /// Campaign parameters template `UuidV4` type.
-    pub const CAMPAIGN_TEMPLATE_UUID_TYPE: Uuid =
-        Uuid::from_u128(0x7E8F_5FA2_44CE_49C8_BFD5_02AF_42C1_79A3);
-    /// Brand parameters document `UuidV4` type.
-    pub const BRAND_DOCUMENT_UUID_TYPE: Uuid =
-        Uuid::from_u128(0x3E48_08CC_C86E_467B_9702_D60B_AA9D_1FCA);
-    /// Brand parameters template `UuidV4` type.
-    pub const BRAND_TEMPLATE_UUID_TYPE: Uuid =
-        Uuid::from_u128(0xFD3C_1735_80B1_4EEA_8D63_5F43_6D97_EA31);
-    /// Proposal action document `UuidV4` type.
-    pub const PROPOSAL_ACTION_DOCUMENT_UUID_TYPE: Uuid =
-        Uuid::from_u128(0x5E60_E623_AD02_4A1B_A1AC_406D_B978_EE48);
-    /// Public vote transaction v2 `UuidV4` type.
-    pub const PUBLIC_VOTE_TX_V2_UUID_TYPE: Uuid =
-        Uuid::from_u128(0x8DE5_586C_E998_4B95_8742_7BE3_C859_2803);
-    /// Private vote transaction v2 `UuidV4` type.
-    pub const PRIVATE_VOTE_TX_V2_UUID_TYPE: Uuid =
-        Uuid::from_u128(0xE78E_E18D_F380_44C1_A852_80AA_6ECB_07FE);
-    /// Immutable ledger block `UuidV4` type.
-    pub const IMMUTABLE_LEDGER_BLOCK_UUID_TYPE: Uuid =
-        Uuid::from_u128(0xD9E7_E6CE_2401_4D7D_9492_F4F7_C642_41C3);
-    /// Submission Action `UuidV4` type.
-    pub const SUBMISSION_ACTION: Uuid = Uuid::from_u128(0x7892_7329_CFD9_4EA1_9C71_0E01_9B12_6A65);
-}

--- a/rust/signed_doc/src/doc_types/mod.rs
+++ b/rust/signed_doc/src/doc_types/mod.rs
@@ -3,71 +3,38 @@
 
 use std::sync::LazyLock;
 
-use catalyst_types::uuid::Uuid;
+use catalyst_types::uuid::uuid;
 
 use crate::DocType;
 
 /// -------------- Document Types --------------
 /// Brand document type.
-#[allow(clippy::expect_used)]
-pub static BRAND_PARAMETERS: LazyLock<DocType> = LazyLock::new(|| {
-    Uuid::from_u128(0x3E48_08CC_C86E_467B_9702_D60B_AA9D_1FCA)
-        .try_into()
-        .expect("Failed to convert brand base types Uuid to DocType")
-});
+pub const BRAND_PARAMETERS: DocType =
+    DocType::try_from_uuid(uuid!("3e4808cc-c86e-467b-9702-d60baa9d1fca"));
 
 /// Campaign Parameters document type.
-#[allow(clippy::expect_used)]
-pub static CAMPAIGN_PARAMETERS: LazyLock<DocType> = LazyLock::new(|| {
-    Uuid::from_u128(0x0110_EA96_A555_47CE_8408_36EF_E6ED_6F7C)
-        .try_into()
-        .expect("Failed to convert campaign base types Uuid to DocType")
-});
+pub const CAMPAIGN_PARAMETERS: DocType =
+    DocType::try_from_uuid(uuid!("0110ea96-a555-47ce-8408-36efe6ed6f7c"));
 
 /// Category Parameters document type.
-#[allow(clippy::expect_used)]
-pub static CATEGORY_PARAMETERS: LazyLock<DocType> = LazyLock::new(|| {
-    Uuid::from_u128(0x48C2_0109_362A_4D32_9BBA_E0A9_CF8B_45BE)
-        .try_into()
-        .expect("Failed to convert category base types Uuid to DocType")
-});
+pub const CATEGORY_PARAMETERS: DocType =
+    DocType::try_from_uuid(uuid!("48c20109-362a-4d32-9bba-e0a9cf8b45be"));
 
 /// Proposal document type.
-#[allow(clippy::expect_used)]
-pub static PROPOSAL: LazyLock<DocType> = LazyLock::new(|| {
-    Uuid::from_u128(0x7808_D2BA_D511_40AF_84E8_C0D1_625F_DFDC)
-        .try_into()
-        .expect("Failed to convert proposal document Uuid to DocType")
-});
+pub const PROPOSAL: DocType = DocType::try_from_uuid(uuid!("7808d2ba-d511-40af-84e8-c0d1625fdfdc"));
 
 /// Proposal comment document type.
-#[allow(clippy::expect_used)]
-pub static PROPOSAL_COMMENT: LazyLock<DocType> = LazyLock::new(|| {
-    Uuid::from_u128(0xB679_DED3_0E7C_41BA_89F8_DA62_A178_98EA)
-        .try_into()
-        .expect("Failed to convert proposal comment document Uuid to DocType")
-});
+pub const PROPOSAL_COMMENT: DocType =
+    DocType::try_from_uuid(uuid!("b679ded3-0e7c-41ba-89f8-da62a17898ea"));
 
 /// Proposal action document type.
-#[allow(clippy::expect_used)]
-pub static PROPOSAL_SUBMISSION_ACTION: LazyLock<DocType> = LazyLock::new(|| {
-    Uuid::from_u128(0x5E60_E623_AD02_4A1B_A1AC_406D_B978_EE48)
-        .try_into()
-        .expect("Failed to convert proposal action document Uuid to DocType")
-});
+pub const PROPOSAL_SUBMISSION_ACTION: DocType =
+    DocType::try_from_uuid(uuid!("5e60e623-ad02-4a1b-a1ac-406db978ee48"));
 
 /// Proposal Comment Template document type.
-#[allow(clippy::expect_used)]
-pub static PROPOSAL_COMMENT_FORM_TEMPLATE: LazyLock<DocType> = LazyLock::new(|| {
-    Uuid::from_u128(0x0B84_24D4_EBFD_46E3_9577_1775_A69D_290C)
-        .try_into()
-        .expect("Failed to convert proposal comment template document Uuid to DocType")
-});
+pub const PROPOSAL_COMMENT_FORM_TEMPLATE: DocType =
+    DocType::try_from_uuid(uuid!("0b8424d4-ebfd-46e3-9577-1775a69d290c"));
 
 /// Proposal Template document type.
-#[allow(clippy::expect_used)]
-pub static PROPOSAL_FORM_TEMPLATE: LazyLock<DocType> = LazyLock::new(|| {
-    Uuid::from_u128(0x0CE8_AB38_9258_4FBC_A62E_7FAA_6E58_318F)
-        .try_into()
-        .expect("Failed to convert proposal template document Uuid to DocType")
-});
+pub const PROPOSAL_FORM_TEMPLATE: DocType =
+    DocType::try_from_uuid(uuid!("0ce8ab38-9258-4fbc-a62e-7faa6e58318f"));

--- a/rust/signed_doc/src/doc_types/mod.rs
+++ b/rust/signed_doc/src/doc_types/mod.rs
@@ -1,40 +1,40 @@
 //! An implementation of different defined document types
 //! <https://input-output-hk.github.io/catalyst-libs/architecture/08_concepts/signed_doc/types/>
 
-use std::sync::LazyLock;
-
-use catalyst_types::uuid::uuid;
-
 use crate::DocType;
+
+macro_rules! doc_type_init {
+    ($s:literal) => {
+        match DocType::try_from_uuid(catalyst_types::uuid::uuid!($s)) {
+            Ok(v) => v,
+            Err(_) => panic!("invalid uuid v4 value"),
+        }
+    };
+}
 
 /// -------------- Document Types --------------
 /// Brand document type.
-pub const BRAND_PARAMETERS: DocType =
-    DocType::try_from_uuid(uuid!("3e4808cc-c86e-467b-9702-d60baa9d1fca"));
+pub const BRAND_PARAMETERS: DocType = doc_type_init!("3e4808cc-c86e-467b-9702-d60baa9d1fca");
 
 /// Campaign Parameters document type.
-pub const CAMPAIGN_PARAMETERS: DocType =
-    DocType::try_from_uuid(uuid!("0110ea96-a555-47ce-8408-36efe6ed6f7c"));
+pub const CAMPAIGN_PARAMETERS: DocType = doc_type_init!("0110ea96-a555-47ce-8408-36efe6ed6f7c");
 
 /// Category Parameters document type.
-pub const CATEGORY_PARAMETERS: DocType =
-    DocType::try_from_uuid(uuid!("48c20109-362a-4d32-9bba-e0a9cf8b45be"));
+pub const CATEGORY_PARAMETERS: DocType = doc_type_init!("48c20109-362a-4d32-9bba-e0a9cf8b45be");
 
 /// Proposal document type.
-pub const PROPOSAL: DocType = DocType::try_from_uuid(uuid!("7808d2ba-d511-40af-84e8-c0d1625fdfdc"));
+pub const PROPOSAL: DocType = doc_type_init!("7808d2ba-d511-40af-84e8-c0d1625fdfdc");
 
 /// Proposal comment document type.
-pub const PROPOSAL_COMMENT: DocType =
-    DocType::try_from_uuid(uuid!("b679ded3-0e7c-41ba-89f8-da62a17898ea"));
+pub const PROPOSAL_COMMENT: DocType = doc_type_init!("b679ded3-0e7c-41ba-89f8-da62a17898ea");
 
 /// Proposal action document type.
 pub const PROPOSAL_SUBMISSION_ACTION: DocType =
-    DocType::try_from_uuid(uuid!("5e60e623-ad02-4a1b-a1ac-406db978ee48"));
+    doc_type_init!("5e60e623-ad02-4a1b-a1ac-406db978ee48");
 
 /// Proposal Comment Template document type.
 pub const PROPOSAL_COMMENT_FORM_TEMPLATE: DocType =
-    DocType::try_from_uuid(uuid!("0b8424d4-ebfd-46e3-9577-1775a69d290c"));
+    doc_type_init!("0b8424d4-ebfd-46e3-9577-1775a69d290c");
 
 /// Proposal Template document type.
-pub const PROPOSAL_FORM_TEMPLATE: DocType =
-    DocType::try_from_uuid(uuid!("0ce8ab38-9258-4fbc-a62e-7faa6e58318f"));
+pub const PROPOSAL_FORM_TEMPLATE: DocType = doc_type_init!("0ce8ab38-9258-4fbc-a62e-7faa6e58318f");

--- a/rust/signed_doc/src/lib.rs
+++ b/rust/signed_doc/src/lib.rs
@@ -24,9 +24,7 @@ use cbork_utils::{array::Array, decode_context::DecodeCtx, with_cbor_bytes::With
 pub use content::Content;
 use decode_context::{CompatibilityPolicy, DecodeContext};
 pub use metadata::{
-    doc_type::{map_doc_type, to_deprecated_doc_type},
-    ContentEncoding, ContentType, DocLocator, DocType, DocumentRef, DocumentRefs, Metadata,
-    Section,
+    ContentEncoding, ContentType, DocLocator, DocType, DocumentRef, DocumentRefs, Metadata, Section,
 };
 use minicbor::{decode, encode, Decode, Decoder, Encode};
 pub use signature::{CatalystId, Signatures};

--- a/rust/signed_doc/src/metadata/doc_type.rs
+++ b/rust/signed_doc/src/metadata/doc_type.rs
@@ -2,24 +2,15 @@
 
 use std::{
     fmt::{Display, Formatter},
-    hash::{Hash, Hasher},
-    ops::Deref,
+    hash::Hash,
 };
 
 use catalyst_types::uuid::{CborContext, Uuid, UuidV4};
-use cbork_utils::{array::Array, decode_context::DecodeCtx};
 use minicbor::{Decode, Decoder, Encode};
-use serde::{Deserialize, Deserializer};
-use tracing::warn;
-
-use crate::{
-    decode_context::CompatibilityPolicy,
-    doc_types::{deprecated, PROPOSAL, PROPOSAL_COMMENT, PROPOSAL_SUBMISSION_ACTION},
-};
 
 /// List of `UUIDv4` document type.
-#[derive(Clone, Debug, serde::Serialize, PartialEq, Eq)]
-pub struct DocType(Vec<UuidV4>);
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct DocType(UuidV4);
 
 /// `DocType` Errors.
 #[derive(Debug, Clone, thiserror::Error)]
@@ -27,54 +18,14 @@ pub enum DocTypeError {
     /// Invalid UUID.
     #[error("Invalid UUID: {0}")]
     InvalidUuid(Uuid),
-    /// `DocType` cannot be empty.
-    #[error("DocType cannot be empty")]
-    Empty,
     /// Invalid string conversion
     #[error("Invalid string conversion: {0}")]
     StringConversion(String),
 }
 
-impl Deref for DocType {
-    type Target = Vec<UuidV4>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl IntoIterator for DocType {
-    type IntoIter = <Vec<UuidV4> as IntoIterator>::IntoIter;
-    type Item = UuidV4;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
-    }
-}
-
-impl<'a> IntoIterator for &'a DocType {
-    type IntoIter = <&'a Vec<UuidV4> as IntoIterator>::IntoIter;
-    type Item = &'a UuidV4;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.iter()
-    }
-}
-
-impl Hash for DocType {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        let list = self
-            .0
-            .iter()
-            .map(std::string::ToString::to_string)
-            .collect::<Vec<_>>();
-        list.hash(state);
-    }
-}
-
 impl From<UuidV4> for DocType {
     fn from(value: UuidV4) -> Self {
-        DocType(vec![value])
+        DocType(value)
     }
 }
 
@@ -82,81 +33,25 @@ impl TryFrom<Uuid> for DocType {
     type Error = DocTypeError;
 
     fn try_from(value: Uuid) -> Result<Self, Self::Error> {
-        let uuid_v4 = UuidV4::try_from(value).map_err(|_| DocTypeError::InvalidUuid(value))?;
-        Ok(DocType(vec![uuid_v4]))
+        UuidV4::try_from(value)
+            .map_err(|_| DocTypeError::InvalidUuid(value))
+            .map(Into::into)
     }
 }
 
-impl TryFrom<Vec<Uuid>> for DocType {
+impl TryFrom<String> for DocType {
     type Error = DocTypeError;
 
-    fn try_from(value: Vec<Uuid>) -> Result<Self, Self::Error> {
-        if value.is_empty() {
-            return Err(DocTypeError::Empty);
-        }
-
-        let converted = value
-            .into_iter()
-            .map(|u| UuidV4::try_from(u).map_err(|_| DocTypeError::InvalidUuid(u)))
-            .collect::<Result<Vec<UuidV4>, DocTypeError>>()?;
-
-        DocType::try_from(converted)
-    }
-}
-
-impl From<DocType> for Vec<Uuid> {
-    fn from(value: DocType) -> Vec<Uuid> {
-        value.0.into_iter().map(Uuid::from).collect()
-    }
-}
-
-impl From<DocType> for Vec<String> {
-    fn from(val: DocType) -> Self {
-        val.0.into_iter().map(|uuid| uuid.to_string()).collect()
-    }
-}
-
-impl TryFrom<Vec<UuidV4>> for DocType {
-    type Error = DocTypeError;
-
-    fn try_from(value: Vec<UuidV4>) -> Result<Self, Self::Error> {
-        if value.is_empty() {
-            return Err(DocTypeError::Empty);
-        }
-        Ok(DocType(value))
-    }
-}
-
-impl TryFrom<Vec<String>> for DocType {
-    type Error = DocTypeError;
-
-    fn try_from(value: Vec<String>) -> Result<Self, Self::Error> {
-        if value.is_empty() {
-            return Err(DocTypeError::Empty);
-        }
-        let converted = value
-            .into_iter()
-            .map(|s| {
-                s.parse::<UuidV4>()
-                    .map_err(|_| DocTypeError::StringConversion(s))
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-
-        Ok(DocType(converted))
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        s.parse::<UuidV4>()
+            .map_err(|_| DocTypeError::StringConversion(s))
+            .map(Self)
     }
 }
 
 impl Display for DocType {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(UuidV4::to_string)
-                .collect::<Vec<_>>()
-                .join(", ")
-        )
+        write!(f, "{}", self.0)
     }
 }
 
@@ -164,90 +59,15 @@ impl Display for DocType {
 // document_type = [ 1* uuid_v4 ]
 // ; UUIDv4
 // uuid_v4 = #6.37(bytes .size 16)
-impl Decode<'_, CompatibilityPolicy> for DocType {
-    fn decode(
-        d: &mut Decoder, policy: &mut CompatibilityPolicy,
-    ) -> Result<Self, minicbor::decode::Error> {
-        const CONTEXT: &str = "DocType decoding";
-
-        match d.datatype()? {
-            minicbor::data::Type::Array => {
-                let arr = Array::decode(d, &mut DecodeCtx::Deterministic)?;
-
-                if arr.is_empty() {
-                    return Err(minicbor::decode::Error::message(format!(
-                        "{CONTEXT}: empty array"
-                    )));
-                }
-
-                arr.into_iter()
-                    .map(|uuid| {
-                        UuidV4::decode(&mut minicbor::Decoder::new(&uuid), &mut CborContext::Tagged)
-                    })
-                    .collect::<Result<_, _>>()
-                    .map(Self)
-                    .map_err(|e| {
-                        minicbor::decode::Error::message(format!(
-                            "{CONTEXT}: Invalid UUIDv4 in array: {e}"
-                        ))
-                    })
-            },
-            minicbor::data::Type::Tag => {
-                // Handle single tagged UUID
-                match policy {
-                    CompatibilityPolicy::Accept | CompatibilityPolicy::Warn => {
-                        if matches!(policy, CompatibilityPolicy::Warn) {
-                            warn!("{CONTEXT}: Conversion of document type single UUID to type DocType");
-                        }
-
-                        let uuid = UuidV4::decode(d, &mut CborContext::Tagged).map_err(|e| {
-                            minicbor::decode::Error::message(format!(
-                                "{CONTEXT}: Cannot decode single UUIDv4: {e}"
-                            ))
-                        })?;
-
-                        Ok(map_doc_type(uuid))
-                    },
-
-                    CompatibilityPolicy::Fail => {
-                        Err(minicbor::decode::Error::message(format!(
-                            "{CONTEXT}: Conversion of document type single UUID to type DocType is not allowed"
-                        )))
-                    },
-                }
-            },
-            other => {
-                Err(minicbor::decode::Error::message(format!(
-                    "{CONTEXT}: expected array of UUIDor tagged UUIDv4, got {other}",
-                )))
-            },
-        }
-    }
-}
-
-/// Map single UUID doc type to new list of doc types
-/// <https://github.com/input-output-hk/catalyst-libs/blob/main/docs/src/architecture/08_concepts/signed_doc/types.md#document-types>
-pub fn map_doc_type(uuid: UuidV4) -> DocType {
-    match uuid {
-        id if Uuid::from(id) == deprecated::PROPOSAL_DOCUMENT_UUID_TYPE => PROPOSAL.clone(),
-        id if Uuid::from(id) == deprecated::COMMENT_DOCUMENT_UUID_TYPE => PROPOSAL_COMMENT.clone(),
-        id if Uuid::from(id) == deprecated::PROPOSAL_ACTION_DOCUMENT_UUID_TYPE => {
-            PROPOSAL_SUBMISSION_ACTION.clone()
-        },
-        id => DocType(vec![id]),
-    }
-}
-
-/// Maps `DocType` to the deprecated corresponding doc type.
-pub fn to_deprecated_doc_type(doc_type: &DocType) -> Option<UuidV4> {
-    if doc_type == &*PROPOSAL {
-        UuidV4::try_from(deprecated::PROPOSAL_DOCUMENT_UUID_TYPE).ok()
-    } else if doc_type == &*PROPOSAL_COMMENT {
-        UuidV4::try_from(deprecated::COMMENT_DOCUMENT_UUID_TYPE).ok()
-    } else if doc_type == &*PROPOSAL_SUBMISSION_ACTION {
-        UuidV4::try_from(deprecated::PROPOSAL_ACTION_DOCUMENT_UUID_TYPE).ok()
-    } else {
-        doc_type.0.first().cloned()
+impl Decode<'_, ()> for DocType {
+    fn decode(d: &mut Decoder, _ctx: &mut ()) -> Result<Self, minicbor::decode::Error> {
+        UuidV4::decode(d, &mut CborContext::Tagged)
+            .map_err(|e| {
+                minicbor::decode::Error::message(format!(
+                    "DocType decoding Cannot decode single UUIDv4: {e}"
+                ))
+            })
+            .map(Self)
     }
 }
 
@@ -255,249 +75,176 @@ impl<C> Encode<C> for DocType {
     fn encode<W: minicbor::encode::Write>(
         &self, e: &mut minicbor::Encoder<W>, _ctx: &mut C,
     ) -> Result<(), minicbor::encode::Error<W::Error>> {
-        e.array(
-            self.0
-                .len()
-                .try_into()
-                .map_err(minicbor::encode::Error::message)?,
-        )?;
-
-        for id in &self.0 {
-            id.encode(e, &mut CborContext::Tagged)?;
-        }
-        Ok(())
+        self.0.encode(e, &mut CborContext::Tagged)
     }
 }
 
-impl<'de> Deserialize<'de> for DocType {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where D: Deserializer<'de> {
-        #[derive(Deserialize)]
-        #[serde(untagged)]
-        enum DocTypeInput {
-            /// Single UUID string.
-            Single(String),
-            /// List of UUID string.
-            Multiple(Vec<String>),
-        }
+// #[cfg(test)]
+// mod tests {
+//     use minicbor::Encoder;
+//     use serde_json::json;
+//     use test_case::test_case;
 
-        let input = DocTypeInput::deserialize(deserializer)?;
-        let dt = match input {
-            DocTypeInput::Single(s) => {
-                let uuid = s.parse().map_err(|_| {
-                    serde::de::Error::custom(DocTypeError::StringConversion(s.clone()))
-                })?;
-                // If there is a map from old (single uuid) to new use that list, else convert that
-                // single uuid to [uuid] - of type DocType
-                map_doc_type(uuid)
-            },
-            DocTypeInput::Multiple(v) => v.try_into().map_err(serde::de::Error::custom)?,
-        };
-        Ok(dt)
-    }
-}
+//     use super::*;
 
-#[cfg(test)]
-mod tests {
-    use minicbor::Encoder;
-    use serde_json::json;
-    use test_case::test_case;
+//     #[test_case(
+//         CompatibilityPolicy::Accept,
+//         {
+//             Encoder::new(Vec::new())
+//         } ;
+//         "Invalid empty CBOR bytes"
+//     )]
+//     #[test_case(
+//         CompatibilityPolicy::Accept,
+//         {
+//             let mut e = Encoder::new(Vec::new());
+//             e.array(0).unwrap();
+//             e
+//         } ;
+//         "Invalid empty CBOR array"
+//     )]
+//     #[test_case(
+//         CompatibilityPolicy::Fail,
+//         {
+//             let mut e = Encoder::new(Vec::new());
+//             e.encode_with(UuidV4::new(), &mut CborContext::Tagged).unwrap();
+//             e
+//         } ;
+//         "Valid single uuid v4 (old format), fail policy"
+//     )]
+//     #[test_case(
+//         CompatibilityPolicy::Accept,
+//         {
+//             let mut e = Encoder::new(Vec::new());
+//             e.encode_with(UuidV4::new(), &mut CborContext::Untagged).unwrap();
+//             e
+//         } ;
+//         "Invalid single untagged uuid v4 (old format)"
+//     )]
+//     #[test_case(
+//         CompatibilityPolicy::Accept,
+//         {
+//             let mut e = Encoder::new(Vec::new());
+//             e.array(1).unwrap().encode_with(UuidV4::new(), &mut
+// CborContext::Untagged).unwrap();             e
+//         } ;
+//         "Invalid untagged uuid v4 array (new format)"
+//     )]
+//     fn test_invalid_cbor_decode(mut policy: CompatibilityPolicy, e: Encoder<Vec<u8>>) {
+//         assert!(
+//             DocType::decode(&mut Decoder::new(e.into_writer().as_slice()), &mut
+// policy).is_err()         );
+//     }
 
-    use super::*;
+//     #[test_case(
+//         CompatibilityPolicy::Accept,
+//         |uuid: UuidV4| {
+//             let mut e = Encoder::new(Vec::new());
+//             e.encode_with(uuid, &mut CborContext::Tagged).unwrap();
+//             e
+//         } ;
+//         "Valid single uuid v4 (old format)"
+//     )]
+//     #[test_case(
+//         CompatibilityPolicy::Warn,
+//         |uuid: UuidV4| {
+//             let mut e = Encoder::new(Vec::new());
+//             e.encode_with(uuid, &mut CborContext::Tagged).unwrap();
+//             e
+//         } ;
+//         "Valid single uuid v4 (old format), warn policy"
+//     )]
+//     #[test_case(
+//         CompatibilityPolicy::Accept,
+//         |uuid: UuidV4| {
+//             let mut e = Encoder::new(Vec::new());
+//             e.array(1).unwrap().encode_with(uuid, &mut CborContext::Tagged).unwrap();
+//             e
+//         } ;
+//         "Array of uuid v4 (new format)"
+//     )]
+//     #[test_case(
+//         CompatibilityPolicy::Fail,
+//         |uuid: UuidV4| {
+//             let mut e = Encoder::new(Vec::new());
+//             e.array(1).unwrap().encode_with(uuid, &mut CborContext::Tagged).unwrap();
+//             e
+//         } ;
+//         "Array of uuid v4 (new format), fail policy"
+//     )]
+//     fn test_valid_cbor_decode(e_gen: impl FnOnce(UuidV4) -> Encoder<Vec<u8>>) {
+//         let uuid = UuidV4::new();
+//         let e = e_gen(uuid);
 
-    #[test_case(
-        CompatibilityPolicy::Accept,
-        {
-            Encoder::new(Vec::new())
-        } ;
-        "Invalid empty CBOR bytes"
-    )]
-    #[test_case(
-        CompatibilityPolicy::Accept,
-        {
-            let mut e = Encoder::new(Vec::new());
-            e.array(0).unwrap();
-            e
-        } ;
-        "Invalid empty CBOR array"
-    )]
-    #[test_case(
-        CompatibilityPolicy::Fail,
-        {
-            let mut e = Encoder::new(Vec::new());
-            e.encode_with(UuidV4::new(), &mut CborContext::Tagged).unwrap();
-            e
-        } ;
-        "Valid single uuid v4 (old format), fail policy"
-    )]
-    #[test_case(
-        CompatibilityPolicy::Accept,
-        {
-            let mut e = Encoder::new(Vec::new());
-            e.encode_with(UuidV4::new(), &mut CborContext::Untagged).unwrap();
-            e
-        } ;
-        "Invalid single untagged uuid v4 (old format)"
-    )]
-    #[test_case(
-        CompatibilityPolicy::Accept,
-        {
-            let mut e = Encoder::new(Vec::new());
-            e.array(1).unwrap().encode_with(UuidV4::new(), &mut CborContext::Untagged).unwrap();
-            e
-        } ;
-        "Invalid untagged uuid v4 array (new format)"
-    )]
-    fn test_invalid_cbor_decode(mut policy: CompatibilityPolicy, e: Encoder<Vec<u8>>) {
-        assert!(
-            DocType::decode(&mut Decoder::new(e.into_writer().as_slice()), &mut policy).is_err()
-        );
-    }
+//         let doc_type =
+//             DocType::decode(&mut Decoder::new(e.into_writer().as_slice()), &mut
+// ()).unwrap();         assert_eq!(doc_type.0, uuid);
+//     }
 
-    #[test_case(
-        CompatibilityPolicy::Accept,
-        |uuid: UuidV4| {
-            let mut e = Encoder::new(Vec::new());
-            e.encode_with(uuid, &mut CborContext::Tagged).unwrap();
-            e
-        } ;
-        "Valid single uuid v4 (old format)"
-    )]
-    #[test_case(
-        CompatibilityPolicy::Warn,
-        |uuid: UuidV4| {
-            let mut e = Encoder::new(Vec::new());
-            e.encode_with(uuid, &mut CborContext::Tagged).unwrap();
-            e
-        } ;
-        "Valid single uuid v4 (old format), warn policy"
-    )]
-    #[test_case(
-        CompatibilityPolicy::Accept,
-        |uuid: UuidV4| {
-            let mut e = Encoder::new(Vec::new());
-            e.array(1).unwrap().encode_with(uuid, &mut CborContext::Tagged).unwrap();
-            e
-        } ;
-        "Array of uuid v4 (new format)"
-    )]
-    #[test_case(
-        CompatibilityPolicy::Fail,
-        |uuid: UuidV4| {
-            let mut e = Encoder::new(Vec::new());
-            e.array(1).unwrap().encode_with(uuid, &mut CborContext::Tagged).unwrap();
-            e
-        } ;
-        "Array of uuid v4 (new format), fail policy"
-    )]
-    fn test_valid_cbor_decode(
-        mut policy: CompatibilityPolicy, e_gen: impl FnOnce(UuidV4) -> Encoder<Vec<u8>>,
-    ) {
-        let uuid = UuidV4::new();
-        let e = e_gen(uuid);
+//     #[test_case(
+//         |uuid: Uuid| { vec![uuid.to_string()] } ;
+//         "vec of strings"
+//     )]
+//     #[test_case(
+//         |uuid: Uuid| { vec![uuid] } ;
+//         "vec of uuid"
+//     )]
+//     #[test_case(
+//         |uuid: Uuid| { vec![UuidV4::try_from(uuid).unwrap()] } ;
+//         "vec of UuidV4"
+//     )]
+//     #[test_case(
+//         |uuid: Uuid| { uuid } ;
+//         "single uuid"
+//     )]
+//     fn test_valid_try_from<T>(input_gen: impl FnOnce(Uuid) -> T)
+//     where DocType: TryFrom<T, Error = DocTypeError> {
+//         let uuid = Uuid::new_v4();
+//         let doc_type = DocType::try_from(input_gen(uuid)).unwrap();
+//         assert_eq!(doc_type.0.len(), 1);
+//         assert_eq!(doc_type.0.first().unwrap().uuid(), uuid);
+//     }
 
-        let doc_type =
-            DocType::decode(&mut Decoder::new(e.into_writer().as_slice()), &mut policy).unwrap();
-        assert_eq!(doc_type.0, vec![uuid]);
-    }
+//     #[test_case(
+//         Vec::<String>::new() => matches Err(DocTypeError::Empty) ;
+//         "Empty string vec"
+//     )]
+//     #[test_case(
+//         Vec::<Uuid>::new() => matches Err(DocTypeError::Empty) ;
+//         "Empty Uuid vec"
+//     )]
+//     #[test_case(
+//         Vec::<UuidV4>::new() => matches Err(DocTypeError::Empty) ;
+//         "Empty UuidV4 vec"
+//     )]
+//     #[test_case(
+//         vec!["not-a-uuid".to_string()] => matches
+// Err(DocTypeError::StringConversion(_)) ;         "Not a valid Uuid string"
+//     )]
+//     #[test_case(
+//         vec![Uuid::now_v7()] => matches Err(DocTypeError::InvalidUuid(_)) ;
+//         "Not a valid vec of uuid v4"
+//     )]
+//     #[test_case(
+//         Uuid::now_v7() => matches Err(DocTypeError::InvalidUuid(_)) ;
+//         "Not a valid uuid v4"
+//     )]
+//     fn test_invalid_try_from<T>(input: T) -> Result<DocType, DocTypeError>
+//     where DocType: TryFrom<T, Error = DocTypeError> {
+//         DocType::try_from(input)
+//     }
 
-    #[test_case(
-        |uuid: Uuid| { vec![uuid.to_string()] } ;
-        "vec of strings"
-    )]
-    #[test_case(
-        |uuid: Uuid| { vec![uuid] } ;
-        "vec of uuid"
-    )]
-    #[test_case(
-        |uuid: Uuid| { vec![UuidV4::try_from(uuid).unwrap()] } ;
-        "vec of UuidV4"
-    )]
-    #[test_case(
-        |uuid: Uuid| { uuid } ;
-        "single uuid"
-    )]
-    fn test_valid_try_from<T>(input_gen: impl FnOnce(Uuid) -> T)
-    where DocType: TryFrom<T, Error = DocTypeError> {
-        let uuid = Uuid::new_v4();
-        let doc_type = DocType::try_from(input_gen(uuid)).unwrap();
-        assert_eq!(doc_type.0.len(), 1);
-        assert_eq!(doc_type.0.first().unwrap().uuid(), uuid);
-    }
-
-    #[test_case(
-        Vec::<String>::new() => matches Err(DocTypeError::Empty) ;
-        "Empty string vec"
-    )]
-    #[test_case(
-        Vec::<Uuid>::new() => matches Err(DocTypeError::Empty) ;
-        "Empty Uuid vec"
-    )]
-    #[test_case(
-        Vec::<UuidV4>::new() => matches Err(DocTypeError::Empty) ;
-        "Empty UuidV4 vec"
-    )]
-    #[test_case(
-        vec!["not-a-uuid".to_string()] => matches Err(DocTypeError::StringConversion(_)) ;
-        "Not a valid Uuid string"
-    )]
-    #[test_case(
-        vec![Uuid::now_v7()] => matches Err(DocTypeError::InvalidUuid(_)) ;
-        "Not a valid vec of uuid v4"
-    )]
-    #[test_case(
-        Uuid::now_v7() => matches Err(DocTypeError::InvalidUuid(_)) ;
-        "Not a valid uuid v4"
-    )]
-    fn test_invalid_try_from<T>(input: T) -> Result<DocType, DocTypeError>
-    where DocType: TryFrom<T, Error = DocTypeError> {
-        DocType::try_from(input)
-    }
-
-    #[test_case(
-        deprecated::PROPOSAL_DOCUMENT_UUID_TYPE => PROPOSAL.clone() ;
-        "deprecated proposal document type"
-    )]
-    #[test_case(
-        deprecated::COMMENT_DOCUMENT_UUID_TYPE => PROPOSAL_COMMENT.clone() ;
-        "deprecated proposal comment document type"
-    )]
-    #[test_case(
-        deprecated::PROPOSAL_ACTION_DOCUMENT_UUID_TYPE => PROPOSAL_SUBMISSION_ACTION.clone() ;
-        "deprecated proposal submission action type"
-    )]
-    fn test_compatibility_mapping(uuid: Uuid) -> DocType {
-        let mut e = Encoder::new(Vec::new());
-        e.encode_with(UuidV4::try_from(uuid).unwrap(), &mut CborContext::Tagged)
-            .unwrap();
-
-        // cbor decoding
-        let cbor_doc_type = DocType::decode(
-            &mut Decoder::new(e.into_writer().as_slice()),
-            &mut CompatibilityPolicy::Accept,
-        )
-        .unwrap();
-
-        // json decoding
-        let json = json!(uuid);
-        let json_doc_type = serde_json::from_value(json).unwrap();
-
-        assert!(cbor_doc_type == json_doc_type);
-
-        cbor_doc_type
-    }
-
-    #[test_case(
-        serde_json::json!(UuidV4::new()) ;
-        "Document type old format"
-    )]
-    #[test_case(
-        serde_json::json!([UuidV4::new(), UuidV4::new()]) ;
-        "Document type new format"
-    )]
-    fn test_json_valid_serde(json: serde_json::Value) {
-        let refs: DocType = serde_json::from_value(json).unwrap();
-        let json_from_refs = serde_json::to_value(&refs).unwrap();
-        assert_eq!(refs, serde_json::from_value(json_from_refs).unwrap());
-    }
-}
+//     #[test_case(
+//         serde_json::json!(UuidV4::new()) ;
+//         "Document type old format"
+//     )]
+//     #[test_case(
+//         serde_json::json!([UuidV4::new(), UuidV4::new()]) ;
+//         "Document type new format"
+//     )]
+//     fn test_json_valid_serde(json: serde_json::Value) {
+//         let refs: DocType = serde_json::from_value(json).unwrap();
+//         let json_from_refs = serde_json::to_value(&refs).unwrap();
+//         assert_eq!(refs, serde_json::from_value(json_from_refs).unwrap());
+//     }
+// }

--- a/rust/signed_doc/src/metadata/doc_type.rs
+++ b/rust/signed_doc/src/metadata/doc_type.rs
@@ -15,6 +15,9 @@ pub struct DocType(UuidV4);
 
 impl DocType {
     /// A const alternative impl of `TryFrom<Uuid>`
+    ///
+    /// # Errors
+    ///  - `catalyst_types::uuid::InvalidUuidV4`
     pub const fn try_from_uuid(uuid: Uuid) -> Result<Self, catalyst_types::uuid::InvalidUuidV4> {
         match UuidV4::try_from_uuid(uuid) {
             Ok(v) => Ok(Self(v)),

--- a/rust/signed_doc/src/metadata/doc_type.rs
+++ b/rust/signed_doc/src/metadata/doc_type.rs
@@ -100,7 +100,7 @@ mod tests {
     #[test_case(
         {
             let mut e = Encoder::new(Vec::new());
-            e.encode_with(UuidV7::new(), &mut CborContext::Untagged).unwrap();
+            e.encode_with(UuidV7::new(), &mut CborContext::Tagged).unwrap();
             e
         } ;
         "Invalid tagged uuid v7"

--- a/rust/signed_doc/src/metadata/doc_type.rs
+++ b/rust/signed_doc/src/metadata/doc_type.rs
@@ -55,10 +55,6 @@ impl Display for DocType {
     }
 }
 
-// ; Document Type
-// document_type = [ 1* uuid_v4 ]
-// ; UUIDv4
-// uuid_v4 = #6.37(bytes .size 16)
 impl Decode<'_, ()> for DocType {
     fn decode(d: &mut Decoder, _ctx: &mut ()) -> Result<Self, minicbor::decode::Error> {
         UuidV4::decode(d, &mut CborContext::Tagged)
@@ -79,172 +75,92 @@ impl<C> Encode<C> for DocType {
     }
 }
 
-// #[cfg(test)]
-// mod tests {
-//     use minicbor::Encoder;
-//     use serde_json::json;
-//     use test_case::test_case;
+#[cfg(test)]
+mod tests {
+    use catalyst_types::uuid::UuidV7;
+    use minicbor::Encoder;
+    use test_case::test_case;
 
-//     use super::*;
+    use super::*;
 
-//     #[test_case(
-//         CompatibilityPolicy::Accept,
-//         {
-//             Encoder::new(Vec::new())
-//         } ;
-//         "Invalid empty CBOR bytes"
-//     )]
-//     #[test_case(
-//         CompatibilityPolicy::Accept,
-//         {
-//             let mut e = Encoder::new(Vec::new());
-//             e.array(0).unwrap();
-//             e
-//         } ;
-//         "Invalid empty CBOR array"
-//     )]
-//     #[test_case(
-//         CompatibilityPolicy::Fail,
-//         {
-//             let mut e = Encoder::new(Vec::new());
-//             e.encode_with(UuidV4::new(), &mut CborContext::Tagged).unwrap();
-//             e
-//         } ;
-//         "Valid single uuid v4 (old format), fail policy"
-//     )]
-//     #[test_case(
-//         CompatibilityPolicy::Accept,
-//         {
-//             let mut e = Encoder::new(Vec::new());
-//             e.encode_with(UuidV4::new(), &mut CborContext::Untagged).unwrap();
-//             e
-//         } ;
-//         "Invalid single untagged uuid v4 (old format)"
-//     )]
-//     #[test_case(
-//         CompatibilityPolicy::Accept,
-//         {
-//             let mut e = Encoder::new(Vec::new());
-//             e.array(1).unwrap().encode_with(UuidV4::new(), &mut
-// CborContext::Untagged).unwrap();             e
-//         } ;
-//         "Invalid untagged uuid v4 array (new format)"
-//     )]
-//     fn test_invalid_cbor_decode(mut policy: CompatibilityPolicy, e: Encoder<Vec<u8>>) {
-//         assert!(
-//             DocType::decode(&mut Decoder::new(e.into_writer().as_slice()), &mut
-// policy).is_err()         );
-//     }
+    #[test_case(
+        {
+            Encoder::new(Vec::new())
+        } ;
+        "Invalid empty CBOR bytes"
+    )]
+    #[test_case(
+        {
+            let mut e = Encoder::new(Vec::new());
+            e.encode_with(UuidV4::new(), &mut CborContext::Untagged).unwrap();
+            e
+        } ;
+        "Invalid untagged uuid v4"
+    )]
+    #[test_case(
+        {
+            let mut e = Encoder::new(Vec::new());
+            e.encode_with(UuidV7::new(), &mut CborContext::Untagged).unwrap();
+            e
+        } ;
+        "Invalid tagged uuid v7"
+    )]
+    fn test_invalid_cbor_decode(e: Encoder<Vec<u8>>) {
+        assert!(DocType::decode(&mut Decoder::new(e.into_writer().as_slice()), &mut ()).is_err());
+    }
 
-//     #[test_case(
-//         CompatibilityPolicy::Accept,
-//         |uuid: UuidV4| {
-//             let mut e = Encoder::new(Vec::new());
-//             e.encode_with(uuid, &mut CborContext::Tagged).unwrap();
-//             e
-//         } ;
-//         "Valid single uuid v4 (old format)"
-//     )]
-//     #[test_case(
-//         CompatibilityPolicy::Warn,
-//         |uuid: UuidV4| {
-//             let mut e = Encoder::new(Vec::new());
-//             e.encode_with(uuid, &mut CborContext::Tagged).unwrap();
-//             e
-//         } ;
-//         "Valid single uuid v4 (old format), warn policy"
-//     )]
-//     #[test_case(
-//         CompatibilityPolicy::Accept,
-//         |uuid: UuidV4| {
-//             let mut e = Encoder::new(Vec::new());
-//             e.array(1).unwrap().encode_with(uuid, &mut CborContext::Tagged).unwrap();
-//             e
-//         } ;
-//         "Array of uuid v4 (new format)"
-//     )]
-//     #[test_case(
-//         CompatibilityPolicy::Fail,
-//         |uuid: UuidV4| {
-//             let mut e = Encoder::new(Vec::new());
-//             e.array(1).unwrap().encode_with(uuid, &mut CborContext::Tagged).unwrap();
-//             e
-//         } ;
-//         "Array of uuid v4 (new format), fail policy"
-//     )]
-//     fn test_valid_cbor_decode(e_gen: impl FnOnce(UuidV4) -> Encoder<Vec<u8>>) {
-//         let uuid = UuidV4::new();
-//         let e = e_gen(uuid);
+    #[test_case(
+        |uuid: UuidV4| {
+            let mut e = Encoder::new(Vec::new());
+            e.encode_with(uuid, &mut CborContext::Tagged).unwrap();
+            e
+        } ;
+        "Valid uuid v4"
+    )]
+    fn test_valid_cbor_decode(e_gen: impl FnOnce(UuidV4) -> Encoder<Vec<u8>>) {
+        let uuid = UuidV4::new();
+        let e = e_gen(uuid);
 
-//         let doc_type =
-//             DocType::decode(&mut Decoder::new(e.into_writer().as_slice()), &mut
-// ()).unwrap();         assert_eq!(doc_type.0, uuid);
-//     }
+        let doc_type =
+            DocType::decode(&mut Decoder::new(e.into_writer().as_slice()), &mut ()).unwrap();
+        assert_eq!(doc_type.0, uuid);
+    }
 
-//     #[test_case(
-//         |uuid: Uuid| { vec![uuid.to_string()] } ;
-//         "vec of strings"
-//     )]
-//     #[test_case(
-//         |uuid: Uuid| { vec![uuid] } ;
-//         "vec of uuid"
-//     )]
-//     #[test_case(
-//         |uuid: Uuid| { vec![UuidV4::try_from(uuid).unwrap()] } ;
-//         "vec of UuidV4"
-//     )]
-//     #[test_case(
-//         |uuid: Uuid| { uuid } ;
-//         "single uuid"
-//     )]
-//     fn test_valid_try_from<T>(input_gen: impl FnOnce(Uuid) -> T)
-//     where DocType: TryFrom<T, Error = DocTypeError> {
-//         let uuid = Uuid::new_v4();
-//         let doc_type = DocType::try_from(input_gen(uuid)).unwrap();
-//         assert_eq!(doc_type.0.len(), 1);
-//         assert_eq!(doc_type.0.first().unwrap().uuid(), uuid);
-//     }
+    #[test_case(
+        |uuid: Uuid| { uuid.to_string() } ;
+        "strings"
+    )]
+    #[test_case(
+        |uuid: Uuid| { uuid } ;
+        "Uuid"
+    )]
+    fn test_valid_try_from<T>(input_gen: impl FnOnce(Uuid) -> T)
+    where DocType: TryFrom<T, Error = DocTypeError> {
+        let uuid = Uuid::new_v4();
+        let doc_type = DocType::try_from(input_gen(uuid)).unwrap();
+        assert_eq!(doc_type.0.uuid(), uuid);
+    }
 
-//     #[test_case(
-//         Vec::<String>::new() => matches Err(DocTypeError::Empty) ;
-//         "Empty string vec"
-//     )]
-//     #[test_case(
-//         Vec::<Uuid>::new() => matches Err(DocTypeError::Empty) ;
-//         "Empty Uuid vec"
-//     )]
-//     #[test_case(
-//         Vec::<UuidV4>::new() => matches Err(DocTypeError::Empty) ;
-//         "Empty UuidV4 vec"
-//     )]
-//     #[test_case(
-//         vec!["not-a-uuid".to_string()] => matches
-// Err(DocTypeError::StringConversion(_)) ;         "Not a valid Uuid string"
-//     )]
-//     #[test_case(
-//         vec![Uuid::now_v7()] => matches Err(DocTypeError::InvalidUuid(_)) ;
-//         "Not a valid vec of uuid v4"
-//     )]
-//     #[test_case(
-//         Uuid::now_v7() => matches Err(DocTypeError::InvalidUuid(_)) ;
-//         "Not a valid uuid v4"
-//     )]
-//     fn test_invalid_try_from<T>(input: T) -> Result<DocType, DocTypeError>
-//     where DocType: TryFrom<T, Error = DocTypeError> {
-//         DocType::try_from(input)
-//     }
+    #[test_case(
+        "not-a-uuid".to_string() => matches
+        Err(DocTypeError::StringConversion(_)) ;         "Not a valid Uuid string"
+    )]
+    #[test_case(
+        Uuid::now_v7() => matches Err(DocTypeError::InvalidUuid(_)) ;
+        "Not a valid uuid v4"
+    )]
+    fn test_invalid_try_from<T>(input: T) -> Result<DocType, DocTypeError>
+    where DocType: TryFrom<T, Error = DocTypeError> {
+        DocType::try_from(input)
+    }
 
-//     #[test_case(
-//         serde_json::json!(UuidV4::new()) ;
-//         "Document type old format"
-//     )]
-//     #[test_case(
-//         serde_json::json!([UuidV4::new(), UuidV4::new()]) ;
-//         "Document type new format"
-//     )]
-//     fn test_json_valid_serde(json: serde_json::Value) {
-//         let refs: DocType = serde_json::from_value(json).unwrap();
-//         let json_from_refs = serde_json::to_value(&refs).unwrap();
-//         assert_eq!(refs, serde_json::from_value(json_from_refs).unwrap());
-//     }
-// }
+    #[test_case(
+        serde_json::json!(UuidV4::new()) ;
+        "Document type old format"
+    )]
+    fn test_json_valid_serde(json: serde_json::Value) {
+        let refs: DocType = serde_json::from_value(json).unwrap();
+        let json_from_refs = serde_json::to_value(&refs).unwrap();
+        assert_eq!(refs, serde_json::from_value(json_from_refs).unwrap());
+    }
+}

--- a/rust/signed_doc/src/metadata/doc_type.rs
+++ b/rust/signed_doc/src/metadata/doc_type.rs
@@ -8,7 +8,7 @@ use std::{
 use catalyst_types::uuid::{CborContext, Uuid, UuidV4};
 use minicbor::{Decode, Decoder, Encode};
 
-/// List of `UUIDv4` document type.
+/// Document type - `UUIDv4`.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct DocType(UuidV4);
 

--- a/rust/signed_doc/src/metadata/mod.rs
+++ b/rust/signed_doc/src/metadata/mod.rs
@@ -331,26 +331,17 @@ mod tests {
         serde_json::json!({
             "id": "0197f398-9f43-7c23-a576-f765131b81f2",
             "ver": "0197f398-9f43-7c23-a576-f765131b81f2",
-            "type": [ "ab7c2428-c353-4331-856e-385b2eb20546" ],
-            "content-type": "application/json",
-        }) ;
-        "minimally valid JSON, new format document type"
-    )]
-    #[test_case(
-        serde_json::json!({
-            "id": "0197f398-9f43-7c23-a576-f765131b81f2",
-            "ver": "0197f398-9f43-7c23-a576-f765131b81f2",
             "type":  "ab7c2428-c353-4331-856e-385b2eb20546",
             "content-type": "application/json",
         }) ;
-        "minimally valid JSON, old format document type"
+        "minimally valid JSON"
     )]
     #[test_case(
         serde_json::json!(
             {
                 "id": "0197f398-9f43-7c23-a576-f765131b81f2",
                 "ver": "0197f398-9f43-7c23-a576-f765131b81f2",
-                "type":  [ "ab7c2428-c353-4331-856e-385b2eb20546" ],
+                "type":  "ab7c2428-c353-4331-856e-385b2eb20546",
                 "content-type": "application/json",
                 "ref":  [
                     {
@@ -361,14 +352,14 @@ mod tests {
                 ]
             }
         ) ;
-        "minimally valid JSON, old format document reference type new format"
+        "minimally valid JSON, new format reference type"
     )]
     #[test_case(
         serde_json::json!(
             {
                 "id": "0197f398-9f43-7c23-a576-f765131b81f2",
                 "ver": "0197f398-9f43-7c23-a576-f765131b81f2",
-                "type":  [ "ab7c2428-c353-4331-856e-385b2eb20546" ],
+                "type":  "ab7c2428-c353-4331-856e-385b2eb20546",
                 "content-type": "application/json",
                 "ref": {
                     "id": "0197f398-9f43-7c23-a576-f765131b81f2",
@@ -376,7 +367,7 @@ mod tests {
                 },
             }
         ) ;
-        "minimally valid JSON, old format document reference type old format"
+        "minimally valid JSON, old format reference type"
     )]
     fn test_json_valid_serde(json: serde_json::Value) {
         let metadata = Metadata::from_json(json).unwrap();

--- a/rust/signed_doc/src/metadata/supported_field.rs
+++ b/rust/signed_doc/src/metadata/supported_field.rs
@@ -241,10 +241,7 @@ impl minicbor::Decode<'_, crate::decode_context::DecodeContext> for Option<Suppo
                 d.decode_with(&mut catalyst_types::uuid::CborContext::Tagged)
                     .map(SupportedField::Ver)
             },
-            SupportedLabel::Type => {
-                d.decode_with(&mut ctx.policy().clone())
-                    .map(SupportedField::Type)
-            },
+            SupportedLabel::Type => d.decode().map(SupportedField::Type),
             SupportedLabel::Reply => {
                 d.decode_with(&mut ctx.policy().clone())
                     .map(SupportedField::Reply)

--- a/rust/signed_doc/src/validator/mod.rs
+++ b/rust/signed_doc/src/validator/mod.rs
@@ -18,9 +18,8 @@ use rules::{
 
 use crate::{
     doc_types::{
-        deprecated::{self},
         BRAND_PARAMETERS, CAMPAIGN_PARAMETERS, CATEGORY_PARAMETERS, PROPOSAL, PROPOSAL_COMMENT,
-        PROPOSAL_COMMENT_TEMPLATE, PROPOSAL_SUBMISSION_ACTION, PROPOSAL_TEMPLATE,
+        PROPOSAL_COMMENT_FORM_TEMPLATE, PROPOSAL_FORM_TEMPLATE, PROPOSAL_SUBMISSION_ACTION,
     },
     metadata::DocType,
     providers::{CatalystSignedDocumentProvider, VerifyingKeyProvider},
@@ -30,18 +29,6 @@ use crate::{
 
 /// A table representing a full set or validation rules per document id.
 static DOCUMENT_RULES: LazyLock<HashMap<DocType, Arc<Rules>>> = LazyLock::new(document_rules_init);
-
-/// Returns an `DocType` from the provided argument.
-/// Reduce redundant conversion.
-/// This function should be used for hardcoded values, panic if conversion fail.
-#[allow(clippy::expect_used)]
-pub(crate) fn expect_doc_type<T>(t: T) -> DocType
-where
-    T: TryInto<DocType>,
-    T::Error: std::fmt::Debug,
-{
-    t.try_into().expect("Failed to convert to DocType")
-}
 
 /// Proposal
 /// Require field: type, id, ver, template, parameters
@@ -62,7 +49,7 @@ fn proposal_rule() -> Rules {
             optional: false,
         },
         content: ContentRule::Templated {
-            exp_template_type: PROPOSAL_TEMPLATE.clone(),
+            exp_template_type: PROPOSAL_FORM_TEMPLATE.clone(),
         },
         parameters: ParametersRule::Specified {
             exp_parameters_type: parameters.clone(),
@@ -99,7 +86,7 @@ fn proposal_comment_rule() -> Rules {
             optional: false,
         },
         content: ContentRule::Templated {
-            exp_template_type: PROPOSAL_COMMENT_TEMPLATE.clone(),
+            exp_template_type: PROPOSAL_COMMENT_FORM_TEMPLATE.clone(),
         },
         doc_ref: RefRule::Specified {
             exp_ref_type: PROPOSAL.clone(),
@@ -185,16 +172,6 @@ fn document_rules_init() -> HashMap<DocType, Arc<Rules>> {
     document_rules_map.insert(PROPOSAL_COMMENT.clone(), Arc::clone(&comment_rules));
     document_rules_map.insert(
         PROPOSAL_SUBMISSION_ACTION.clone(),
-        Arc::clone(&action_rules),
-    );
-
-    // Insert old rules (for backward compatibility)
-    document_rules_map.insert(
-        expect_doc_type(deprecated::COMMENT_DOCUMENT_UUID_TYPE),
-        Arc::clone(&comment_rules),
-    );
-    document_rules_map.insert(
-        expect_doc_type(deprecated::PROPOSAL_ACTION_DOCUMENT_UUID_TYPE),
         Arc::clone(&action_rules),
     );
 

--- a/rust/signed_doc/tests/comment.rs
+++ b/rust/signed_doc/tests/comment.rs
@@ -5,7 +5,6 @@
 use std::sync::LazyLock;
 
 use catalyst_signed_doc::{
-    doc_types::deprecated,
     providers::tests::{TestCatalystSignedDocumentProvider, TestVerifyingKeyProvider},
     *,
 };
@@ -54,7 +53,7 @@ static COMMENT_TEMPLATE_DOC: LazyLock<CatalystSignedDocument> = LazyLock::new(||
         .with_json_metadata(serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": doc_types::PROPOSAL_COMMENT_TEMPLATE.clone(),
+            "type": doc_types::PROPOSAL_COMMENT_FORM_TEMPLATE.clone(),
             "id": UuidV7::new(),
             "ver": UuidV7::new(),
             "parameters": {
@@ -216,49 +215,6 @@ async fn test_invalid_comment_doc_wrong_role() {
 
     let is_valid = validator::validate(&doc, &provider).await.unwrap();
     assert!(!is_valid, "{:?}", doc.problem_report());
-}
-
-// The same as above but test with the old type
-#[tokio::test]
-async fn test_valid_comment_doc_old_type() {
-    let doc = Builder::new()
-        .with_json_metadata(serde_json::json!({
-            "content-type": ContentType::Json.to_string(),
-            "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": deprecated::COMMENT_DOCUMENT_UUID_TYPE,
-            "id": UuidV7::new(),
-            "ver": UuidV7::new(),
-            "ref": {
-                "id": DUMMY_PROPOSAL_DOC.doc_id().unwrap(),
-                "ver": DUMMY_PROPOSAL_DOC.doc_ver().unwrap(),
-            },
-            "template": {
-                "id": COMMENT_TEMPLATE_DOC.doc_id().unwrap(),
-                "ver": COMMENT_TEMPLATE_DOC.doc_ver().unwrap(),
-            },
-            "reply": {
-                "id": COMMENT_REF_DOC.doc_id().unwrap(),
-                "ver": COMMENT_REF_DOC.doc_ver().unwrap()
-            },
-            "parameters": {
-                "id": DUMMY_BRAND_DOC.doc_id().unwrap(),
-                "ver": DUMMY_BRAND_DOC.doc_ver().unwrap(),
-            }
-        }))
-        .unwrap()
-        .with_json_content(&serde_json::json!({}))
-        .unwrap()
-        .build()
-        .unwrap();
-
-    let mut provider = TestCatalystSignedDocumentProvider::default();
-    provider.add_document(None, &DUMMY_BRAND_DOC).unwrap();
-    provider.add_document(None, &DUMMY_PROPOSAL_DOC).unwrap();
-    provider.add_document(None, &COMMENT_REF_DOC).unwrap();
-    provider.add_document(None, &COMMENT_TEMPLATE_DOC).unwrap();
-
-    let is_valid = validator::validate(&doc, &provider).await.unwrap();
-    assert!(is_valid, "{:?}", doc.problem_report());
 }
 
 #[tokio::test]

--- a/rust/signed_doc/tests/decoding.rs
+++ b/rust/signed_doc/tests/decoding.rs
@@ -24,14 +24,13 @@ struct TestCase {
 
 fn signed_doc_with_valid_alias_case(alias: &'static str) -> TestCase {
     let uuid_v7 = UuidV7::new();
-    let uuid_v4 = UuidV4::new();
+    let doc_type = DocType::from(UuidV4::new());
     let doc_ref = DocumentRefs::from(vec![DocumentRef::new(
         UuidV7::new(),
         UuidV7::new(),
         DocLocator::default(),
     )]);
     let doc_ref_cloned = doc_ref.clone();
-
     TestCase {
         name: format!("Provided '{alias}' field should be processed as parameters."),
         bytes_gen: Box::new({
@@ -45,9 +44,7 @@ fn signed_doc_with_valid_alias_case(alias: &'static str) -> TestCase {
                     let mut p_headers = Encoder::new(Vec::new());
                     p_headers.map(5)?;
                     p_headers.u8(3)?.encode(ContentType::Json)?;
-                    p_headers
-                        .str("type")?
-                        .encode_with(uuid_v4, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                    p_headers.str("type")?.encode(&doc_type)?;
                     p_headers
                         .str("id")?
                         .encode_with(uuid_v7, &mut catalyst_types::uuid::CborContext::Tagged)?;
@@ -86,9 +83,8 @@ fn signed_doc_with_valid_alias_case(alias: &'static str) -> TestCase {
 
 fn signed_doc_with_missing_header_field_case(field: &'static str) -> TestCase {
     let uuid_v7 = UuidV7::new();
-    let uuid_v4 = UuidV4::new();
+    let doc_type = DocType::from(UuidV4::new());
     let doc_ref = DocumentRef::new(UuidV7::new(), UuidV7::new(), DocLocator::default());
-
     TestCase {
         name: format!("Catalyst Signed Doc with missing '{field}' header."),
         bytes_gen: Box::new({
@@ -105,9 +101,7 @@ fn signed_doc_with_missing_header_field_case(field: &'static str) -> TestCase {
                         p_headers.u8(3)?.encode(ContentType::Json)?;
                     }
                     if field != "type" {
-                        p_headers
-                            .str("type")?
-                            .encode_with(uuid_v4, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                        p_headers.str("type")?.encode(&doc_type)?;
                     }
                     if field != "id" {
                         p_headers
@@ -163,8 +157,7 @@ fn signed_doc_with_missing_header_field_case(field: &'static str) -> TestCase {
 
 fn signed_doc_with_random_header_field_case(field: &'static str) -> TestCase {
     let uuid_v7 = UuidV7::new();
-    let uuid_v4 = UuidV4::new();
-
+    let doc_type = DocType::from(UuidV4::new());
     TestCase {
         name: format!("Catalyst Signed Doc with random bytes in '{field}' header field."),
         bytes_gen: Box::new({
@@ -193,9 +186,7 @@ fn signed_doc_with_random_header_field_case(field: &'static str) -> TestCase {
                     if field == "type" {
                         p_headers.str("type")?.encode_with(rand_buf, &mut ())?;
                     } else {
-                        p_headers
-                            .str("type")?
-                            .encode_with(uuid_v4, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                        p_headers.str("type")?.encode(&doc_type)?;
                     }
                     if field == "id" {
                         p_headers.str("id")?.encode_with(rand_buf, &mut ())?;
@@ -264,9 +255,8 @@ fn signed_doc_with_random_header_field_case(field: &'static str) -> TestCase {
 // `parameters` value along with its aliases are not allowed to be presented
 fn signed_doc_with_parameters_and_aliases_case(aliases: &'static [&'static str]) -> TestCase {
     let uuid_v7 = UuidV7::new();
-    let uuid_v4 = UuidV4::new();
+    let doc_type = DocType::from(UuidV4::new());
     let doc_ref = DocumentRef::new(UuidV7::new(), UuidV7::new(), DocLocator::default());
-
     TestCase {
         name: format!("Multiple definitions of '{}' at once.", aliases.join(", ")),
         bytes_gen: Box::new({
@@ -280,9 +270,7 @@ fn signed_doc_with_parameters_and_aliases_case(aliases: &'static [&'static str])
                     let mut p_headers = Encoder::new(Vec::new());
                     p_headers.map(4u64.overflowing_add(u64::try_from(aliases.len())?).0)?;
                     p_headers.u8(3)?.encode(ContentType::Json)?;
-                    p_headers
-                        .str("type")?
-                        .encode_with(uuid_v4, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                    p_headers.str("type")?.encode(&doc_type)?;
                     p_headers
                         .str("id")?
                         .encode_with(uuid_v7, &mut catalyst_types::uuid::CborContext::Tagged)?;
@@ -318,14 +306,12 @@ fn signed_doc_with_parameters_and_aliases_case(aliases: &'static [&'static str])
 
 fn signed_doc_with_content_encoding_case(upper: bool) -> TestCase {
     let uuid_v7 = UuidV7::new();
-    let uuid_v4 = UuidV4::new();
-
+    let doc_type = DocType::from(UuidV4::new());
     let name = if upper {
         "Content-Encoding"
     } else {
         "content-encoding"
     };
-
     TestCase {
         name: format!("content_encoding field, allow upper and lower case key value: '{name}'"),
         bytes_gen: Box::new({
@@ -339,9 +325,7 @@ fn signed_doc_with_content_encoding_case(upper: bool) -> TestCase {
                     let mut p_headers = Encoder::new(Vec::new());
                     p_headers.map(5)?;
                     p_headers.u8(3)?.encode(ContentType::Json)?;
-                    p_headers
-                        .str("type")?
-                        .encode_with(uuid_v4, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                    p_headers.str("type")?.encode(&doc_type)?;
                     p_headers
                         .str("id")?
                         .encode_with(uuid_v7, &mut catalyst_types::uuid::CborContext::Tagged)?;
@@ -380,8 +364,7 @@ fn signed_doc_with_content_encoding_case(upper: bool) -> TestCase {
 
 fn signed_doc_with_random_kid_case() -> TestCase {
     let uuid_v7 = UuidV7::new();
-    let uuid_v4 = UuidV4::new();
-
+    let doc_type = DocType::from(UuidV4::new());
     TestCase {
         name: "Invalid signature kid field format (random bytes)".to_string(),
         bytes_gen: Box::new({
@@ -395,9 +378,7 @@ fn signed_doc_with_random_kid_case() -> TestCase {
                     let mut p_headers = Encoder::new(Vec::new());
                     p_headers.map(5)?;
                     p_headers.u8(3)?.encode(ContentType::Json)?;
-                    p_headers
-                        .str("type")?
-                        .encode_with(uuid_v4, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                    p_headers.str("type")?.encode(&doc_type)?;
                     p_headers
                         .str("id")?
                         .encode_with(uuid_v7, &mut catalyst_types::uuid::CborContext::Tagged)?;
@@ -442,8 +423,7 @@ fn signed_doc_with_random_kid_case() -> TestCase {
 
 fn signed_doc_with_wrong_cose_tag_case() -> TestCase {
     let uuid_v7 = UuidV7::new();
-    let uuid_v4 = UuidV4::new();
-
+    let doc_type = DocType::from(UuidV4::new());
     TestCase {
         name: "Catalyst Signed Doc with wrong COSE sign tag value (not `98`)".to_string(),
         bytes_gen: Box::new({
@@ -457,9 +437,7 @@ fn signed_doc_with_wrong_cose_tag_case() -> TestCase {
                     let mut p_headers = Encoder::new(Vec::new());
                     p_headers.map(5)?;
                     p_headers.u8(3)?.encode(ContentType::Json)?;
-                    p_headers
-                        .str("type")?
-                        .encode_with(uuid_v4, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                    p_headers.str("type")?.encode(&doc_type)?;
                     p_headers
                         .str("id")?
                         .encode_with(uuid_v7, &mut catalyst_types::uuid::CborContext::Tagged)?;
@@ -501,11 +479,11 @@ fn decoding_empty_bytes_case() -> TestCase {
 
 fn signed_doc_with_minimal_metadata_fields_case() -> TestCase {
     let uuid_v7 = UuidV7::new();
-    let uuid_v4 = UuidV4::new();
-
+    let doc_type = DocType::from(UuidV4::new());
     TestCase {
         name: "Catalyst Signed Doc with minimally defined metadata fields, signed (one signature), CBOR tagged.".to_string(),
         bytes_gen: Box::new({
+            let doc_type = doc_type.clone();
             move || {
                 let (_, _, kid) = create_dummy_key_pair(RoleId::Role0)?;
 
@@ -520,7 +498,7 @@ fn signed_doc_with_minimal_metadata_fields_case() -> TestCase {
                     p_headers.u8(3)?.encode(ContentType::Json)?;
                     p_headers
                         .str("type")?
-                        .encode_with(uuid_v4, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                        .encode(&doc_type)?;
                     p_headers
                         .str("id")?
                         .encode_with(uuid_v7, &mut catalyst_types::uuid::CborContext::Tagged)?;
@@ -551,7 +529,7 @@ fn signed_doc_with_minimal_metadata_fields_case() -> TestCase {
         valid_doc: true,
         post_checks: Some(Box::new({
             move |doc| {
-                anyhow::ensure!(doc.doc_type()? == &DocType::from(uuid_v4));
+                anyhow::ensure!(doc.doc_type()? == &doc_type);
                 anyhow::ensure!(doc.doc_id()? == uuid_v7);
                 anyhow::ensure!(doc.doc_ver()? == uuid_v7);
                 anyhow::ensure!(doc.doc_content_type()? == ContentType::Json);
@@ -567,17 +545,17 @@ fn signed_doc_with_minimal_metadata_fields_case() -> TestCase {
 
 fn signed_doc_with_complete_metadata_fields_case() -> TestCase {
     let uuid_v7 = UuidV7::new();
-    let uuid_v4 = UuidV4::new();
+    let doc_type = DocType::from(UuidV4::new());
     let doc_ref = DocumentRefs::from(vec![DocumentRef::new(
         UuidV7::new(),
         UuidV7::new(),
         DocLocator::default(),
     )]);
     let doc_ref_cloned = doc_ref.clone();
-
     TestCase {
         name: "Catalyst Signed Doc with all metadata fields defined, signed (one signature), CBOR tagged.".to_string(),
         bytes_gen: Box::new({
+            let doc_type = doc_type.clone();
             move || {
                 let (_, _, kid) = create_dummy_key_pair(RoleId::Role0)?;
 
@@ -589,7 +567,7 @@ fn signed_doc_with_complete_metadata_fields_case() -> TestCase {
 
                 p_headers.map(9)?;
                 p_headers.u8(3)?.encode(ContentType::Json)?;
-                p_headers.str("type")?.encode_with(uuid_v4, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                p_headers.str("type")?.encode(&doc_type)?;
                 p_headers.str("id")?.encode_with(uuid_v7, &mut catalyst_types::uuid::CborContext::Tagged)?;
                 p_headers.str("ver")?.encode_with(uuid_v7, &mut catalyst_types::uuid::CborContext::Tagged)?;
                 p_headers
@@ -635,7 +613,7 @@ fn signed_doc_with_complete_metadata_fields_case() -> TestCase {
         post_checks: Some(Box::new({
             move |doc| {
                 let refs = doc_ref_cloned.clone();
-                anyhow::ensure!(doc.doc_type()? == &DocType::from(uuid_v4));
+                anyhow::ensure!(doc.doc_type()? == &doc_type);
                 anyhow::ensure!(doc.doc_id()? == uuid_v7);
                 anyhow::ensure!(doc.doc_ver()? == uuid_v7);
                 anyhow::ensure!(doc.doc_meta().doc_ref() == Some(&refs));
@@ -652,11 +630,12 @@ fn signed_doc_with_complete_metadata_fields_case() -> TestCase {
 
 fn minimally_valid_tagged_signed_doc() -> TestCase {
     let uuid_v7 = UuidV7::new();
-    let uuid_v4 = UuidV4::new();
+    let doc_type = DocType::from(UuidV4::new());
     TestCase {
         name: "Catalyst Signed Doc with minimally defined metadata fields, unsigned, CBOR tagged."
             .to_string(),
         bytes_gen: Box::new({
+            let doc_type = doc_type.clone();
             move || {
                 let mut e = Encoder::new(Vec::new());
                 e.tag(Tag::new(98))?;
@@ -666,9 +645,7 @@ fn minimally_valid_tagged_signed_doc() -> TestCase {
 
                 p_headers.map(4)?;
                 p_headers.u8(3)?.encode(ContentType::Json)?;
-                p_headers
-                    .str("type")?
-                    .encode_with(uuid_v4, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                p_headers.str("type")?.encode(&doc_type)?;
                 p_headers
                     .str("id")?
                     .encode_with(uuid_v7, &mut catalyst_types::uuid::CborContext::Tagged)?;
@@ -691,7 +668,7 @@ fn minimally_valid_tagged_signed_doc() -> TestCase {
         valid_doc: true,
         post_checks: Some(Box::new({
             move |doc| {
-                anyhow::ensure!(doc.doc_type()? == &DocType::from(uuid_v4));
+                anyhow::ensure!(doc.doc_type()? == &doc_type);
                 anyhow::ensure!(doc.doc_id()? == uuid_v7);
                 anyhow::ensure!(doc.doc_ver()? == uuid_v7);
                 anyhow::ensure!(doc.doc_content_type()? == ContentType::Json);
@@ -710,11 +687,12 @@ fn minimally_valid_tagged_signed_doc() -> TestCase {
 
 fn minimally_valid_untagged_signed_doc() -> TestCase {
     let uuid_v7 = UuidV7::new();
-    let uuid_v4 = UuidV4::new();
+    let doc_type = DocType::from(UuidV4::new());
     TestCase {
         name: "Catalyst Signed Doc with minimally defined metadata fields, unsigned, CBOR tagged."
             .to_string(),
         bytes_gen: Box::new({
+            let doc_type = doc_type.clone();
             move || {
                 let mut e = Encoder::new(Vec::new());
                 e.array(4)?;
@@ -723,9 +701,7 @@ fn minimally_valid_untagged_signed_doc() -> TestCase {
 
                 p_headers.map(4)?;
                 p_headers.u8(3)?.encode(ContentType::Json)?;
-                p_headers
-                    .str("type")?
-                    .encode_with(uuid_v4, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                p_headers.str("type")?.encode(&doc_type)?;
                 p_headers
                     .str("id")?
                     .encode_with(uuid_v7, &mut catalyst_types::uuid::CborContext::Tagged)?;
@@ -748,7 +724,7 @@ fn minimally_valid_untagged_signed_doc() -> TestCase {
         valid_doc: true,
         post_checks: Some(Box::new({
             move |doc| {
-                anyhow::ensure!(doc.doc_type()? == &DocType::from(uuid_v4));
+                anyhow::ensure!(doc.doc_type()? == &doc_type);
                 anyhow::ensure!(doc.doc_id()? == uuid_v7);
                 anyhow::ensure!(doc.doc_ver()? == uuid_v7);
                 anyhow::ensure!(doc.doc_content_type()? == ContentType::Json);
@@ -767,7 +743,7 @@ fn minimally_valid_untagged_signed_doc() -> TestCase {
 
 fn signed_doc_valid_null_as_no_content() -> TestCase {
     let uuid_v7 = UuidV7::new();
-    let uuid_v4 = UuidV4::new();
+    let doc_type = DocType::from(UuidV4::new());
     TestCase {
         name: "Catalyst Signed Doc with 'content' defined as Null.".to_string(),
         bytes_gen: Box::new({
@@ -780,10 +756,7 @@ fn signed_doc_valid_null_as_no_content() -> TestCase {
 
                 p_headers.map(4)?;
                 p_headers.u8(3)?.encode(ContentType::Json)?;
-                p_headers
-                    .str("type")?
-                    .array(1)?
-                    .encode_with(uuid_v4, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                p_headers.str("type")?.encode(&doc_type)?;
                 p_headers
                     .str("id")?
                     .encode_with(uuid_v7, &mut catalyst_types::uuid::CborContext::Tagged)?;
@@ -817,7 +790,7 @@ fn signed_doc_valid_null_as_no_content() -> TestCase {
 
 fn signed_doc_valid_empty_bstr_as_no_content() -> TestCase {
     let uuid_v7 = UuidV7::new();
-    let uuid_v4 = UuidV4::new();
+    let doc_type = DocType::from(UuidV4::new());
     TestCase {
         name: "Catalyst Signed Doc with 'content' defined as empty bstr.".to_string(),
         bytes_gen: Box::new({
@@ -830,10 +803,7 @@ fn signed_doc_valid_empty_bstr_as_no_content() -> TestCase {
 
                 p_headers.map(4)?;
                 p_headers.u8(3)?.encode(ContentType::Json)?;
-                p_headers
-                    .str("type")?
-                    .array(1)?
-                    .encode_with(uuid_v4, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                p_headers.str("type")?.encode(&doc_type)?;
                 p_headers
                     .str("id")?
                     .encode_with(uuid_v7, &mut catalyst_types::uuid::CborContext::Tagged)?;
@@ -865,7 +835,7 @@ fn signed_doc_valid_empty_bstr_as_no_content() -> TestCase {
 
 fn signed_doc_with_non_empty_unprotected_headers() -> TestCase {
     let uuid_v7 = UuidV7::new();
-    let uuid_v4 = UuidV4::new();
+    let doc_type = DocType::from(UuidV4::new());
     TestCase {
         name: "Catalyst Signed Doc with non empty unprotected headers".to_string(),
         bytes_gen: Box::new({
@@ -878,10 +848,7 @@ fn signed_doc_with_non_empty_unprotected_headers() -> TestCase {
 
                 p_headers.map(4)?;
                 p_headers.u8(3)?.encode(ContentType::Json)?;
-                p_headers
-                    .str("type")?
-                    .array(1)?
-                    .encode_with(uuid_v4, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                p_headers.str("type")?.encode(&doc_type)?;
                 p_headers
                     .str("id")?
                     .encode_with(uuid_v7, &mut catalyst_types::uuid::CborContext::Tagged)?;
@@ -910,7 +877,7 @@ fn signed_doc_with_non_empty_unprotected_headers() -> TestCase {
 
 fn signed_doc_with_signatures_non_empty_unprotected_headers() -> TestCase {
     let uuid_v7 = UuidV7::new();
-    let uuid_v4 = UuidV4::new();
+    let doc_type = DocType::from(UuidV4::new());
     TestCase {
         name: "Catalyst Signed Doc with signatures non empty unprotected headers".to_string(),
         bytes_gen: Box::new({
@@ -925,10 +892,7 @@ fn signed_doc_with_signatures_non_empty_unprotected_headers() -> TestCase {
 
                 p_headers.map(4)?;
                 p_headers.u8(3)?.encode(ContentType::Json)?;
-                p_headers
-                    .str("type")?
-                    .array(1)?
-                    .encode_with(uuid_v4, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                p_headers.str("type")?.encode(&doc_type)?;
                 p_headers
                     .str("id")?
                     .encode_with(uuid_v7, &mut catalyst_types::uuid::CborContext::Tagged)?;
@@ -966,8 +930,7 @@ fn signed_doc_with_signatures_non_empty_unprotected_headers() -> TestCase {
 
 fn signed_doc_with_strict_deterministic_decoding_wrong_order() -> TestCase {
     let uuid_v7 = UuidV7::new();
-    let uuid_v4 = UuidV4::new();
-
+    let doc_type = DocType::from(UuidV4::new());
     TestCase {
         name: "Catalyst Signed Doc with minimally defined metadata fields, with enabled strictly decoded rules, metadata field in the wrong order".to_string(),
         bytes_gen: Box::new({
@@ -984,8 +947,8 @@ fn signed_doc_with_strict_deterministic_decoding_wrong_order() -> TestCase {
                     p_headers.map(4)?;
                     p_headers.u8(3)?.encode(ContentType::Json)?;
                     p_headers
-                        .str("type")?.array(1)?
-                        .encode_with(uuid_v4, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                        .str("type")?
+                        .encode(&doc_type)?;
                     p_headers
                         .str("id")?
                         .encode_with(uuid_v7, &mut catalyst_types::uuid::CborContext::Tagged)?;
@@ -1020,11 +983,11 @@ fn signed_doc_with_strict_deterministic_decoding_wrong_order() -> TestCase {
 
 fn signed_doc_with_non_strict_deterministic_decoding_wrong_order() -> TestCase {
     let uuid_v7 = UuidV7::new();
-    let uuid_v4 = UuidV4::new();
-
+    let doc_type = DocType::from(UuidV4::new());
     TestCase {
         name: "Catalyst Signed Doc with minimally defined metadata fields, with enabled non strictly (warn) decoded rules, metadata field in the wrong order".to_string(),
         bytes_gen: Box::new({
+            let doc_type = doc_type.clone();
             move || {
                 let (_, _, kid) = create_dummy_key_pair(RoleId::Role0)?;
 
@@ -1038,8 +1001,8 @@ fn signed_doc_with_non_strict_deterministic_decoding_wrong_order() -> TestCase {
                     p_headers.map(4)?;
                     p_headers.u8(3)?.encode(ContentType::Json)?;
                     p_headers
-                        .str("type")?.array(1)?
-                        .encode_with(uuid_v4, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                        .str("type")?
+                        .encode(&doc_type)?;
                     p_headers
                         .str("id")?
                         .encode_with(uuid_v7, &mut catalyst_types::uuid::CborContext::Tagged)?;
@@ -1070,7 +1033,7 @@ fn signed_doc_with_non_strict_deterministic_decoding_wrong_order() -> TestCase {
         valid_doc: true,
         post_checks: Some(Box::new({
             move |doc| {
-                anyhow::ensure!(doc.doc_type()? == &DocType::from(uuid_v4));
+                anyhow::ensure!(doc.doc_type()? == &doc_type);
                 anyhow::ensure!(doc.doc_id()? == uuid_v7);
                 anyhow::ensure!(doc.doc_ver()? == uuid_v7);
                 anyhow::ensure!(doc.doc_content_type()? == ContentType::Json);
@@ -1086,12 +1049,12 @@ fn signed_doc_with_non_strict_deterministic_decoding_wrong_order() -> TestCase {
 
 fn signed_doc_with_non_supported_metadata_invalid() -> TestCase {
     let uuid_v7 = UuidV7::new();
-    let uuid_v4 = UuidV4::new();
-
+    let doc_type = DocType::from(UuidV4::new());
     TestCase {
         name: "Catalyst Signed Doc with non-supported defined metadata fields is invalid."
             .to_string(),
         bytes_gen: Box::new({
+            let doc_type = doc_type.clone();
             move || {
                 let mut e = Encoder::new(Vec::new());
                 e.tag(Tag::new(98))?;
@@ -1102,9 +1065,7 @@ fn signed_doc_with_non_supported_metadata_invalid() -> TestCase {
 
                     p_headers.map(5)?;
                     p_headers.u8(3)?.encode(ContentType::Json)?;
-                    p_headers
-                        .str("type")?
-                        .encode_with(uuid_v4, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                    p_headers.str("type")?.encode(&doc_type)?;
                     p_headers
                         .str("id")?
                         .encode_with(uuid_v7, &mut catalyst_types::uuid::CborContext::Tagged)?;
@@ -1131,7 +1092,7 @@ fn signed_doc_with_non_supported_metadata_invalid() -> TestCase {
         valid_doc: false,
         post_checks: Some(Box::new({
             move |doc| {
-                anyhow::ensure!(doc.doc_type()? == &DocType::from(uuid_v4));
+                anyhow::ensure!(doc.doc_type()? == &doc_type);
                 anyhow::ensure!(doc.doc_id()? == uuid_v7);
                 anyhow::ensure!(doc.doc_ver()? == uuid_v7);
                 anyhow::ensure!(doc.doc_content_type()? == ContentType::Json);
@@ -1147,12 +1108,12 @@ fn signed_doc_with_non_supported_metadata_invalid() -> TestCase {
 
 fn signed_doc_with_kid_in_id_form_invalid() -> TestCase {
     let uuid_v7 = UuidV7::new();
-    let uuid_v4 = UuidV4::new();
-
+    let doc_type = DocType::from(UuidV4::new());
     TestCase {
         name: "Catalyst Signed Doc with Signature KID in Id form, instead of URI form is invalid."
             .to_string(),
         bytes_gen: Box::new({
+            let doc_type = doc_type.clone();
             move || {
                 let (_, _, kid) = create_dummy_key_pair(RoleId::Role0)?;
 
@@ -1165,9 +1126,7 @@ fn signed_doc_with_kid_in_id_form_invalid() -> TestCase {
 
                     p_headers.map(4)?;
                     p_headers.u8(3)?.encode(ContentType::Json)?;
-                    p_headers
-                        .str("type")?
-                        .encode_with(uuid_v4, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                    p_headers.str("type")?.encode(&doc_type)?;
                     p_headers
                         .str("id")?
                         .encode_with(uuid_v7, &mut catalyst_types::uuid::CborContext::Tagged)?;
@@ -1201,7 +1160,7 @@ fn signed_doc_with_kid_in_id_form_invalid() -> TestCase {
         valid_doc: false,
         post_checks: Some(Box::new({
             move |doc| {
-                anyhow::ensure!(doc.doc_type()? == &DocType::from(uuid_v4));
+                anyhow::ensure!(doc.doc_type()? == &doc_type);
                 anyhow::ensure!(doc.doc_id()? == uuid_v7);
                 anyhow::ensure!(doc.doc_ver()? == uuid_v7);
                 anyhow::ensure!(doc.doc_content_type()? == ContentType::Json);
@@ -1217,8 +1176,7 @@ fn signed_doc_with_kid_in_id_form_invalid() -> TestCase {
 
 fn signed_doc_with_non_supported_protected_signature_header_invalid() -> TestCase {
     let uuid_v7 = UuidV7::new();
-    let uuid_v4 = UuidV4::new();
-
+    let doc_type = DocType::from(UuidV4::new());
     TestCase {
         name: "Catalyst Signed Doc with unsupported protected Signature header is invalid."
             .to_string(),
@@ -1235,9 +1193,7 @@ fn signed_doc_with_non_supported_protected_signature_header_invalid() -> TestCas
 
                     p_headers.map(4)?;
                     p_headers.u8(3)?.encode(ContentType::Json)?;
-                    p_headers
-                        .str("type")?
-                        .encode_with(uuid_v4, &mut catalyst_types::uuid::CborContext::Tagged)?;
+                    p_headers.str("type")?.encode(&doc_type)?;
                     p_headers
                         .str("id")?
                         .encode_with(uuid_v7, &mut catalyst_types::uuid::CborContext::Tagged)?;

--- a/rust/signed_doc/tests/proposal.rs
+++ b/rust/signed_doc/tests/proposal.rs
@@ -5,7 +5,6 @@
 use std::sync::LazyLock;
 
 use catalyst_signed_doc::{
-    doc_types::deprecated,
     providers::tests::{TestCatalystSignedDocumentProvider, TestVerifyingKeyProvider},
     *,
 };
@@ -38,7 +37,7 @@ static PROPOSAL_TEMPLATE_DOC: LazyLock<CatalystSignedDocument> = LazyLock::new(|
         .with_json_metadata(serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": doc_types::PROPOSAL_TEMPLATE.clone(),
+            "type": doc_types::PROPOSAL_FORM_TEMPLATE.clone(),
             "id": UuidV7::new(),
             "ver": UuidV7::new(),
             "parameters": {
@@ -152,45 +151,12 @@ async fn test_invalid_proposal_doc_wrong_role() {
 }
 
 #[tokio::test]
-async fn test_valid_proposal_doc_old_type() {
-    let doc = Builder::new()
-        .with_json_metadata(serde_json::json!({
-            "content-type": ContentType::Json.to_string(),
-            "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": deprecated::PROPOSAL_DOCUMENT_UUID_TYPE,
-            "id": UuidV7::new(),
-            "ver": UuidV7::new(),
-            "template": {
-                "id": PROPOSAL_TEMPLATE_DOC.doc_id().unwrap(),
-                "ver": PROPOSAL_TEMPLATE_DOC.doc_ver().unwrap(),
-            },
-            "parameters": {
-                "id": DUMMY_BRAND_DOC.doc_id().unwrap(),
-                "ver": DUMMY_BRAND_DOC.doc_ver().unwrap(),
-            }
-        }))
-        .unwrap()
-        .with_json_content(&serde_json::json!({}))
-        .unwrap()
-        .build()
-        .unwrap();
-
-    let mut provider = TestCatalystSignedDocumentProvider::default();
-
-    provider.add_document(None, &PROPOSAL_TEMPLATE_DOC).unwrap();
-    provider.add_document(None, &DUMMY_BRAND_DOC).unwrap();
-
-    let is_valid = validator::validate(&doc, &provider).await.unwrap();
-    assert!(is_valid);
-}
-
-#[tokio::test]
 async fn test_invalid_proposal_doc_missing_template() {
     let doc = Builder::new()
         .with_json_metadata(serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": deprecated::PROPOSAL_DOCUMENT_UUID_TYPE,
+            "type": doc_types::PROPOSAL.clone(),
             "id": UuidV7::new(),
             "ver": UuidV7::new(),
             // "template": {
@@ -223,7 +189,7 @@ async fn test_invalid_proposal_doc_missing_parameters() {
         .with_json_metadata(serde_json::json!({
             "content-type": ContentType::Json.to_string(),
             "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": deprecated::PROPOSAL_DOCUMENT_UUID_TYPE,
+            "type": doc_types::PROPOSAL.clone(),
             "id": UuidV7::new(),
             "ver": UuidV7::new(),
             "template": {

--- a/rust/signed_doc/tests/submission.rs
+++ b/rust/signed_doc/tests/submission.rs
@@ -5,7 +5,6 @@
 use std::sync::LazyLock;
 
 use catalyst_signed_doc::{
-    doc_types::deprecated,
     providers::tests::{TestCatalystSignedDocumentProvider, TestVerifyingKeyProvider},
     *,
 };
@@ -144,41 +143,6 @@ async fn test_invalid_submission_action_wrong_role() {
 
     let is_valid = validator::validate(&doc, &provider).await.unwrap();
     assert!(!is_valid);
-}
-
-#[tokio::test]
-async fn test_valid_submission_action_old_type() {
-    let doc = Builder::new()
-        .with_json_metadata(serde_json::json!({
-            "content-type": ContentType::Json.to_string(),
-            "content-encoding": ContentEncoding::Brotli.to_string(),
-            "type": deprecated::PROPOSAL_ACTION_DOCUMENT_UUID_TYPE,
-            "id": UuidV7::new(),
-            "ver": UuidV7::new(),
-            "ref": {
-                "id": DUMMY_PROPOSAL_DOC.doc_id().unwrap(),
-                "ver": DUMMY_PROPOSAL_DOC.doc_ver().unwrap(),
-            },
-            "parameters": {
-                "id": DUMMY_BRAND_DOC.doc_id().unwrap(),
-                "ver": DUMMY_BRAND_DOC.doc_ver().unwrap(),
-            }
-        }))
-        .unwrap()
-        .with_json_content(&serde_json::json!({
-            "action": "final"
-        }))
-        .unwrap()
-        .build()
-        .unwrap();
-
-    let mut provider = TestCatalystSignedDocumentProvider::default();
-
-    provider.add_document(None, &DUMMY_PROPOSAL_DOC).unwrap();
-    provider.add_document(None, &DUMMY_BRAND_DOC).unwrap();
-
-    let is_valid = validator::validate(&doc, &provider).await.unwrap();
-    assert!(is_valid, "{:?}", doc.problem_report());
 }
 
 #[tokio::test]


### PR DESCRIPTION
# Description

Revert back to the original definition of the `type` metadata field, to be a single `UUIDv4` instead of of array of uuids

## Related Issue(s)

Related to https://github.com/input-output-hk/catalyst-libs/issues/330