### PR TITLE
chore(general): bump cat-ci versions to `v3.5.12`

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,9 +1,9 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/mdlint:v3.5.7 AS mdlint-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cspell:v3.5.7 AS cspell-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/python:v3.5.7 AS python-ci
-IMPORT github.com/input-output-hk/catalyst-ci:v3.5.7 AS cat-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/mdlint:v3.5.12 AS mdlint-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cspell:v3.5.12 AS cspell-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/python:v3.5.12 AS python-ci
+IMPORT github.com/input-output-hk/catalyst-ci:v3.5.12 AS cat-ci
 
 FROM debian:stable-slim
 

--- a/docs/Earthfile
+++ b/docs/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.5.7 AS docs-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.5.12 AS docs-ci
 
 IMPORT .. AS repo
 

--- a/docs/src/architecture/08_concepts/catalyst_voting/cddl/Earthfile
+++ b/docs/src/architecture/08_concepts/catalyst_voting/cddl/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:v3.5.7 AS cddl-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:v3.5.12 AS cddl-ci
 
 check-cddl:
     FROM cddl-ci+cddl-base

--- a/docs/src/architecture/08_concepts/immutable_ledger/cddl/Earthfile
+++ b/docs/src/architecture/08_concepts/immutable_ledger/cddl/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:v3.5.7 AS cddl-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:v3.5.12 AS cddl-ci
 
 check-cddl:
     FROM cddl-ci+cddl-base

--- a/docs/src/architecture/08_concepts/signed_doc/cddl/Earthfile
+++ b/docs/src/architecture/08_concepts/signed_doc/cddl/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:v3.5.7 AS cddl-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:v3.5.12 AS cddl-ci
 
 check-cddl:
     FROM cddl-ci+cddl-base

--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.5.10 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.5.12 AS rust-ci
 IMPORT ../ AS repo-ci
 
 COPY_SRC:

--- a/rust/c509-certificate/Earthfile
+++ b/rust/c509-certificate/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust::v3.5.10 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust::v3.5.12 AS rust-ci
 
 IMPORT .. AS rust-local
 IMPORT ../.. AS repo

--- a/specs/Earthfile
+++ b/specs/Earthfile
@@ -1,8 +1,8 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/python:v3.5.7 AS python-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/debian:v3.5.7 AS debian
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cue:v3.5.7 AS cue
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/python:v3.5.12 AS python-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/debian:v3.5.12 AS debian
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cue:v3.5.12 AS cue
 
 IMPORT ../docs AS docs
 

--- a/specs/generators/pages/signed_doc/cddl/Earthfile.jinja
+++ b/specs/generators/pages/signed_doc/cddl/Earthfile.jinja
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:v3.5.7 AS cddl-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:v3.5.12 AS cddl-ci
 
 check-cddl:
     FROM cddl-ci+cddl-base

--- a/utilities/docs-preview/Earthfile
+++ b/utilities/docs-preview/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.5.7 AS docs-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.5.12 AS docs-ci
 
 # update-docs-dev-script: get the latest docs dev script from CI.
 update-docs-dev-script:


### PR DESCRIPTION
# Description

Bumped `cat-ci` version to the most recent one `v3.5.12`. Solving rust builder issue with `refinery` tool build
```
rust-tools+tool-refinery |   --> /usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/time-0.3.28/src/format_description/parse/mod.rs:83:9
rust-tools+tool-refinery |    |
rust-tools+tool-refinery | 83 |     let items = format_items
rust-tools+tool-refinery |    |         ^^^^^
rust-tools+tool-refinery | ...
rust-tools+tool-refinery | 86 |     Ok(items.into())
rust-tools+tool-refinery |    |              ---- type must be known at this point
rust-tools+tool-refinery |    |
rust-tools+tool-refinery | help: consider giving `items` an explicit type, where the placeholders `_` are specified
rust-tools+tool-refinery |    |
rust-tools+tool-refinery | 83 |     let items: Box<_> = format_items
rust-tools+tool-refinery |    |  
```

## Related Pull Requests

https://github.com/input-output-hk/catalyst-voices/pull/3336

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
