### PR TITLE
feat(rust/rbac-registration): Bump `rbac-registration` version to `0.0.7`

### DIFF
--- a/rust/rbac-registration/Cargo.toml
+++ b/rust/rbac-registration/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rbac-registration"
 description = "Role Based Access Control Registration"
 keywords = ["cardano", "catalyst", "rbac registration"]
-version = "0.0.6"
+version = "0.0.7"
 authors = [
     "Arissara Chotivichit <arissara.chotivichit@iohk.io>"
 ]


### PR DESCRIPTION
# Description

Bump `rbac-registration` version to `0.0.7`.