### PR TITLE
fix(rust/hermes-ipfs): Failing latest `yamux-0.13.6` dep

### DIFF
--- a/rust/hermes-ipfs/Cargo.toml
+++ b/rust/hermes-ipfs/Cargo.toml
@@ -1,3 +1,5 @@
+# cspell: words yamux
+
 [package]
 name = "hermes-ipfs"
 version = "0.0.3"


### PR DESCRIPTION
# Description

- A new release of transitive dependency was release `yamux-0.13.6` which is not compatible with out rustc version `1.85`. It uses some freashly stabilised `is_multiple_of` function.