### PR TITLE
feat(rust/signed-doc): `RefRule` auto generation

### DIFF
--- a/rust/catalyst-signed-doc-macro/src/rules/doc_ref.rs
+++ b/rust/catalyst-signed-doc-macro/src/rules/doc_ref.rs
@@ -3,14 +3,39 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
-/// `signed_doc.json` "ref" field JSON defintion
-#[derive(serde::Deserialize)]
-pub(crate) struct Ref {}
+use crate::signed_doc_spec::{self, IsRequired};
 
 /// Generating `RefRule` instantiation
-pub(crate) fn ref_rule(_ref_spec: &Ref) -> anyhow::Result<TokenStream> {
-    let res = quote! {
-        crate::validator::rules::RefRule::NotSpecified
-    };
-    Ok(res)
+pub(crate) fn ref_rule(ref_spec: &signed_doc_spec::doc_ref::Ref) -> anyhow::Result<TokenStream> {
+    match ref_spec.required {
+        IsRequired::Yes => {
+            let doc_name = ref_spec.doc_type.as_ref().ok_or(anyhow::anyhow!(
+                "'type' field should exists for the required 'ref' metadata definition"
+            ))?;
+            let const_type_name_ident = doc_name.ident();
+            Ok(quote! {
+                crate::validator::rules::RefRule::Specified {
+                    exp_ref_types: vec![ #const_type_name_ident ]
+                    optional: false,
+                }
+            })
+        },
+        IsRequired::Optional => {
+            let doc_name = ref_spec.doc_type.as_ref().ok_or(anyhow::anyhow!(
+                "'type' field should exists for the required 'ref' metadata definition"
+            ))?;
+            let const_type_name_ident = doc_name.ident();
+            Ok(quote! {
+                crate::validator::rules::RefRule::Specified {
+                    exp_ref_types: vec![ #const_type_name_ident ]
+                    optional: true,
+                }
+            })
+        },
+        IsRequired::Excluded => {
+            Ok(quote! {
+                crate::validator::rules::RefRule::NotSpecified
+            })
+        },
+    }
 }

--- a/rust/catalyst-signed-doc-macro/src/rules/doc_ref.rs
+++ b/rust/catalyst-signed-doc-macro/src/rules/doc_ref.rs
@@ -1,0 +1,16 @@
+//! `RefRule` generation
+
+use proc_macro2::TokenStream;
+use quote::quote;
+
+/// `signed_doc.json` "ref" field JSON defintion
+#[derive(serde::Deserialize)]
+pub(crate) struct Ref {}
+
+/// Generating `RefRule` instantiation
+pub(crate) fn ref_rule(_ref_spec: &Ref) -> anyhow::Result<TokenStream> {
+    let res = quote! {
+        crate::validator::rules::RefRule::NotSpecified
+    };
+    Ok(res)
+}

--- a/rust/catalyst-signed-doc-macro/src/rules/doc_ref.rs
+++ b/rust/catalyst-signed-doc-macro/src/rules/doc_ref.rs
@@ -8,8 +8,8 @@ use crate::signed_doc_spec::{self, IsRequired};
 /// Generating `RefRule` instantiation
 pub(crate) fn ref_rule(ref_spec: &signed_doc_spec::doc_ref::Ref) -> anyhow::Result<TokenStream> {
     let optional = match ref_spec.required {
-        IsRequired::Yes => true,
-        IsRequired::Optional => false,
+        IsRequired::Yes => false,
+        IsRequired::Optional => true,
         IsRequired::Excluded => {
             return Ok(quote! {
                 crate::validator::rules::RefRule::NotSpecified

--- a/rust/catalyst-signed-doc-macro/src/rules/mod.rs
+++ b/rust/catalyst-signed-doc-macro/src/rules/mod.rs
@@ -1,5 +1,7 @@
 //! `catalyst_signed_documents_rules!` macro implementation
 
+pub(crate) mod doc_ref;
+
 use proc_macro2::TokenStream;
 use quote::quote;
 
@@ -10,9 +12,10 @@ pub(crate) fn catalyst_signed_documents_rules_impl() -> anyhow::Result<TokenStre
     let spec = CatalystSignedDocSpec::load_signed_doc_spec()?;
 
     let mut rules_definitions = Vec::new();
-    for (doc_name, _doc_spec) in spec.docs {
+    for (doc_name, doc_spec) in spec.docs {
         let const_type_name_ident = doc_name.ident();
 
+        let ref_rule = doc_ref::ref_rule(&doc_spec.metadata.doc_ref)?;
         // TODO: implement a proper initialization for all specific validation rules
         let rules = quote! {
             crate::validator::rules::Rules {
@@ -27,7 +30,7 @@ pub(crate) fn catalyst_signed_documents_rules_impl() -> anyhow::Result<TokenStre
                 },
                 content: crate::validator::rules::ContentRule::NotSpecified,
                 parameters: crate::validator::rules::ParametersRule::NotSpecified,
-                doc_ref: crate::validator::rules::RefRule::NotSpecified,
+                doc_ref: #ref_rule,
                 reply: crate::validator::rules::ReplyRule::NotSpecified,
                 section: crate::validator::rules::SectionRule::NotSpecified,
                 kid: crate::validator::rules::SignatureKidRule {

--- a/rust/catalyst-signed-doc-macro/src/signed_doc_spec.rs
+++ b/rust/catalyst-signed-doc-macro/src/signed_doc_spec.rs
@@ -2,7 +2,6 @@
 
 use std::collections::HashMap;
 
-use anyhow::Context;
 use proc_macro2::Ident;
 use quote::format_ident;
 
@@ -43,6 +42,16 @@ pub(crate) struct DocSpec {
     /// Document type UUID v4 value
     #[serde(rename = "type")]
     pub(crate) doc_type: String,
+
+    /// Document type metadata definitions
+    pub(crate) metadata: Metadata,
+}
+
+/// Document's metadata fields defintion
+#[derive(serde::Deserialize)]
+pub(crate) struct Metadata {
+    #[serde(rename = "ref")]
+    pub(crate) doc_ref: crate::rules::doc_ref::Ref,
 }
 
 impl CatalystSignedDocSpec {
@@ -50,8 +59,7 @@ impl CatalystSignedDocSpec {
     // #[allow(dependency_on_unit_never_type_fallback)]
     pub(crate) fn load_signed_doc_spec() -> anyhow::Result<CatalystSignedDocSpec> {
         let signed_doc_str = include_str!("../../../specs/signed_doc.json");
-        let signed_doc_spec = serde_json::from_str(signed_doc_str)
-            .context("Catalyst Signed Documents spec must be a JSON object")?;
+        let signed_doc_spec = serde_json::from_str(signed_doc_str)?;
         Ok(signed_doc_spec)
     }
 }

--- a/rust/catalyst-signed-doc-macro/src/signed_doc_spec/doc_ref.rs
+++ b/rust/catalyst-signed-doc-macro/src/signed_doc_spec/doc_ref.rs
@@ -1,12 +1,12 @@
 //! `signed_doc.json` "ref" field JSON defintion
 
-use crate::signed_doc_spec::{DocumentName, IsRequired};
+use crate::signed_doc_spec::{DocTypes, IsRequired};
 
 /// `signed_doc.json` "ref" field JSON object
 #[derive(serde::Deserialize)]
 pub(crate) struct Ref {
     pub(crate) required: IsRequired,
     #[serde(rename = "type")]
-    pub(crate) doc_type: Option<DocumentName>,
-    // pub(crate) multiple: Option<bool>,
+    pub(crate) doc_type: DocTypes,
+    pub(crate) multiple: Option<bool>,
 }

--- a/rust/catalyst-signed-doc-macro/src/signed_doc_spec/doc_ref.rs
+++ b/rust/catalyst-signed-doc-macro/src/signed_doc_spec/doc_ref.rs
@@ -4,6 +4,7 @@ use crate::signed_doc_spec::{DocTypes, IsRequired};
 
 /// `signed_doc.json` "ref" field JSON object
 #[derive(serde::Deserialize)]
+#[allow(clippy::missing_docs_in_private_items)]
 pub(crate) struct Ref {
     pub(crate) required: IsRequired,
     #[serde(rename = "type")]

--- a/rust/catalyst-signed-doc-macro/src/signed_doc_spec/doc_ref.rs
+++ b/rust/catalyst-signed-doc-macro/src/signed_doc_spec/doc_ref.rs
@@ -1,4 +1,4 @@
-//! `signed_doc.json` "ref" field JSON defintion
+//! `signed_doc.json` "ref" field JSON definition
 
 use crate::signed_doc_spec::{DocTypes, IsRequired};
 

--- a/rust/catalyst-signed-doc-macro/src/signed_doc_spec/doc_ref.rs
+++ b/rust/catalyst-signed-doc-macro/src/signed_doc_spec/doc_ref.rs
@@ -1,0 +1,12 @@
+//! `signed_doc.json` "ref" field JSON defintion
+
+use crate::signed_doc_spec::{DocumentName, IsRequired};
+
+/// `signed_doc.json` "ref" field JSON object
+#[derive(serde::Deserialize)]
+pub(crate) struct Ref {
+    pub(crate) required: IsRequired,
+    #[serde(rename = "type")]
+    pub(crate) doc_type: Option<DocumentName>,
+    // pub(crate) multiple: Option<bool>,
+}

--- a/rust/catalyst-signed-doc-macro/src/signed_doc_spec/mod.rs
+++ b/rust/catalyst-signed-doc-macro/src/signed_doc_spec/mod.rs
@@ -1,5 +1,7 @@
 //! Catalyst Signed Document spec type
 
+pub(crate) mod doc_ref;
+
 use std::collections::HashMap;
 
 use proc_macro2::Ident;
@@ -51,14 +53,23 @@ pub(crate) struct DocSpec {
 #[derive(serde::Deserialize)]
 pub(crate) struct Metadata {
     #[serde(rename = "ref")]
-    pub(crate) doc_ref: crate::rules::doc_ref::Ref,
+    pub(crate) doc_ref: doc_ref::Ref,
+}
+
+/// "required" field defition
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum IsRequired {
+    Yes,
+    Excluded,
+    Optional,
 }
 
 impl CatalystSignedDocSpec {
     /// Loading a Catalyst Signed Documents spec from the `signed_doc.json`
     // #[allow(dependency_on_unit_never_type_fallback)]
     pub(crate) fn load_signed_doc_spec() -> anyhow::Result<CatalystSignedDocSpec> {
-        let signed_doc_str = include_str!("../../../specs/signed_doc.json");
+        let signed_doc_str = include_str!("../../../../specs/signed_doc.json");
         let signed_doc_spec = serde_json::from_str(signed_doc_str)?;
         Ok(signed_doc_spec)
     }

--- a/rust/catalyst-signed-doc-macro/src/signed_doc_spec/mod.rs
+++ b/rust/catalyst-signed-doc-macro/src/signed_doc_spec/mod.rs
@@ -51,6 +51,7 @@ pub(crate) struct DocSpec {
 
 /// Document's metadata fields defintion
 #[derive(serde::Deserialize)]
+#[allow(clippy::missing_docs_in_private_items)]
 pub(crate) struct Metadata {
     #[serde(rename = "ref")]
     pub(crate) doc_ref: doc_ref::Ref,
@@ -59,12 +60,14 @@ pub(crate) struct Metadata {
 /// "required" field defition
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[allow(clippy::missing_docs_in_private_items)]
 pub(crate) enum IsRequired {
     Yes,
     Excluded,
     Optional,
 }
 
+/// A helper type for deserialization "type" metadata field
 pub(crate) struct DocTypes(Vec<DocumentName>);
 
 impl Deref for DocTypes {
@@ -76,6 +79,7 @@ impl Deref for DocTypes {
 }
 
 impl<'de> serde::Deserialize<'de> for DocTypes {
+    #[allow(clippy::missing_docs_in_private_items)]
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where D: serde::Deserializer<'de> {
         #[derive(serde::Deserialize)]

--- a/rust/catalyst-signed-doc-macro/src/signed_doc_spec/mod.rs
+++ b/rust/catalyst-signed-doc-macro/src/signed_doc_spec/mod.rs
@@ -49,7 +49,7 @@ pub(crate) struct DocSpec {
     pub(crate) metadata: Metadata,
 }
 
-/// Document's metadata fields defintion
+/// Document's metadata fields definition
 #[derive(serde::Deserialize)]
 #[allow(clippy::missing_docs_in_private_items)]
 pub(crate) struct Metadata {
@@ -57,7 +57,7 @@ pub(crate) struct Metadata {
     pub(crate) doc_ref: doc_ref::Ref,
 }
 
-/// "required" field defition
+/// "required" field definition
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
 #[allow(clippy::missing_docs_in_private_items)]


### PR DESCRIPTION
# Description

Added macro `RefRule` auto instantiation based on the `signed_doc.json` specification file.

## Related Issue(s)

Closes https://github.com/input-output-hk/catalyst-libs/issues/513

## Description of Changes

Provide a clear and concise description of what the pull request changes.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
