### PR TITLE
feat(cardano-chain-follower): Test mode for chain follower to dump transactions.

### DIFF
--- a/rust/Justfile
+++ b/rust/Justfile
@@ -36,6 +36,9 @@ pre-push: sync-cfg code-format code-lint
     earthly +check
     earthly +build
 
+build-follow_chains: code-format code-lint
+    cargo build --release --package cardano-chain-follower --example follow_chains --features mimalloc
+
 # Run long running developer test for mithril downloading.
 run-mithril-download-example-preprod: code-format code-lint
     cargo build -r --package cardano-chain-follower --example follow_chains --features mimalloc
@@ -68,3 +71,16 @@ debug-heap-mithril-download-example: code-format code-lint
     cargo build --package cardano-chain-follower --example follow_chains
     RUST_LOG="error,follow_chains=debug,cardano_chain_follower=debug,mithril-client=debug" \
     heaptrack ./target/debug/examples/follow_chains --preprod
+
+# Dump a set of transactions to aid with development and debugging.
+# Example: `dump-txn-preprod 91972303 7558ca3658d6c5`
+dump-txn-preprod START_SLOT TXN_HASH:
+    echo Starting at {{START_SLOT}} Look for Transaction Hash {{TXN_HASH}}
+    # RUST_LOG="error,follow_chains=debug,cardano_chain_follower=debug,mithril-client=debug" \#
+    ./target/release/examples/follow_chains --inhibit-stats --preprod --mithril-sync-workers 64 --mithril-sync-chunk-size 16 --mithril-sync-queue-ahead=6 --start-at-slot {{START_SLOT}} --dump-transaction {{TXN_HASH}}
+
+# Dump a set of transactions to aid with development and debugging.
+dump-txn-mainnet START_SLOT TXN_HASH:
+    echo Starting at {{START_SLOT}} Look for Transaction Hash {{TXN_HASH}}
+    # RUST_LOG="error,follow_chains=debug,cardano_chain_follower=debug,mithril-client=debug" \#
+    ./target/release/examples/follow_chains --inhibit-stats --mainnet --mithril-sync-workers 64 --mithril-sync-chunk-size 16 --mithril-sync-queue-ahead=6 --start-at-slot {{START_SLOT}} --dump-transaction {{TXN_HASH}}

--- a/rust/cardano-chain-follower/Cargo.toml
+++ b/rust/cardano-chain-follower/Cargo.toml
@@ -65,6 +65,7 @@ test-log = { version = "0.2.16", default-features = false, features = [
 ] }
 clap = "4.5.23"
 rbac-registration = { version = "0.0.5", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250724-01" }
+minicbor = { version = "2.0.0", features = ["alloc","half"]}
 
 # Note, these features are for support of features exposed by dependencies.
 [features]


### PR DESCRIPTION
Adds a mode to the chain follower example, to dump requested transactions, and start searching from known slot.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
