### PR TITLE
chore(rust/cardano-chain-follower): Bump `cardano-chain-follower` version

### DIFF
--- a/rust/cardano-chain-follower/Cargo.toml
+++ b/rust/cardano-chain-follower/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cardano-chain-follower"
-version = "0.0.11"
+version = "0.0.12"
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
# Description

Bumping a `cardano-chain-follower` crate version to make a new release for it