### PR TITLE
feat(general): Get rid from the `path` dependencies

### DIFF
--- a/rust/cardano-blockchain-types/Cargo.toml
+++ b/rust/cardano-blockchain-types/Cargo.toml
@@ -20,8 +20,8 @@ workspace = true
 [dependencies]
 pallas = { version = "0.33.0" }
 # pallas-hardano = { version = "0.33.0" }
-cbork-utils = { version = "0.0.1", path = "../cbork-utils" }
-catalyst-types = { version = "0.0.3", path = "../catalyst-types" }
+cbork-utils = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250724-00" }
+catalyst-types = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250724-00" }
 
 ouroboros = "0.18.4"
 tracing = "0.1.41"

--- a/rust/cardano-chain-follower/Cargo.toml
+++ b/rust/cardano-chain-follower/Cargo.toml
@@ -19,8 +19,8 @@ mithril-client = { version = "0.12.2", default-features = false, features = [
     "full",
     "num-integer-backend",
 ] }
-cardano-blockchain-types = { version = "0.0.4", path = "../cardano-blockchain-types" }
-catalyst-types = { version = "0.0.3", path = "../catalyst-types" }
+cardano-blockchain-types = { version = "0.0.4", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250724-00" }
+catalyst-types = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250724-00" }
 
 
 thiserror = "1.0.69"
@@ -64,7 +64,7 @@ test-log = { version = "0.2.16", default-features = false, features = [
     "trace",
 ] }
 clap = "4.5.23"
-rbac-registration = { version = "0.0.5", path = "../rbac-registration" }
+rbac-registration = { version = "0.0.5", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250724-00" }
 
 # Note, these features are for support of features exposed by dependencies.
 [features]

--- a/rust/rbac-registration/Cargo.toml
+++ b/rust/rbac-registration/Cargo.toml
@@ -32,8 +32,8 @@ uuid = "1.11.0"
 oid-registry = "0.7.1"
 thiserror = "2.0.11"
 
-c509-certificate = { version = "0.0.3", path = "../c509-certificate" }
+c509-certificate = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250724-00" }
 pallas = { version = "0.33.0" }
-cbork-utils = { version = "0.0.1", path = "../cbork-utils" }
-cardano-blockchain-types = { version = "0.0.4", path = "../cardano-blockchain-types" }
-catalyst-types = { version = "0.0.3", path = "../catalyst-types" }
+cbork-utils = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250724-00" }
+cardano-blockchain-types = { version = "0.0.4", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250724-00" }
+catalyst-types = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250724-00" }

--- a/rust/signed_doc/Cargo.toml
+++ b/rust/signed_doc/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-catalyst-types = { version = "0.0.3", path = "../catalyst-types" }
+catalyst-types = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250724-00" }
 
 anyhow = "1.0.95"
 serde = { version = "1.0.217", features = ["derive"] }

--- a/rust/vote-tx-v1/Cargo.toml
+++ b/rust/vote-tx-v1/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-catalyst-voting = { version = "0.0.1", path = "../catalyst-voting" }
+catalyst-voting = { version = "0.0.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250724-00" }
 anyhow = "1.0.89"
 
 [dev-dependencies]


### PR DESCRIPTION
# Description

- Get rid of the using Rust path dependencies in all our crates

## Related Issue(s)

Closes https://github.com/input-output-hk/catalyst-libs/issues/404
