### PR TITLE
feat(rust/signed-doc): Not required `content-type` during decoding

### DIFF
--- a/rust/signed_doc/src/builder.rs
+++ b/rust/signed_doc/src/builder.rs
@@ -92,7 +92,7 @@ impl ContentBuilder {
         json: &serde_json::Value,
     ) -> anyhow::Result<SignaturesBuilder> {
         anyhow::ensure!(
-            self.metadata.content_type()? == ContentType::Json,
+            self.metadata.content_type() == Some(ContentType::Json),
             "Already set metadata field `content-type` is not JSON value"
         );
 

--- a/rust/signed_doc/src/lib.rs
+++ b/rust/signed_doc/src/lib.rs
@@ -137,6 +137,7 @@ impl CatalystSignedDocument {
     }
 
     /// Return document `ContentType`.
+    #[must_use]
     pub fn doc_content_type(&self) -> Option<ContentType> {
         self.inner.metadata.content_type()
     }

--- a/rust/signed_doc/src/lib.rs
+++ b/rust/signed_doc/src/lib.rs
@@ -137,10 +137,7 @@ impl CatalystSignedDocument {
     }
 
     /// Return document `ContentType`.
-    ///
-    /// # Errors
-    /// - Missing 'content-type' field.
-    pub fn doc_content_type(&self) -> anyhow::Result<ContentType> {
+    pub fn doc_content_type(&self) -> Option<ContentType> {
         self.inner.metadata.content_type()
     }
 

--- a/rust/signed_doc/src/metadata/mod.rs
+++ b/rust/signed_doc/src/metadata/mod.rs
@@ -67,15 +67,11 @@ impl Metadata {
     }
 
     /// Returns the Document Content Type, if any.
-    ///
-    /// # Errors
-    /// - Missing 'content-type' field.
-    pub fn content_type(&self) -> anyhow::Result<ContentType> {
+    pub fn content_type(&self) -> Option<ContentType> {
         self.0
             .get(&SupportedLabel::ContentType)
             .and_then(SupportedField::try_as_content_type_ref)
             .copied()
-            .ok_or(anyhow::anyhow!("Missing 'content-type' field"))
     }
 
     /// Returns the Document Content Encoding, if any.
@@ -180,9 +176,6 @@ impl Metadata {
         if metadata.doc_ver().is_err() {
             report.missing_field("ver", REPORT_CONTEXT);
         }
-        if metadata.content_type().is_err() {
-            report.missing_field("content-type", REPORT_CONTEXT);
-        }
 
         Ok(metadata)
     }
@@ -224,7 +217,7 @@ impl Display for Metadata {
         writeln!(f, "  type: {:?},", self.doc_type().ok())?;
         writeln!(f, "  id: {:?},", self.doc_id().ok())?;
         writeln!(f, "  ver: {:?},", self.doc_ver().ok())?;
-        writeln!(f, "  content_type: {:?},", self.content_type().ok())?;
+        writeln!(f, "  content_type: {:?},", self.content_type())?;
         writeln!(f, "  content_encoding: {:?},", self.content_encoding())?;
         writeln!(f, "  additional_fields: {{")?;
         writeln!(f, "    ref: {:?}", self.doc_ref())?;

--- a/rust/signed_doc/src/validator/rules/content.rs
+++ b/rust/signed_doc/src/validator/rules/content.rs
@@ -62,7 +62,7 @@ impl ContentRule {
             };
 
             let template_validator = |template_doc: &CatalystSignedDocument| {
-                let Ok(template_content_type) = template_doc.doc_content_type() else {
+                let Some(template_content_type) = template_doc.doc_content_type() else {
                     doc.report().missing_field(
                         "content-type",
                         &format!("{context}, referenced document must have a content-type field"),

--- a/rust/signed_doc/src/validator/rules/content_type.rs
+++ b/rust/signed_doc/src/validator/rules/content_type.rs
@@ -16,7 +16,7 @@ impl ContentTypeRule {
         &self,
         doc: &CatalystSignedDocument,
     ) -> anyhow::Result<bool> {
-        let Ok(content_type) = doc.doc_content_type() else {
+        let Some(content_type) = doc.doc_content_type() else {
             doc.report().missing_field(
                 "content-type",
                 "Cannot get a content type field during the field validation",

--- a/rust/signed_doc/tests/decoding.rs
+++ b/rust/signed_doc/tests/decoding.rs
@@ -158,10 +158,7 @@ fn signed_doc_with_missing_header_field_case(field: &'static str) -> TestCase {
                 // protected headers (metadata fields)
                 e.bytes({
                     let mut p_headers = Encoder::new(Vec::new());
-                    p_headers.map(4)?;
-                    if field != "content-type" {
-                        p_headers.u8(3)?.encode(ContentType::Json)?;
-                    }
+                    p_headers.map(3)?;
                     if field != "type" {
                         p_headers.str("type")?.encode(&doc_type)?;
                     }
@@ -198,9 +195,6 @@ fn signed_doc_with_missing_header_field_case(field: &'static str) -> TestCase {
         valid_doc: false,
         post_checks: Some(Box::new({
             move |doc| {
-                if field == "content-type" {
-                    anyhow::ensure!(doc.doc_meta().content_type().is_err());
-                }
                 if field == "type" {
                     anyhow::ensure!(doc.doc_meta().doc_type().is_err());
                 }
@@ -234,17 +228,10 @@ fn signed_doc_with_random_header_field_case(field: &'static str) -> TestCase {
                     let mut rand_buf = [0u8; 128];
                     rng.try_fill(&mut rand_buf)?;
 
-                    let is_required_header = ["content-type", "type", "id", "ver"]
-                        .iter()
-                        .any(|v| v == &field);
+                    let is_required_header = ["type", "id", "ver"].iter().any(|v| v == &field);
 
                     let mut p_headers = Encoder::new(Vec::new());
-                    p_headers.map(if is_required_header { 4 } else { 5 })?;
-                    if field == "content-type" {
-                        p_headers.u8(3)?.encode_with(rand_buf, &mut ())?;
-                    } else {
-                        p_headers.u8(3)?.encode(ContentType::Json)?;
-                    }
+                    p_headers.map(if is_required_header { 3 } else { 4 })?;
                     if field == "type" {
                         p_headers.str("type")?.encode_with(rand_buf, &mut ())?;
                     } else {
@@ -287,6 +274,7 @@ fn signed_doc_with_random_header_field_case(field: &'static str) -> TestCase {
         valid_doc: false,
         post_checks: Some(Box::new({
             move |doc| {
+                anyhow::ensure!(doc.doc_meta().content_type().is_none());
                 anyhow::ensure!(doc.doc_meta().content_encoding().is_none());
                 anyhow::ensure!(doc.doc_meta().doc_ref().is_none());
                 anyhow::ensure!(doc.doc_meta().template().is_none());
@@ -295,9 +283,6 @@ fn signed_doc_with_random_header_field_case(field: &'static str) -> TestCase {
                 anyhow::ensure!(doc.doc_meta().parameters().is_none());
                 anyhow::ensure!(doc.doc_meta().collaborators().is_empty());
 
-                if field == "content-type" {
-                    anyhow::ensure!(doc.doc_meta().content_type().is_err());
-                }
                 if field == "type" {
                     anyhow::ensure!(doc.doc_meta().doc_type().is_err());
                 }
@@ -594,7 +579,7 @@ fn signed_doc_with_minimal_metadata_fields_case() -> TestCase {
                 anyhow::ensure!(doc.doc_type()? == &doc_type);
                 anyhow::ensure!(doc.doc_id()? == uuid_v7);
                 anyhow::ensure!(doc.doc_ver()? == uuid_v7);
-                anyhow::ensure!(doc.doc_content_type()? == ContentType::Json);
+                anyhow::ensure!(doc.doc_content_type() == Some(ContentType::Json));
                 anyhow::ensure!(
                     doc.encoded_content() == serde_json::to_vec(&serde_json::Value::Null)?
                 );
@@ -682,7 +667,7 @@ fn signed_doc_with_complete_metadata_fields_case() -> TestCase {
                 anyhow::ensure!(doc.doc_meta().doc_ref() == Some(&refs));
                 anyhow::ensure!(doc.doc_meta().template() == Some(&refs));
                 anyhow::ensure!(doc.doc_meta().reply() == Some(&refs));
-                anyhow::ensure!(doc.doc_content_type()? == ContentType::Json);
+                anyhow::ensure!(doc.doc_content_type() == Some(ContentType::Json));
                 anyhow::ensure!(doc.encoded_content() == serde_json::to_vec(&serde_json::Value::Null)?);
                 anyhow::ensure!(doc.kids().len() == 1);
                 anyhow::ensure!(!doc.is_deprecated()?);
@@ -735,7 +720,7 @@ fn minimally_valid_tagged_signed_doc() -> TestCase {
                 anyhow::ensure!(doc.doc_type()? == &doc_type);
                 anyhow::ensure!(doc.doc_id()? == uuid_v7);
                 anyhow::ensure!(doc.doc_ver()? == uuid_v7);
-                anyhow::ensure!(doc.doc_content_type()? == ContentType::Json);
+                anyhow::ensure!(doc.doc_content_type() == Some(ContentType::Json));
                 anyhow::ensure!(doc.doc_meta().doc_ref().is_none());
                 anyhow::ensure!(doc.doc_meta().template().is_none());
                 anyhow::ensure!(doc.doc_meta().reply().is_none());
@@ -791,7 +776,7 @@ fn minimally_valid_untagged_signed_doc() -> TestCase {
                 anyhow::ensure!(doc.doc_type()? == &doc_type);
                 anyhow::ensure!(doc.doc_id()? == uuid_v7);
                 anyhow::ensure!(doc.doc_ver()? == uuid_v7);
-                anyhow::ensure!(doc.doc_content_type()? == ContentType::Json);
+                anyhow::ensure!(doc.doc_content_type() == Some(ContentType::Json));
                 anyhow::ensure!(doc.doc_meta().doc_ref().is_none());
                 anyhow::ensure!(doc.doc_meta().template().is_none());
                 anyhow::ensure!(doc.doc_meta().reply().is_none());
@@ -1100,7 +1085,7 @@ fn signed_doc_with_non_strict_deterministic_decoding_wrong_order() -> TestCase {
                 anyhow::ensure!(doc.doc_type()? == &doc_type);
                 anyhow::ensure!(doc.doc_id()? == uuid_v7);
                 anyhow::ensure!(doc.doc_ver()? == uuid_v7);
-                anyhow::ensure!(doc.doc_content_type()? == ContentType::Json);
+                anyhow::ensure!(doc.doc_content_type() == Some(ContentType::Json));
                 anyhow::ensure!(
                     doc.encoded_content() == serde_json::to_vec(&serde_json::Value::Null)?
                 );
@@ -1159,7 +1144,7 @@ fn signed_doc_with_non_supported_metadata_invalid() -> TestCase {
                 anyhow::ensure!(doc.doc_type()? == &doc_type);
                 anyhow::ensure!(doc.doc_id()? == uuid_v7);
                 anyhow::ensure!(doc.doc_ver()? == uuid_v7);
-                anyhow::ensure!(doc.doc_content_type()? == ContentType::Json);
+                anyhow::ensure!(doc.doc_content_type() == Some(ContentType::Json));
                 anyhow::ensure!(
                     doc.encoded_content() == serde_json::to_vec(&serde_json::Value::Null)?
                 );
@@ -1227,7 +1212,7 @@ fn signed_doc_with_kid_in_id_form_invalid() -> TestCase {
                 anyhow::ensure!(doc.doc_type()? == &doc_type);
                 anyhow::ensure!(doc.doc_id()? == uuid_v7);
                 anyhow::ensure!(doc.doc_ver()? == uuid_v7);
-                anyhow::ensure!(doc.doc_content_type()? == ContentType::Json);
+                anyhow::ensure!(doc.doc_content_type() == Some(ContentType::Json));
                 anyhow::ensure!(
                     doc.encoded_content() == serde_json::to_vec(&serde_json::Value::Null)?
                 );
@@ -1323,7 +1308,6 @@ fn catalyst_signed_doc_decoding_test() {
         signed_doc_with_valid_alias_case("brand_id"),
         signed_doc_with_valid_alias_case("campaign_id"),
         signed_doc_with_valid_alias_case("parameters"),
-        signed_doc_with_missing_header_field_case("content-type"),
         signed_doc_with_missing_header_field_case("type"),
         signed_doc_with_missing_header_field_case("id"),
         signed_doc_with_missing_header_field_case("ver"),


### PR DESCRIPTION
# Description

Updated decoding logic of Catalyst Signed Document, `content-type` metadata field could be optional, not required field.

## Related Issue(s)

Related to https://github.com/input-output-hk/catalyst-internal-docs/issues/266

## Description of Changes

- Changed `doc_content_type` method
- Removed verification that `content-type` should be present during decoding logic
- Fixed decoding tests

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
