### PR TITLE
chore(rust/rbac-registration): `rbac-registration` with latest `cardano-blockchain-types`

### DIFF
--- a/rust/rbac-registration/Cargo.toml
+++ b/rust/rbac-registration/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rbac-registration"
 description = "Role Based Access Control Registration"
 keywords = ["cardano", "catalyst", "rbac registration"]
-version = "0.0.7"
+version = "0.0.8"
 authors = [
     "Arissara Chotivichit <arissara.chotivichit@iohk.io>"
 ]
@@ -33,7 +33,6 @@ oid-registry = "0.7.1"
 thiserror = "2.0.11"
 
 c509-certificate = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "c509-certificate-v0.0.3" }
-pallas = { version = "0.33.0" }
 cbork-utils = { version = "0.0.2", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "cbork-utils-v0.0.2" }
-cardano-blockchain-types = { version = "0.0.5", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "cardano-blockchain-types-v0.0.5" }
-catalyst-types = { version = "0.0.5", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "catalyst-types-v0.0.5" }
+cardano-blockchain-types = { version = "0.0.6", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "cardano-blockchain-types/v0.0.6" }
+catalyst-types = { version = "0.0.6", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "catalyst-types/v0.0.6" }

--- a/rust/rbac-registration/src/cardano/cip509/cip509.rs
+++ b/rust/rbac-registration/src/cardano/cip509/cip509.rs
@@ -9,12 +9,16 @@ use std::{
 
 use anyhow::{anyhow, Context};
 use cardano_blockchain_types::{
-    MetadatumLabel, MultiEraBlock, StakeAddress, TransactionId, TxnIndex,
+    hashes::{Blake2b256Hash, TransactionId, BLAKE_2B256_SIZE},
+    pallas_addresses::{Address, ShelleyAddress},
+    pallas_codec::utils::Nullable,
+    pallas_primitives::conway,
+    pallas_traverse::MultiEraTx,
+    MetadatumLabel, MultiEraBlock, StakeAddress, TxnIndex,
 };
 use catalyst_types::{
     catalyst_id::{role_index::RoleId, CatalystId},
     cbor_utils::{report_duplicated_key, report_missing_keys},
-    hashes::{Blake2b256Hash, BLAKE_2B256_SIZE},
     problem_report::ProblemReport,
     uuid::UuidV4,
 };
@@ -22,14 +26,6 @@ use cbork_utils::decode_helper::{decode_bytes, decode_helper, decode_map_len};
 use minicbor::{
     decode::{self},
     Decode, Decoder,
-};
-use pallas::{
-    codec::utils::Nullable,
-    ledger::{
-        addresses::{Address, ShelleyAddress},
-        primitives::conway,
-        traverse::MultiEraTx,
-    },
 };
 use strum_macros::FromRepr;
 use tracing::warn;
@@ -459,7 +455,7 @@ impl Decode<'_, DecodeContext<'_, '_>> for Cip509 {
 
 /// Records the payment history for the given set of addresses.
 fn payment_history(
-    txn: &conway::MintedTx,
+    txn: &conway::Tx,
     track_payment_addresses: &[ShelleyAddress],
     origin: &PointTxnIdx,
     report: &ProblemReport,
@@ -474,7 +470,7 @@ fn payment_history(
         .collect();
 
     for (index, output) in txn.transaction_body.outputs.iter().enumerate() {
-        let conway::PseudoTransactionOutput::PostAlonzo(output) = output else {
+        let conway::TransactionOutput::PostAlonzo(output) = output else {
             continue;
         };
 

--- a/rust/rbac-registration/src/cardano/cip509/decode_context.rs
+++ b/rust/rbac-registration/src/cardano/cip509/decode_context.rs
@@ -2,8 +2,8 @@
 
 use std::collections::HashMap;
 
+use cardano_blockchain_types::{pallas_addresses::ShelleyAddress, pallas_primitives::conway};
 use catalyst_types::problem_report::ProblemReport;
-use pallas::ledger::{addresses::ShelleyAddress, primitives::conway};
 
 use crate::cardano::cip509::{Payment, PointTxnIdx};
 
@@ -12,7 +12,7 @@ pub struct DecodeContext<'r, 't> {
     /// A slot and a transaction index.
     pub origin: PointTxnIdx,
     /// A transaction.
-    pub txn: &'t conway::MintedTx<'t>,
+    pub txn: &'t conway::Tx<'t>,
     /// A payment history.
     pub payment_history: HashMap<ShelleyAddress, Vec<Payment>>,
     /// A problem report.

--- a/rust/rbac-registration/src/cardano/cip509/types/payment_history.rs
+++ b/rust/rbac-registration/src/cardano/cip509/types/payment_history.rs
@@ -2,9 +2,8 @@
 
 use std::collections::HashMap;
 
-use pallas::{
-    crypto::hash::Hash,
-    ledger::{addresses::ShelleyAddress, primitives::conway::Value},
+use cardano_blockchain_types::{
+    pallas_addresses::ShelleyAddress, pallas_crypto::hash::Hash, pallas_primitives::conway::Value,
 };
 
 use super::point_tx_idx::PointTxnIdx;

--- a/rust/rbac-registration/src/cardano/cip509/types/role_data.rs
+++ b/rust/rbac-registration/src/cardano/cip509/types/role_data.rs
@@ -2,13 +2,13 @@
 
 use std::{borrow::Cow, collections::HashMap};
 
-use cardano_blockchain_types::TxnWitness;
-use catalyst_types::{catalyst_id::role_index::RoleId, problem_report::ProblemReport};
-use pallas::ledger::{
-    addresses::{Address, ShelleyAddress},
-    primitives::conway,
-    traverse::MultiEraTx,
+use cardano_blockchain_types::{
+    pallas_addresses::{Address, ShelleyAddress},
+    pallas_primitives::conway,
+    pallas_traverse::MultiEraTx,
+    TxnWitness,
 };
+use catalyst_types::{catalyst_id::role_index::RoleId, problem_report::ProblemReport};
 
 use crate::cardano::cip509::{
     rbac::role_data::CborRoleData, utils::cip19::extract_key_hash, KeyLocalRef,
@@ -32,7 +32,7 @@ impl RoleData {
     #[must_use]
     pub fn new(
         data: CborRoleData,
-        txn: &conway::MintedTx,
+        txn: &conway::Tx,
         report: &ProblemReport,
     ) -> Self {
         let payment_key = if data.number == Some(RoleId::Role0) && data.payment_key.is_none() {
@@ -101,7 +101,7 @@ impl RoleData {
 /// Converts the payment key from the form encoded in CBOR role data to `ShelleyAddress`.
 fn convert_payment_key(
     index: Option<u16>,
-    txn: &conway::MintedTx,
+    txn: &conway::Tx,
     context: &str,
     report: &ProblemReport,
 ) -> Option<ShelleyAddress> {
@@ -118,8 +118,8 @@ fn convert_payment_key(
     };
 
     let address = match outputs.get(index) {
-        Some(conway::PseudoTransactionOutput::PostAlonzo(o)) => &o.address,
-        Some(conway::PseudoTransactionOutput::Legacy(o)) => &o.address,
+        Some(conway::TransactionOutput::PostAlonzo(o)) => &o.address,
+        Some(conway::TransactionOutput::Legacy(o)) => &o.address,
         None => {
             report.other(
                 &format!(

--- a/rust/rbac-registration/src/cardano/cip509/types/role_data_record.rs
+++ b/rust/rbac-registration/src/cardano/cip509/types/role_data_record.rs
@@ -2,8 +2,8 @@
 
 use std::collections::HashMap;
 
+use cardano_blockchain_types::pallas_addresses::ShelleyAddress;
 use catalyst_types::catalyst_id::key_rotation::KeyRotation;
-use pallas::ledger::addresses::ShelleyAddress;
 
 use super::{CertOrPk, PointData, PointTxnIdx};
 

--- a/rust/rbac-registration/src/cardano/cip509/types/tx_input_hash.rs
+++ b/rust/rbac-registration/src/cardano/cip509/types/tx_input_hash.rs
@@ -1,7 +1,7 @@
 //! Transaction input hash type
 
 use anyhow::Context;
-use catalyst_types::hashes::Blake2b128Hash;
+use cardano_blockchain_types::hashes::Blake2b128Hash;
 
 /// A 16-byte hash of the transaction inputs field.
 ///

--- a/rust/rbac-registration/src/cardano/cip509/utils/cip134_uri_set.rs
+++ b/rust/rbac-registration/src/cardano/cip509/utils/cip134_uri_set.rs
@@ -10,10 +10,9 @@ use c509_certificate::{
     general_names::general_name::{GeneralNameTypeRegistry, GeneralNameValue},
     C509ExtensionType,
 };
-use cardano_blockchain_types::{Cip0134Uri, StakeAddress};
+use cardano_blockchain_types::{pallas_addresses::Address, Cip0134Uri, StakeAddress};
 use catalyst_types::problem_report::ProblemReport;
 use der_parser::der::parse_der_sequence;
-use pallas::ledger::addresses::Address;
 use tracing::debug;
 use x509_cert::der::oid::db::rfc5912::ID_CE_SUBJECT_ALT_NAME;
 
@@ -304,7 +303,7 @@ fn convert_stake_addresses(uris: &[Cip0134Uri]) -> Vec<StakeAddress> {
 
 #[cfg(test)]
 mod tests {
-    use pallas::ledger::addresses::{Address, Network};
+    use cardano_blockchain_types::pallas_addresses::{Address, Network};
 
     use crate::{cardano::cip509::Cip509, utils::test};
 

--- a/rust/rbac-registration/src/cardano/cip509/validation.rs
+++ b/rust/rbac-registration/src/cardano/cip509/validation.rs
@@ -7,20 +7,22 @@
 use std::borrow::Cow;
 
 use c509_certificate::c509::C509;
-use cardano_blockchain_types::{Network, TxnWitness, VKeyHash};
-use catalyst_types::{
-    catalyst_id::{role_index::RoleId, CatalystId},
+use cardano_blockchain_types::{
     hashes::{Blake2b128Hash, Blake2b256Hash},
-    problem_report::ProblemReport,
-};
-use ed25519_dalek::{Signature, VerifyingKey};
-use pallas::{
-    codec::{
+    pallas_addresses::Address,
+    pallas_codec::{
         minicbor::{Encode, Encoder},
         utils::Bytes,
     },
-    ledger::{addresses::Address, primitives::conway, traverse::MultiEraTx},
+    pallas_primitives::conway,
+    pallas_traverse::MultiEraTx,
+    Network, TxnWitness, VKeyHash,
 };
+use catalyst_types::{
+    catalyst_id::{role_index::RoleId, CatalystId},
+    problem_report::ProblemReport,
+};
+use ed25519_dalek::{Signature, VerifyingKey};
 use x509_cert::{der::Encode as X509Encode, Certificate as X509};
 
 use crate::cardano::cip509::{
@@ -44,7 +46,7 @@ pub(crate) const URI: u8 = 134;
 /// Checks that hashing transactions inputs produces the value equal to the given one.
 pub fn validate_txn_inputs_hash(
     hash: &TxInputHash,
-    transaction: &conway::MintedTx,
+    transaction: &conway::Tx,
     report: &ProblemReport,
 ) {
     let context = "Cip509 transaction input hash validation";
@@ -118,7 +120,7 @@ pub fn validate_aux(
 /// Checks that all public keys extracted from x509 and c509 certificates are present in
 /// the witness set of the transaction.
 pub fn validate_stake_public_key(
-    transaction: &conway::MintedTx,
+    transaction: &conway::Tx,
     uris: Option<&Cip0134UriSet>,
     report: &ProblemReport,
 ) {

--- a/rust/rbac-registration/src/cardano/cip509/x509_chunks.rs
+++ b/rust/rbac-registration/src/cardano/cip509/x509_chunks.rs
@@ -122,9 +122,8 @@ fn decompress(
 mod tests {
     use std::collections::HashMap;
 
-    use cardano_blockchain_types::Point;
+    use cardano_blockchain_types::{pallas_traverse::MultiEraTx, Point};
     use catalyst_types::problem_report::ProblemReport;
-    use pallas::ledger::traverse::MultiEraTx;
 
     use super::*;
     use crate::{cardano::cip509::PointTxnIdx, utils::test};

--- a/rust/rbac-registration/src/registration/cardano/mod.rs
+++ b/rust/rbac-registration/src/registration/cardano/mod.rs
@@ -9,7 +9,7 @@ use std::{
 
 use anyhow::Context;
 use c509_certificate::c509::C509;
-use cardano_blockchain_types::{Point, StakeAddress, TransactionId, TxnIndex};
+use cardano_blockchain_types::{hashes::TransactionId, Point, StakeAddress, TxnIndex};
 use catalyst_types::{
     catalyst_id::{key_rotation::KeyRotation, role_index::RoleId, CatalystId},
     conversion::zero_out_last_n_bytes,

--- a/rust/rbac-registration/src/utils/test.rs
+++ b/rust/rbac-registration/src/utils/test.rs
@@ -2,7 +2,9 @@
 
 // cspell: words stake_test1urs8t0ssa3w9wh90ld5tprp3gurxd487rth2qlqk6ernjqcef4ugr
 
-use cardano_blockchain_types::{MultiEraBlock, Network, Point, Slot, TransactionId, TxnIndex};
+use cardano_blockchain_types::{
+    hashes::TransactionId, MultiEraBlock, Network, Point, Slot, TxnIndex,
+};
 use catalyst_types::{catalyst_id::role_index::RoleId, uuid::UuidV4};
 use uuid::Uuid;
 


### PR DESCRIPTION
# Description

Update `rbac-registration` crate with the latest `cardano-blockchain-types` version.