### PR TITLE
feat(rust): Bump `rbac-registration` and `cardano-chain-follower`

### DIFF
--- a/rust/cardano-chain-follower/Cargo.toml
+++ b/rust/cardano-chain-follower/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cardano-chain-follower"
-version = "0.0.13"
+version = "0.0.14"
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/rust/rbac-registration/Cargo.toml
+++ b/rust/rbac-registration/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rbac-registration"
 description = "Role Based Access Control Registration"
 keywords = ["cardano", "catalyst", "rbac registration"]
-version = "0.0.8"
+version = "0.0.9"
 authors = [
     "Arissara Chotivichit <arissara.chotivichit@iohk.io>"
 ]


### PR DESCRIPTION
# Description

Bumping `rbac-registration` to `0.0.9`  and `cardano-chain-follower` to `0.0.14` for new releases

## Related Pull Requests

Needed for https://github.com/input-output-hk/catalyst-voices/pull/3336

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
