### PR TITLE
fix(rust): Fixing `build` for `arm` architectures

### DIFF
--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -57,9 +57,7 @@ build:
     FROM +builder-src
 
     LET ARCH=$(uname -m)
-    RUN echo $ARCH
     IF [ "$ARCH" != "aarch64" ] && [ "$ARCH" != "arm64" ]
-        RUN false
         DO rust-ci+EXECUTE \
             --cmd="/scripts/std_build.py" \
             --args1="--libs=c509-certificate --libs=cardano-blockchain-types --libs=cardano-chain-follower --libs=hermes-ipfs" \


### PR DESCRIPTION
# Description

It is an issue with `llvm-cov` https://github.com/rust-lang/rust/issues/141577, which reproduces for us on `arm` architectures