### PR TITLE
fix(rust/rbac-registration): Fix some RBAC logging

### DIFF
--- a/rust/rbac-registration/src/cardano/cip509/cip509.rs
+++ b/rust/rbac-registration/src/cardano/cip509/cip509.rs
@@ -454,7 +454,7 @@ fn payment_history(
     report: &ProblemReport,
 ) -> HashMap<ShelleyAddress, Vec<Payment>> {
     let hash = MultiEraTx::Conway(Box::new(Cow::Borrowed(txn))).hash();
-    let context = format!("Populating payment history for Cip509, transaction hash = {hash:?}");
+    let context = format!("Populating payment history for Cip509, transaction hash = {hash}");
 
     let mut result: HashMap<_, _> = track_payment_addresses
         .iter()

--- a/rust/rbac-registration/src/cardano/cip509/cip509.rs
+++ b/rust/rbac-registration/src/cardano/cip509/cip509.rs
@@ -454,7 +454,7 @@ fn payment_history(
     report: &ProblemReport,
 ) -> HashMap<ShelleyAddress, Vec<Payment>> {
     let hash = MultiEraTx::Conway(Box::new(Cow::Borrowed(txn))).hash();
-    let context = format!("Populating payment history for Cip509, transaction hash = {hash}");
+    let context = format!("Populating payment history for Cip509, transaction = {hash}");
 
     let mut result: HashMap<_, _> = track_payment_addresses
         .iter()

--- a/rust/rbac-registration/src/cardano/cip509/types/role_data.rs
+++ b/rust/rbac-registration/src/cardano/cip509/types/role_data.rs
@@ -155,7 +155,7 @@ fn validate_payment_output(
     if let Err(e) = compare_key_hash(&[key], witness, 0.into()) {
         report.other(
             &format!(
-                "Unable to find payment output key ({key:?}) in the transaction witness set: {e:?}"
+                "Unable to find payment output key ({key}) in the transaction witness set: {e:?}"
             ),
             context,
         );

--- a/rust/rbac-registration/src/cardano/cip509/types/role_data.rs
+++ b/rust/rbac-registration/src/cardano/cip509/types/role_data.rs
@@ -135,7 +135,7 @@ fn convert_payment_key(
         Ok(a) => a,
         Err(e) => {
             report.other(
-                &format!("Invalid address in payment key index ({index}): {e:?}"),
+                &format!("Invalid address in payment key index ({index}): {e}"),
                 context,
             );
             return None;
@@ -145,9 +145,16 @@ fn convert_payment_key(
 
     match address {
         Address::Shelley(a) => Some(a),
-        a => {
+        Address::Byron(_) => {
             report.other(
-                &format!("Unsupported address type ({a:?}) in payment key index ({index})"),
+                &format!("Unsupported Byron address type in payment key index ({index})"),
+                context,
+            );
+            None
+        },
+        Address::Stake(_) => {
+            report.other(
+                &format!("Unsupported Stake address type in payment key index ({index})"),
                 context,
             );
             None

--- a/rust/rbac-registration/src/cardano/cip509/types/role_data.rs
+++ b/rust/rbac-registration/src/cardano/cip509/types/role_data.rs
@@ -11,9 +11,7 @@ use pallas::ledger::{
 };
 
 use crate::cardano::cip509::{
-    rbac::role_data::CborRoleData,
-    utils::cip19::{compare_key_hash, extract_key_hash},
-    KeyLocalRef,
+    rbac::role_data::CborRoleData, utils::cip19::extract_key_hash, KeyLocalRef,
 };
 
 /// A role data.
@@ -152,10 +150,11 @@ fn validate_payment_output(
     // Set transaction index to 0 because the list of transaction is manually constructed
     // for TxWitness -> &[txn.clone()], so we can assume that the witness contains only
     // the witness within this transaction.
-    if let Err(e) = compare_key_hash(&[key], witness, 0.into()) {
+    if !witness.check_witness_in_tx(&key, 0.into()) {
+        // TODO: FIXME: Fix payment key format.
         report.other(
             &format!(
-                "Unable to find payment output key ({key}) in the transaction witness set: {e:?}"
+                "Payment Key FIXME (0x{key}) is not present in the transaction witness set, and can not be verified as owned and spendable."
             ),
             context,
         );

--- a/rust/rbac-registration/src/cardano/cip509/utils/cip19.rs
+++ b/rust/rbac-registration/src/cardano/cip509/utils/cip19.rs
@@ -1,28 +1,9 @@
 //! Utility functions for CIP-19 address.
 
-use anyhow::bail;
-use cardano_blockchain_types::{TxnIndex, TxnWitness, VKeyHash};
+use cardano_blockchain_types::VKeyHash;
 
 /// Extract the first 28 bytes from the given key
 /// Refer to <https://cips.cardano.org/cip/CIP-19> for more information.
 pub(crate) fn extract_key_hash(key: &[u8]) -> Option<VKeyHash> {
     key.get(1..29).and_then(|v| v.try_into().ok())
-}
-
-/// Compare the given public key bytes with the transaction witness set.
-pub(crate) fn compare_key_hash(
-    pk_addrs: &[VKeyHash], witness: &TxnWitness, txn_idx: TxnIndex,
-) -> anyhow::Result<()> {
-    if pk_addrs.is_empty() {
-        bail!("No public key addresses provided");
-    }
-
-    pk_addrs.iter().try_for_each(|pk_addr| {
-        // Key hash not found in the transaction witness set
-        if !witness.check_witness_in_tx(pk_addr, txn_idx) {
-            bail!("Public key hash not found in transaction witness set given {pk_addr}",);
-        }
-
-        Ok(())
-    })
 }

--- a/rust/rbac-registration/src/cardano/cip509/utils/cip19.rs
+++ b/rust/rbac-registration/src/cardano/cip509/utils/cip19.rs
@@ -20,10 +20,7 @@ pub(crate) fn compare_key_hash(
     pk_addrs.iter().try_for_each(|pk_addr| {
         // Key hash not found in the transaction witness set
         if !witness.check_witness_in_tx(pk_addr, txn_idx) {
-            bail!(
-                "Public key hash not found in transaction witness set given {:?}",
-                pk_addr
-            );
+            bail!("Public key hash not found in transaction witness set given {pk_addr}",);
         }
 
         Ok(())

--- a/rust/rbac-registration/src/cardano/cip509/validation.rs
+++ b/rust/rbac-registration/src/cardano/cip509/validation.rs
@@ -105,7 +105,7 @@ pub fn validate_aux(
     let hash = Blake2b256Hash::new(raw_aux_data);
     if hash != auxiliary_data_hash {
         report.other(
-            &format!("Incorrect transaction auxiliary data hash = '{hash:?}', expected = '{auxiliary_data_hash:?}'"),
+            &format!("Incorrect transaction auxiliary data hash = '{hash}', expected = '{auxiliary_data_hash}'"),
             context,
         );
     }

--- a/rust/rbac-registration/src/cardano/cip509/validation.rs
+++ b/rust/rbac-registration/src/cardano/cip509/validation.rs
@@ -103,7 +103,9 @@ pub fn validate_aux(
     let hash = Blake2b256Hash::new(raw_aux_data);
     if hash != auxiliary_data_hash {
         report.other(
-            &format!("Incorrect transaction auxiliary data hash = '{hash}', expected = '{auxiliary_data_hash}'"),
+            &format!("Incorrect transaction auxiliary data hash = '0x{hash}', expected = '0x{auxiliary_data_hash}'. \
+            This metadata does not belong with this transaction. \
+            Catalyst metadata may not be transcribed to any other transaction body, and is therefore invalid."),
             context,
         );
     }

--- a/rust/rbac-registration/src/cardano/cip509/validation.rs
+++ b/rust/rbac-registration/src/cardano/cip509/validation.rs
@@ -143,7 +143,7 @@ pub fn validate_stake_public_key(
     }
 
     for (hash, address) in pk_addrs {
-        if witness.check_witness_in_tx(&hash, 0.into()) {
+        if !witness.check_witness_in_tx(&hash, 0.into()) {
             report.other(
                 &format!(
                     "Payment Key '{address}' (0x{hash}) is not present in the transaction witness set, and can not be verified as owned and spendable."
@@ -558,7 +558,7 @@ mod tests {
         let report = registration.consume().unwrap_err();
         assert!(report.is_problematic());
         let report = format!("{report:?}");
-        assert!(report.contains("Public key hash not found in transaction witness set"));
+        assert!(report.contains("is not present in the transaction witness set, and can not be verified as owned and spendable"));
     }
 
     #[test]

--- a/rust/rbac-registration/src/registration/cardano/mod.rs
+++ b/rust/rbac-registration/src/registration/cardano/mod.rs
@@ -7,7 +7,7 @@ use std::{
     sync::Arc,
 };
 
-use anyhow::{bail, Context};
+use anyhow::{anyhow, bail, Context};
 use c509_certificate::c509::C509;
 use cardano_blockchain_types::{Point, StakeAddress, TransactionId, TxnIndex};
 use catalyst_types::{
@@ -344,9 +344,9 @@ impl RegistrationChainInner {
             context,
         )?;
 
-        let Ok((purpose, registration, payment_history)) = cip509.consume() else {
-            bail!("Unable to start a chain: invalid Cip509");
-        };
+        let (purpose, registration, payment_history) = cip509
+            .consume()
+            .map_err(|_| anyhow!("Unable to start a chain: invalid Cip509"))?;
 
         let purpose = vec![purpose];
         let certificate_uris = registration.certificate_uris.clone();
@@ -430,9 +430,9 @@ impl RegistrationChainInner {
         }
 
         let point_tx_idx = cip509.origin().clone();
-        let Ok((purpose, registration, payment_history)) = cip509.consume() else {
-            bail!("Unable to update a chain: invalid Cip509");
-        };
+        let (purpose, registration, payment_history) = cip509
+            .consume()
+            .map_err(|_| anyhow!("Unable to update a chain: invalid Cip509"))?;
 
         // Add purpose to the chain, if not already exist
         if !self.purpose.contains(&purpose) {

--- a/rust/rbac-registration/src/registration/cardano/mod.rs
+++ b/rust/rbac-registration/src/registration/cardano/mod.rs
@@ -46,6 +46,7 @@ impl RegistrationChain {
     /// # Errors
     ///
     /// Returns an error if data is invalid
+    #[must_use]
     pub fn new(cip509: Cip509) -> Option<Self> {
         let inner = RegistrationChainInner::new(cip509)?;
 
@@ -62,6 +63,7 @@ impl RegistrationChain {
     /// # Errors
     ///
     /// Returns an error if data is invalid
+    #[must_use]
     pub fn update(
         &self,
         cip509: Cip509,
@@ -300,6 +302,7 @@ impl RegistrationChainInner {
     /// # Errors
     ///
     /// Returns an error if data is invalid
+    #[must_use]
     fn new(cip509: Cip509) -> Option<Self> {
         let context = "Registration Chain new";
         // Should be chain root, return immediately if not
@@ -405,6 +408,7 @@ impl RegistrationChainInner {
     /// # Errors
     ///
     /// Returns an error if data is invalid
+    #[must_use]
     fn update(
         &self,
         cip509: Cip509,

--- a/rust/rbac-registration/src/registration/cardano/mod.rs
+++ b/rust/rbac-registration/src/registration/cardano/mod.rs
@@ -17,7 +17,6 @@ use catalyst_types::{
     uuid::UuidV4,
 };
 use ed25519_dalek::{Signature, VerifyingKey};
-use tracing::error;
 use update_rbac::{
     revocations_list, update_c509_certs, update_public_keys, update_role_data, update_x509_certs,
 };
@@ -345,13 +344,8 @@ impl RegistrationChainInner {
             context,
         )?;
 
-        let (purpose, registration, payment_history) = match cip509.consume() {
-            Ok(v) => v,
-            Err(e) => {
-                let error = format!("Invalid Cip509: {e:?}");
-                error!(error);
-                bail!(error);
-            },
+        let Ok((purpose, registration, payment_history)) = cip509.consume() else {
+            bail!("Unable to start a chain: invalid Cip509");
         };
 
         let purpose = vec![purpose];
@@ -436,13 +430,8 @@ impl RegistrationChainInner {
         }
 
         let point_tx_idx = cip509.origin().clone();
-        let (purpose, registration, payment_history) = match cip509.consume() {
-            Ok(v) => v,
-            Err(e) => {
-                let error = format!("Invalid Cip509: {e:?}");
-                error!(error);
-                bail!(error);
-            },
+        let Ok((purpose, registration, payment_history)) = cip509.consume() else {
+            bail!("Unable to update a chain: invalid Cip509");
         };
 
         // Add purpose to the chain, if not already exist


### PR DESCRIPTION
# Description

- Fix (some) logging (use `Display` instead of `Debug` for hashes).
- Remove verbose logging in `RegistrationChain::new` and `RegistrationChain::update` functions.