### PR TITLE
feat(rust/signed-doc): Split into two `ContentRule` and `TemplateRule`

### DIFF
--- a/rust/catalyst-signed-doc-macro/src/rules/mod.rs
+++ b/rust/catalyst-signed-doc-macro/src/rules/mod.rs
@@ -26,11 +26,12 @@ pub(crate) fn catalyst_signed_documents_rules_impl() -> anyhow::Result<TokenStre
                     exp: ContentEncoding::Brotli,
                     optional: false,
                 },
-                content: crate::validator::rules::ContentRule::NotSpecified,
+                template: crate::validator::rules::TemplateRule::NotSpecified,
                 parameters: crate::validator::rules::ParametersRule::NotSpecified,
                 doc_ref: #ref_rule,
                 reply: crate::validator::rules::ReplyRule::NotSpecified,
                 section: crate::validator::rules::SectionRule::NotSpecified,
+                content: crate::validator::rules::ContentRule::Nil,
                 kid: crate::validator::rules::SignatureKidRule {
                     exp: &[],
                 },

--- a/rust/signed_doc/src/builder.rs
+++ b/rust/signed_doc/src/builder.rs
@@ -246,11 +246,14 @@ pub(crate) mod tests {
             kid: super::CatalystId,
         ) -> anyhow::Result<Self> {
             let metadata = WithCborBytes::new(self.metadata, &mut ())?;
-            let content = WithCborBytes::new(self.content, &mut ())?;
-            self.signatures
-                .push(super::build_signature(sign_fn, kid, &metadata, &content)?);
+            self.signatures.push(super::build_signature(
+                sign_fn,
+                kid,
+                &metadata,
+                &self.content,
+            )?);
             self.metadata = metadata.inner();
-            self.content = content.inner();
+            self.content = self.content;
             Ok(self)
         }
 

--- a/rust/signed_doc/src/builder.rs
+++ b/rust/signed_doc/src/builder.rs
@@ -253,7 +253,6 @@ pub(crate) mod tests {
                 &self.content,
             )?);
             self.metadata = metadata.inner();
-            self.content = self.content;
             Ok(self)
         }
 

--- a/rust/signed_doc/src/builder.rs
+++ b/rust/signed_doc/src/builder.rs
@@ -34,7 +34,7 @@ pub struct SignaturesBuilder {
     /// metadata
     metadata: WithCborBytes<Metadata>,
     /// content
-    content: WithCborBytes<Content>,
+    content: Content,
     /// signatures
     signatures: Signatures,
 }
@@ -71,7 +71,7 @@ impl ContentBuilder {
     fn into_signatures_builder(self) -> anyhow::Result<SignaturesBuilder> {
         Ok(SignaturesBuilder {
             metadata: WithCborBytes::new(self.metadata, &mut ())?,
-            content: WithCborBytes::new(self.content, &mut ())?,
+            content: self.content,
             signatures: Signatures::default(),
         })
     }
@@ -176,7 +176,7 @@ fn build_signature(
     sign_fn: impl FnOnce(Vec<u8>) -> Vec<u8>,
     kid: CatalystId,
     metadata: &WithCborBytes<Metadata>,
-    content: &WithCborBytes<Content>,
+    content: &Content,
 ) -> anyhow::Result<Signature> {
     let data_to_sign = tbs_data(&kid, metadata, content)?;
     let sign_bytes = sign_fn(data_to_sign);

--- a/rust/signed_doc/src/content.rs
+++ b/rust/signed_doc/src/content.rs
@@ -2,25 +2,19 @@
 
 /// Document Content bytes (COSE payload).
 #[derive(Debug, Clone, PartialEq, Default)]
-pub struct Content(Vec<u8>);
+pub struct Content(Option<Vec<u8>>);
 
 impl Content {
     /// Return content bytes.
     #[must_use]
     pub fn bytes(&self) -> &[u8] {
-        self.0.as_slice()
-    }
-
-    /// Return content byte size.
-    #[must_use]
-    pub fn size(&self) -> usize {
-        self.0.len()
+        self.0.as_ref().map(|v| v.as_slice()).unwrap_or(&[])
     }
 }
 
 impl From<Vec<u8>> for Content {
     fn from(value: Vec<u8>) -> Self {
-        Self(value)
+        Self(Some(value))
     }
 }
 
@@ -30,12 +24,15 @@ impl minicbor::Encode<()> for Content {
         e: &mut minicbor::Encoder<W>,
         _ctx: &mut (),
     ) -> Result<(), minicbor::encode::Error<W::Error>> {
-        if self.0.is_empty() {
-            e.null()?;
-        } else {
-            e.bytes(self.0.as_slice())?;
-        }
+        match &self.0 {
+            Some(bytes) => e.bytes(&bytes)?,
+            None => e.null()?,
+        };
         Ok(())
+    }
+
+    fn is_nil(&self) -> bool {
+        self.0.is_none()
     }
 }
 
@@ -46,11 +43,11 @@ impl minicbor::Decode<'_, ()> for Content {
     ) -> Result<Self, minicbor::decode::Error> {
         let p = d.position();
         d.null()
-            .map(|()| Self(Vec::new()))
+            .map(|()| Self(None))
             // important to use `or_else` so it will lazy evaluated at the time when it is needed
             .or_else(|_| {
                 d.set_position(p);
-                d.bytes().map(Vec::from).map(Self)
+                d.bytes().map(Vec::from).map(Some).map(Self)
             })
     }
 }

--- a/rust/signed_doc/src/content.rs
+++ b/rust/signed_doc/src/content.rs
@@ -8,7 +8,7 @@ impl Content {
     /// Return content bytes.
     #[must_use]
     pub fn bytes(&self) -> &[u8] {
-        self.0.as_ref().map(|v| v.as_slice()).unwrap_or(&[])
+        self.0.as_deref().unwrap_or(&[])
     }
 }
 
@@ -25,7 +25,7 @@ impl minicbor::Encode<()> for Content {
         _ctx: &mut (),
     ) -> Result<(), minicbor::encode::Error<W::Error>> {
         match &self.0 {
-            Some(bytes) => e.bytes(&bytes)?,
+            Some(bytes) => e.bytes(bytes)?,
             None => e.null()?,
         };
         Ok(())

--- a/rust/signed_doc/src/lib.rs
+++ b/rust/signed_doc/src/lib.rs
@@ -40,7 +40,7 @@ struct InnerCatalystSignedDocument {
     /// Document Metadata
     metadata: WithCborBytes<Metadata>,
     /// Document Content
-    content: WithCborBytes<Content>,
+    content: Content,
     /// Signatures
     signatures: Signatures,
     /// A comprehensive problem report, which could include a decoding errors along with
@@ -64,7 +64,6 @@ impl Display for CatalystSignedDocument {
         f: &mut Formatter<'_>,
     ) -> Result<(), std::fmt::Error> {
         self.inner.metadata.fmt(f)?;
-        writeln!(f, "Payload Size: {} bytes", self.inner.content.size())?;
         writeln!(f, "Signature Information")?;
         if self.inner.signatures.is_empty() {
             writeln!(f, "  This document is unsigned.")?;
@@ -114,7 +113,7 @@ impl CatalystSignedDocument {
 
     /// Return document content object.
     #[must_use]
-    pub(crate) fn content(&self) -> &WithCborBytes<Content> {
+    pub(crate) fn content(&self) -> &Content {
         &self.inner.content
     }
 
@@ -286,7 +285,7 @@ impl Decode<'_, CompatibilityPolicy> for CatalystSignedDocument {
                     );
                 }
 
-                let content = WithCborBytes::<Content>::decode(
+                let content = Content::decode(
                     &mut minicbor::Decoder::new(content_bytes.as_slice()),
                     &mut (),
                 )?;

--- a/rust/signed_doc/src/signature/mod.rs
+++ b/rust/signed_doc/src/signature/mod.rs
@@ -72,7 +72,7 @@ impl Signatures {
 pub(crate) fn tbs_data(
     kid: &CatalystId,
     metadata: &WithCborBytes<Metadata>,
-    content: &WithCborBytes<Content>,
+    content: &Content,
 ) -> anyhow::Result<Vec<u8>> {
     let mut e = minicbor::Encoder::new(Vec::new());
 

--- a/rust/signed_doc/src/validator/mod.rs
+++ b/rust/signed_doc/src/validator/mod.rs
@@ -19,7 +19,7 @@ use crate::{
     },
     metadata::DocType,
     providers::{CatalystSignedDocumentProvider, VerifyingKeyProvider},
-    validator::rules::SignatureRule,
+    validator::rules::{SignatureRule, TemplateRule},
     CatalystSignedDocument, ContentEncoding, ContentType,
 };
 
@@ -48,8 +48,8 @@ fn proposal_rule() -> Rules {
             exp: ContentEncoding::Brotli,
             optional: false,
         },
-        content: ContentRule::Templated {
-            exp_template_type: PROPOSAL_FORM_TEMPLATE.clone(),
+        template: TemplateRule::Specified {
+            allowed_type: PROPOSAL_FORM_TEMPLATE.clone(),
         },
         parameters: ParametersRule::Specified {
             exp_parameters_type: parameters.clone(),
@@ -58,6 +58,7 @@ fn proposal_rule() -> Rules {
         doc_ref: RefRule::NotSpecified,
         reply: ReplyRule::NotSpecified,
         section: SectionRule::NotSpecified,
+        content: ContentRule::NotNil,
         kid: SignatureKidRule {
             exp: &[RoleId::Proposer],
         },
@@ -86,8 +87,8 @@ fn proposal_comment_rule() -> Rules {
             exp: ContentEncoding::Brotli,
             optional: false,
         },
-        content: ContentRule::Templated {
-            exp_template_type: PROPOSAL_COMMENT_FORM_TEMPLATE.clone(),
+        template: TemplateRule::Specified {
+            allowed_type: PROPOSAL_COMMENT_FORM_TEMPLATE.clone(),
         },
         doc_ref: RefRule::Specified {
             exp_ref_types: vec![PROPOSAL.clone()],
@@ -103,6 +104,7 @@ fn proposal_comment_rule() -> Rules {
             exp_parameters_type: parameters.clone(),
             optional: false,
         },
+        content: ContentRule::NotNil,
         kid: SignatureKidRule {
             exp: &[RoleId::Role0],
         },
@@ -142,7 +144,7 @@ fn proposal_submission_action_rule() -> Rules {
             exp: ContentEncoding::Brotli,
             optional: false,
         },
-        content: ContentRule::Static(ContentSchema::Json(proposal_action_json_schema)),
+        template: TemplateRule::NotSpecified,
         parameters: ParametersRule::Specified {
             exp_parameters_type: parameters,
             optional: false,
@@ -154,6 +156,7 @@ fn proposal_submission_action_rule() -> Rules {
         },
         reply: ReplyRule::NotSpecified,
         section: SectionRule::NotSpecified,
+        content: ContentRule::StaticSchema(ContentSchema::Json(proposal_action_json_schema)),
         kid: SignatureKidRule {
             exp: &[RoleId::Proposer],
         },

--- a/rust/signed_doc/src/validator/rules/content.rs
+++ b/rust/signed_doc/src/validator/rules/content.rs
@@ -43,7 +43,7 @@ impl ContentRule {
         &self,
         doc: &CatalystSignedDocument,
     ) -> anyhow::Result<bool> {
-        const CONTENXT: &str = "Content rule check";
+        const CONTEXT: &str = "Content rule check";
         if let Self::StaticSchema(content_schema) = self {
             match content_schema {
                 ContentSchema::Json(json_schema) => {
@@ -54,14 +54,14 @@ impl ContentRule {
         if let Self::NotNil = self {
             if doc.content().size() == 0 {
                 doc.report()
-                    .functional_validation("Document must have a NOT CBOR `nil` content", CONTENXT);
+                    .functional_validation("Document must have a NOT CBOR `nil` content", CONTEXT);
                 return Ok(false);
             }
         }
         if let Self::Nil = self {
             if doc.content().size() != 0 {
                 doc.report()
-                    .functional_validation("Document must have a CBOR `nil` content", CONTENXT);
+                    .functional_validation("Document must have a CBOR `nil` content", CONTEXT);
                 return Ok(false);
             }
         }

--- a/rust/signed_doc/src/validator/rules/content.rs
+++ b/rust/signed_doc/src/validator/rules/content.rs
@@ -39,6 +39,7 @@ pub(crate) enum ContentRule {
 
 impl ContentRule {
     /// Field validation rule
+    #[allow(clippy::unused_async)]
     pub(crate) async fn check(
         &self,
         doc: &CatalystSignedDocument,

--- a/rust/signed_doc/src/validator/rules/content.rs
+++ b/rust/signed_doc/src/validator/rules/content.rs
@@ -2,6 +2,8 @@
 
 use std::fmt::Debug;
 
+use minicbor::Encode;
+
 use crate::{
     validator::{json_schema, rules::utils::content_json_schema_check},
     CatalystSignedDocument,
@@ -33,7 +35,6 @@ pub(crate) enum ContentRule {
     /// Document's content must be present and not CBOR `nil`
     NotNil,
     /// Document's content must be a CBOR `nil`
-    #[allow(dead_code)]
     Nil,
 }
 
@@ -53,14 +54,14 @@ impl ContentRule {
             }
         }
         if let Self::NotNil = self {
-            if doc.content().size() == 0 {
+            if doc.content().is_nil() {
                 doc.report()
                     .functional_validation("Document must have a NOT CBOR `nil` content", CONTEXT);
                 return Ok(false);
             }
         }
         if let Self::Nil = self {
-            if doc.content().size() != 0 {
+            if !doc.content().is_nil() {
                 doc.report()
                     .functional_validation("Document must have a CBOR `nil` content", CONTEXT);
                 return Ok(false);

--- a/rust/signed_doc/src/validator/rules/content.rs
+++ b/rust/signed_doc/src/validator/rules/content.rs
@@ -134,6 +134,16 @@ mod tests {
     #[test_case(
         || {
             Builder::new()
+                .with_content(vec![])
+                .build()
+        }
+        => true
+        ;
+        "expected not nil empty content"
+    )]
+    #[test_case(
+        || {
+            Builder::new()
                 .build()
         }
         => false
@@ -165,6 +175,16 @@ mod tests {
         => false
         ;
         "non expected not nil content"
+    )]
+    #[test_case(
+        || {
+            Builder::new()
+                .with_content(vec![])
+                .build()
+        }
+        => false
+        ;
+        "non expected not nil empty"
     )]
     #[tokio::test]
     async fn template_rule_nil_test(doc_gen: impl FnOnce() -> CatalystSignedDocument) -> bool {

--- a/rust/signed_doc/src/validator/rules/content.rs
+++ b/rust/signed_doc/src/validator/rules/content.rs
@@ -1,12 +1,10 @@
-//! `template` rule type impl.
+//! `content` rule type impl.
 
-use std::fmt::{Debug, Write};
+use std::fmt::Debug;
 
 use crate::{
-    metadata::ContentType,
-    providers::CatalystSignedDocumentProvider,
-    validator::{json_schema, rules::doc_ref::doc_refs_check},
-    CatalystSignedDocument, DocType,
+    validator::{json_schema, rules::utils::content_json_schema_check},
+    CatalystSignedDocument,
 };
 
 /// Enum represents different content schemas, against which documents content would be
@@ -30,94 +28,40 @@ impl Debug for ContentSchema {
 /// Document's content validation rule
 #[derive(Debug)]
 pub(crate) enum ContentRule {
-    /// Based on the 'template' field and loaded corresponding template document
-    Templated {
-        /// expected `type` field of the template
-        exp_template_type: DocType,
-    },
     /// Statically defined document's content schema.
-    /// `template` field should not been specified
-    Static(ContentSchema),
-    /// 'template' field is not specified
+    StaticSchema(ContentSchema),
+    /// Document's content must be present and not CBOR `nil`
+    NotNil,
+    /// Document's content must be a CBOR `nil`
     #[allow(dead_code)]
-    NotSpecified,
+    Nil,
 }
 
 impl ContentRule {
     /// Field validation rule
-    pub(crate) async fn check<Provider>(
+    pub(crate) async fn check(
         &self,
         doc: &CatalystSignedDocument,
-        provider: &Provider,
-    ) -> anyhow::Result<bool>
-    where
-        Provider: CatalystSignedDocumentProvider,
-    {
-        let context = "Content/Template rule check";
-        if let Self::Templated { exp_template_type } = self {
-            let Some(template_ref) = doc.doc_meta().template() else {
-                doc.report()
-                    .missing_field("template", &format!("{context}, doc"));
-                return Ok(false);
-            };
-
-            let template_validator = |template_doc: &CatalystSignedDocument| {
-                let Some(template_content_type) = template_doc.doc_content_type() else {
-                    doc.report().missing_field(
-                        "content-type",
-                        &format!("{context}, referenced document must have a content-type field"),
-                    );
-                    return false;
-                };
-                match template_content_type {
-                    ContentType::Json => templated_json_schema_check(doc, template_doc),
-                    ContentType::Cddl
-                    | ContentType::Cbor
-                    | ContentType::JsonSchema
-                    | ContentType::Css
-                    | ContentType::CssHandlebars
-                    | ContentType::Html
-                    | ContentType::HtmlHandlebars
-                    | ContentType::Markdown
-                    | ContentType::MarkdownHandlebars
-                    | ContentType::Plain
-                    | ContentType::PlainHandlebars => {
-                        // TODO: not implemented yet
-                        true
-                    },
-                }
-            };
-
-            return doc_refs_check(
-                template_ref,
-                std::slice::from_ref(exp_template_type),
-                false,
-                "template",
-                provider,
-                doc.report(),
-                template_validator,
-            )
-            .await;
+    ) -> anyhow::Result<bool> {
+        const CONTENXT: &str = "Content rule check";
+        if let Self::StaticSchema(content_schema) = self {
+            match content_schema {
+                ContentSchema::Json(json_schema) => {
+                    return Ok(content_json_schema_check(doc, json_schema))
+                },
+            }
         }
-        if let Self::Static(content_schema) = self {
-            if let Some(template) = doc.doc_meta().template() {
-                doc.report().unknown_field(
-                    "template",
-                    &template.to_string(),
-                    &format!("{context} Static, Document does not expect to have a template field",)
-                );
+        if let Self::NotNil = self {
+            if doc.content().size() == 0 {
+                doc.report()
+                    .functional_validation("Document must have a NOT CBOR `nil` content", CONTENXT);
                 return Ok(false);
             }
-
-            return Ok(content_schema_check(doc, content_schema));
         }
-        if let Self::NotSpecified = self {
-            if let Some(template) = doc.doc_meta().template() {
-                doc.report().unknown_field(
-                    "template",
-                    &template.to_string(),
-                    &format!("{context} Not Specified, Document does not expect to have a template field",)
-                );
+        if let Self::Nil = self {
+            if doc.content().size() != 0 {
+                doc.report()
+                    .functional_validation("Document must have a CBOR `nil` content", CONTENXT);
                 return Ok(false);
             }
         }
@@ -126,364 +70,104 @@ impl ContentRule {
     }
 }
 
-/// Validate a provided `doc` against the `template` content's Json schema, assuming that
-/// the `doc` content is JSON.
-fn templated_json_schema_check(
-    doc: &CatalystSignedDocument,
-    template_doc: &CatalystSignedDocument,
-) -> bool {
-    let Ok(template_content) = template_doc.decoded_content() else {
-        doc.report().functional_validation(
-            "Invalid document content, cannot get decoded bytes",
-            "Cannot get a referenced template document content during the templated validation",
-        );
-        return false;
-    };
-    let Ok(template_json_schema) = serde_json::from_slice(&template_content) else {
-        doc.report().functional_validation(
-            "Template document content must be json encoded",
-            "Invalid referenced template document content",
-        );
-        return false;
-    };
-    let Ok(schema) = json_schema::JsonSchema::try_from(&template_json_schema) else {
-        doc.report().functional_validation(
-            "Template document content must be Draft 7 JSON schema",
-            "Invalid referenced template document content",
-        );
-        return false;
-    };
-
-    content_schema_check(doc, &ContentSchema::Json(schema))
-}
-
-/// Validating the document's content against the provided schema
-fn content_schema_check(
-    doc: &CatalystSignedDocument,
-    schema: &ContentSchema,
-) -> bool {
-    let Ok(doc_content) = doc.decoded_content() else {
-        doc.report().functional_validation(
-            "Invalid Document content, cannot get decoded bytes",
-            "Cannot get a document content during the templated validation",
-        );
-        return false;
-    };
-    if doc_content.is_empty() {
-        doc.report()
-            .missing_field("payload", "Document must have a content");
-        return false;
-    }
-    let Ok(doc_json) = serde_json::from_slice(&doc_content) else {
-        doc.report().functional_validation(
-            "Document content must be json encoded",
-            "Invalid referenced template document content",
-        );
-        return false;
-    };
-
-    match schema {
-        ContentSchema::Json(schema_validator) => {
-            let schema_validation_errors =
-                schema_validator
-                    .iter_errors(&doc_json)
-                    .fold(String::new(), |mut str, e| {
-                        let _ = write!(str, "{{ {e} }}, ");
-                        str
-                    });
-
-            if !schema_validation_errors.is_empty() {
-                doc.report().functional_validation(
-            &format!(
-                "Proposal document content does not compliant with the json schema. [{schema_validation_errors}]"
-            ),
-            "Invalid Proposal document content",
-        );
-                return false;
-            }
-        },
-    }
-    true
-}
-
 #[cfg(test)]
 mod tests {
-    use catalyst_types::uuid::{UuidV4, UuidV7};
+    use test_case::test_case;
 
     use super::*;
-    use crate::{
-        builder::tests::Builder, metadata::SupportedField, providers::tests::TestCatalystProvider,
-        DocLocator, DocumentRef,
-    };
+    use crate::builder::tests::Builder;
 
-    #[allow(clippy::too_many_lines)]
-    #[tokio::test]
-    async fn content_rule_templated_test() {
-        let mut provider = TestCatalystProvider::default();
-
-        let exp_template_type = UuidV4::new();
-        let content_type = ContentType::Json;
-        let json_schema = serde_json::to_vec(&serde_json::json!({})).unwrap();
-        let json_content = serde_json::to_vec(&serde_json::json!({})).unwrap();
-
-        let valid_template_doc_id = UuidV7::new();
-        let another_type_template_doc_id = UuidV7::new();
-        let missing_type_template_doc_id = UuidV7::new();
-        let missing_content_type_template_doc_id = UuidV7::new();
-        let missing_content_template_doc_id = UuidV7::new();
-        let invalid_content_template_doc_id = UuidV7::new();
-
-        // Prepare provider documents
-        {
-            let doc = Builder::new()
-                .with_metadata_field(SupportedField::Id(valid_template_doc_id))
-                .with_metadata_field(SupportedField::Ver(valid_template_doc_id))
-                .with_metadata_field(SupportedField::Type(exp_template_type.into()))
-                .with_metadata_field(SupportedField::ContentType(content_type))
-                .with_content(json_schema.clone())
-                .build();
-            provider.add_document(None, &doc).unwrap();
-
-            // reply doc with other `type` field
-            let ref_doc = Builder::new()
-                .with_metadata_field(SupportedField::Id(another_type_template_doc_id))
-                .with_metadata_field(SupportedField::Ver(another_type_template_doc_id))
-                .with_metadata_field(SupportedField::Type(UuidV4::new().into()))
-                .with_metadata_field(SupportedField::ContentType(content_type))
-                .with_content(json_schema.clone())
-                .build();
-            provider.add_document(None, &ref_doc).unwrap();
-
-            // missing `type` field in the referenced document
-            let ref_doc = Builder::new()
-                .with_metadata_field(SupportedField::Id(missing_type_template_doc_id))
-                .with_metadata_field(SupportedField::Ver(missing_type_template_doc_id))
-                .with_metadata_field(SupportedField::ContentType(content_type))
-                .with_content(json_schema.clone())
-                .build();
-            provider.add_document(None, &ref_doc).unwrap();
-
-            // missing `content-type` field in the referenced document
-            let ref_doc = Builder::new()
-                .with_metadata_field(SupportedField::Id(missing_content_type_template_doc_id))
-                .with_metadata_field(SupportedField::Ver(missing_content_type_template_doc_id))
-                .with_metadata_field(SupportedField::Type(exp_template_type.into()))
-                .with_content(json_schema.clone())
-                .build();
-            provider.add_document(None, &ref_doc).unwrap();
-
-            // missing content
-            let ref_doc = Builder::new()
-                .with_metadata_field(SupportedField::Id(missing_content_template_doc_id))
-                .with_metadata_field(SupportedField::Ver(missing_content_template_doc_id))
-                .with_metadata_field(SupportedField::Type(exp_template_type.into()))
-                .with_metadata_field(SupportedField::ContentType(content_type))
-                .build();
-            provider.add_document(None, &ref_doc).unwrap();
-
-            // invalid content, must be json encoded
-            let ref_doc = Builder::new()
-                .with_metadata_field(SupportedField::Id(invalid_content_template_doc_id))
-                .with_metadata_field(SupportedField::Ver(invalid_content_template_doc_id))
-                .with_metadata_field(SupportedField::Type(exp_template_type.into()))
-                .with_metadata_field(SupportedField::ContentType(content_type))
-                .with_content(vec![])
-                .build();
-            provider.add_document(None, &ref_doc).unwrap();
+    #[test_case(
+        |valid_content| {
+            Builder::new()
+                .with_content(valid_content)
+                .build()
         }
-
-        // Create a document where `templates` field is required and referencing a valid document
-        // in provider. Using doc ref of new implementation.
-        let rule = ContentRule::Templated {
-            exp_template_type: exp_template_type.into(),
-        };
-        let doc = Builder::new()
-            .with_metadata_field(SupportedField::Template(
-                vec![DocumentRef::new(
-                    valid_template_doc_id,
-                    valid_template_doc_id,
-                    DocLocator::default(),
-                )]
-                .into(),
-            ))
-            .with_content(json_content.clone())
-            .build();
-        assert!(rule.check(&doc, &provider).await.unwrap());
-
-        // missing `template` field, but its required
-        let doc = Builder::new().with_content(json_content.clone()).build();
-        assert!(!rule.check(&doc, &provider).await.unwrap());
-
-        // missing content
-        let rule = ContentRule::Templated {
-            exp_template_type: exp_template_type.into(),
-        };
-        let doc = Builder::new()
-            .with_metadata_field(SupportedField::Template(
-                vec![DocumentRef::new(
-                    valid_template_doc_id,
-                    valid_template_doc_id,
-                    DocLocator::default(),
-                )]
-                .into(),
-            ))
-            .build();
-        assert!(!rule.check(&doc, &provider).await.unwrap());
-
-        // content not a json encoded
-        let rule = ContentRule::Templated {
-            exp_template_type: exp_template_type.into(),
-        };
-        let doc = Builder::new()
-            .with_metadata_field(SupportedField::Template(
-                vec![DocumentRef::new(
-                    valid_template_doc_id,
-                    valid_template_doc_id,
-                    DocLocator::default(),
-                )]
-                .into(),
-            ))
-            .with_content(vec![1, 2, 3])
-            .build();
-        assert!(!rule.check(&doc, &provider).await.unwrap());
-
-        // reference to the document with another `type` field
-        let doc = Builder::new()
-            .with_metadata_field(SupportedField::Template(
-                vec![DocumentRef::new(
-                    another_type_template_doc_id,
-                    another_type_template_doc_id,
-                    DocLocator::default(),
-                )]
-                .into(),
-            ))
-            .with_content(json_content.clone())
-            .build();
-        assert!(!rule.check(&doc, &provider).await.unwrap());
-
-        // missing `type` field in the referenced document
-        let doc = Builder::new()
-            .with_metadata_field(SupportedField::Template(
-                vec![DocumentRef::new(
-                    missing_type_template_doc_id,
-                    missing_type_template_doc_id,
-                    DocLocator::default(),
-                )]
-                .into(),
-            ))
-            .with_content(json_content.clone())
-            .build();
-        assert!(!rule.check(&doc, &provider).await.unwrap());
-
-        // missing `content-type` field in the referenced doc
-        let rule = ContentRule::Templated {
-            exp_template_type: exp_template_type.into(),
-        };
-        let doc = Builder::new()
-            .with_metadata_field(SupportedField::Template(
-                vec![DocumentRef::new(
-                    missing_content_type_template_doc_id,
-                    missing_content_type_template_doc_id,
-                    DocLocator::default(),
-                )]
-                .into(),
-            ))
-            .with_content(json_content.clone())
-            .build();
-        assert!(!rule.check(&doc, &provider).await.unwrap());
-
-        // missing content in the referenced document
-        let doc = Builder::new()
-            .with_metadata_field(SupportedField::Template(
-                vec![DocumentRef::new(
-                    missing_content_template_doc_id,
-                    missing_content_template_doc_id,
-                    DocLocator::default(),
-                )]
-                .into(),
-            ))
-            .with_content(json_content.clone())
-            .build();
-        assert!(!rule.check(&doc, &provider).await.unwrap());
-
-        // content not a json encoded in the referenced document
-        let doc = Builder::new()
-            .with_metadata_field(SupportedField::Template(
-                vec![DocumentRef::new(
-                    invalid_content_template_doc_id,
-                    invalid_content_template_doc_id,
-                    DocLocator::default(),
-                )]
-                .into(),
-            ))
-            .with_content(json_content.clone())
-            .build();
-        assert!(!rule.check(&doc, &provider).await.unwrap());
-
-        // cannot find a referenced document
-        let doc = Builder::new()
-            .with_metadata_field(SupportedField::Template(
-                vec![DocumentRef::new(
-                    UuidV7::new(),
-                    UuidV7::new(),
-                    DocLocator::default(),
-                )]
-                .into(),
-            ))
-            .with_content(json_content.clone())
-            .build();
-        assert!(!rule.check(&doc, &provider).await.unwrap());
-    }
-
-    #[allow(clippy::too_many_lines)]
+        => true
+        ;
+        "valid content"
+    )]
+    #[test_case(
+        |_| {
+            Builder::new()
+                .with_content(vec![1, 2, 3])
+                .build()
+        }
+        => false
+        ;
+        "corrupted content"
+    )]
+    #[test_case(
+        |_| {
+            Builder::new()
+                .build()
+        }
+        => false
+        ;
+        "missing content"
+    )]
     #[tokio::test]
-    async fn content_rule_static_test() {
-        let provider = TestCatalystProvider::default();
+    async fn content_rule_specified_test(
+        doc_gen: impl FnOnce(Vec<u8>) -> CatalystSignedDocument
+    ) -> bool {
         let schema = json_schema::JsonSchema::try_from(&serde_json::json!({})).unwrap();
         let content_schema = ContentSchema::Json(schema);
-        let json_content = serde_json::to_vec(&serde_json::json!({})).unwrap();
+        let valid_content = serde_json::to_vec(&serde_json::json!({})).unwrap();
 
-        // all correct
-        let rule = ContentRule::Static(content_schema);
-        let doc = Builder::new().with_content(json_content.clone()).build();
-        assert!(rule.check(&doc, &provider).await.unwrap());
-
-        // missing content
-        let doc = Builder::new().build();
-        assert!(!rule.check(&doc, &provider).await.unwrap());
-
-        // content not a json encoded
-        let doc = Builder::new().with_content(vec![1, 2, 3]).build();
-        assert!(!rule.check(&doc, &provider).await.unwrap());
-
-        // defined `template` field which should be absent
-        let ref_id = UuidV7::new();
-        let ref_ver = UuidV7::new();
-        let doc = Builder::new()
-            .with_metadata_field(SupportedField::Template(
-                vec![DocumentRef::new(ref_id, ref_ver, DocLocator::default())].into(),
-            ))
-            .with_content(json_content)
-            .build();
-        assert!(!rule.check(&doc, &provider).await.unwrap());
+        let rule = ContentRule::StaticSchema(content_schema);
+        let doc = doc_gen(valid_content);
+        rule.check(&doc).await.unwrap()
     }
 
+    #[test_case(
+        || {
+            Builder::new()
+                .with_content(vec![1, 2, 3])
+                .build()
+        }
+        => true
+        ;
+        "expected not nil content"
+    )]
+    #[test_case(
+        || {
+            Builder::new()
+                .build()
+        }
+        => false
+        ;
+        "not expected nil content"
+    )]
     #[tokio::test]
-    async fn template_rule_not_specified_test() {
-        let rule = ContentRule::NotSpecified;
-        let provider = TestCatalystProvider::default();
+    async fn template_rule_not_nil_test(doc_gen: impl FnOnce() -> CatalystSignedDocument) -> bool {
+        let rule = ContentRule::NotNil;
+        let doc = doc_gen();
+        rule.check(&doc).await.unwrap()
+    }
 
-        let doc = Builder::new().build();
-        assert!(rule.check(&doc, &provider).await.unwrap());
-
-        // defined `template` field which should be absent
-        let ref_id = UuidV7::new();
-        let ref_ver = UuidV7::new();
-        let doc = Builder::new()
-            .with_metadata_field(SupportedField::Template(
-                vec![DocumentRef::new(ref_id, ref_ver, DocLocator::default())].into(),
-            ))
-            .build();
-        assert!(!rule.check(&doc, &provider).await.unwrap());
+    #[test_case(
+        || {
+            Builder::new()
+                .build()
+        }
+        => true
+        ;
+        "expected nil content"
+    )]
+    #[test_case(
+        || {
+            Builder::new()
+                .with_content(vec![1, 2, 3])
+                .build()
+        }
+        => false
+        ;
+        "non expected not nil content"
+    )]
+    #[tokio::test]
+    async fn template_rule_nil_test(doc_gen: impl FnOnce() -> CatalystSignedDocument) -> bool {
+        let rule = ContentRule::Nil;
+        let doc = doc_gen();
+        rule.check(&doc).await.unwrap()
     }
 }

--- a/rust/signed_doc/src/validator/rules/mod.rs
+++ b/rust/signed_doc/src/validator/rules/mod.rs
@@ -19,6 +19,8 @@ mod reply;
 mod section;
 mod signature;
 mod signature_kid;
+mod template;
+mod utils;
 mod ver;
 
 pub(crate) use content::{ContentRule, ContentSchema};
@@ -32,6 +34,7 @@ pub(crate) use reply::ReplyRule;
 pub(crate) use section::SectionRule;
 pub(crate) use signature::SignatureRule;
 pub(crate) use signature_kid::SignatureKidRule;
+pub(crate) use template::TemplateRule;
 pub(crate) use ver::VerRule;
 
 /// Struct represented a full collection of rules for all fields
@@ -45,16 +48,18 @@ pub(crate) struct Rules {
     pub(crate) content_type: ContentTypeRule,
     /// 'content-encoding' field validation rule
     pub(crate) content_encoding: ContentEncodingRule,
+    /// 'template' field validation rule
+    pub(crate) template: TemplateRule,
     /// 'ref' field validation rule
     pub(crate) doc_ref: RefRule,
-    /// document's content validation rule
-    pub(crate) content: ContentRule,
     /// 'reply' field validation rule
     pub(crate) reply: ReplyRule,
     /// 'section' field validation rule
     pub(crate) section: SectionRule,
     /// 'parameters' field validation rule
     pub(crate) parameters: ParametersRule,
+    /// document's content validation rule
+    pub(crate) content: ContentRule,
     /// `kid` field validation rule
     pub(crate) kid: SignatureKidRule,
     /// document's signatures validation rule
@@ -78,11 +83,12 @@ impl Rules {
             self.ver.check(doc, provider).boxed(),
             self.content_type.check(doc).boxed(),
             self.content_encoding.check(doc).boxed(),
-            self.content.check(doc, provider).boxed(),
+            self.template.check(doc, provider).boxed(),
             self.doc_ref.check(doc, provider).boxed(),
             self.reply.check(doc, provider).boxed(),
             self.section.check(doc).boxed(),
             self.parameters.check(doc, provider).boxed(),
+            self.content.check(doc).boxed(),
             self.kid.check(doc).boxed(),
             self.signature.check(doc, provider).boxed(),
             self.original_author.check(doc, provider).boxed(),

--- a/rust/signed_doc/src/validator/rules/template.rs
+++ b/rust/signed_doc/src/validator/rules/template.rs
@@ -12,6 +12,7 @@ use crate::{
 /// `reply` field validation rule
 #[derive(Debug)]
 pub(crate) enum TemplateRule {
+    /// Is 'template' specified
     Specified {
         /// allowed `type` field of the template
         allowed_type: DocType,

--- a/rust/signed_doc/src/validator/rules/template.rs
+++ b/rust/signed_doc/src/validator/rules/template.rs
@@ -404,7 +404,7 @@ mod tests {
         }
         => false
         ;
-        "referencing to uknown document"
+        "referencing to unknown document"
     )]
     #[tokio::test]
     async fn template_specified_test(

--- a/rust/signed_doc/src/validator/rules/template.rs
+++ b/rust/signed_doc/src/validator/rules/template.rs
@@ -17,7 +17,6 @@ pub(crate) enum TemplateRule {
         allowed_type: DocType,
     },
     /// 'template' field is not specified
-    #[allow(dead_code)]
     NotSpecified,
 }
 

--- a/rust/signed_doc/src/validator/rules/template.rs
+++ b/rust/signed_doc/src/validator/rules/template.rs
@@ -1,0 +1,476 @@
+//! `template` rule type impl.
+
+use crate::{
+    providers::CatalystSignedDocumentProvider,
+    validator::{
+        json_schema::JsonSchema,
+        rules::{doc_ref::doc_refs_check, utils::content_json_schema_check},
+    },
+    CatalystSignedDocument, ContentType, DocType,
+};
+
+/// `reply` field validation rule
+#[derive(Debug)]
+pub(crate) enum TemplateRule {
+    Specified {
+        /// allowed `type` field of the template
+        allowed_type: DocType,
+    },
+    /// 'template' field is not specified
+    #[allow(dead_code)]
+    NotSpecified,
+}
+
+impl TemplateRule {
+    /// Field validation rule
+    pub(crate) async fn check<Provider>(
+        &self,
+        doc: &CatalystSignedDocument,
+        provider: &Provider,
+    ) -> anyhow::Result<bool>
+    where
+        Provider: CatalystSignedDocumentProvider,
+    {
+        let context = "Template rule check";
+
+        if let Self::Specified { allowed_type } = self {
+            let Some(template_ref) = doc.doc_meta().template() else {
+                doc.report()
+                    .missing_field("template", &format!("{context}, doc"));
+                return Ok(false);
+            };
+
+            let template_validator = |template_doc: &CatalystSignedDocument| {
+                let Some(template_content_type) = template_doc.doc_content_type() else {
+                    doc.report().missing_field(
+                        "content-type",
+                        &format!("{context}, referenced document must have a content-type field"),
+                    );
+                    return false;
+                };
+                match template_content_type {
+                    ContentType::Json | ContentType::JsonSchema => {
+                        templated_json_schema_check(doc, template_doc)
+                    },
+                    ContentType::Cddl
+                    | ContentType::Cbor
+                    | ContentType::Css
+                    | ContentType::CssHandlebars
+                    | ContentType::Html
+                    | ContentType::HtmlHandlebars
+                    | ContentType::Markdown
+                    | ContentType::MarkdownHandlebars
+                    | ContentType::Plain
+                    | ContentType::PlainHandlebars => {
+                        // TODO: not implemented yet
+                        true
+                    },
+                }
+            };
+
+            return doc_refs_check(
+                template_ref,
+                std::slice::from_ref(allowed_type),
+                false,
+                "template",
+                provider,
+                doc.report(),
+                template_validator,
+            )
+            .await;
+        }
+        if let Self::NotSpecified = self {
+            if let Some(template) = doc.doc_meta().template() {
+                doc.report().unknown_field(
+                    "template",
+                    &template.to_string(),
+                    &format!("{context} Not Specified, Document does not expect to have a template field",)
+                );
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
+}
+
+/// Validate a provided `doc` against the `template` content's Json schema, assuming that
+/// the `doc` content is JSON.
+fn templated_json_schema_check(
+    doc: &CatalystSignedDocument,
+    template_doc: &CatalystSignedDocument,
+) -> bool {
+    let Ok(template_content) = template_doc.decoded_content() else {
+        doc.report().functional_validation(
+            "Invalid document content, cannot get decoded bytes",
+            "Cannot get a referenced template document content during the templated validation",
+        );
+        return false;
+    };
+    let Ok(template_json_schema) = serde_json::from_slice(&template_content) else {
+        doc.report().functional_validation(
+            "Template document content must be json encoded",
+            "Invalid referenced template document content",
+        );
+        return false;
+    };
+    let Ok(schema) = JsonSchema::try_from(&template_json_schema) else {
+        doc.report().functional_validation(
+            "Template document content must be Draft 7 JSON schema",
+            "Invalid referenced template document content",
+        );
+        return false;
+    };
+
+    content_json_schema_check(doc, &schema)
+}
+
+#[cfg(test)]
+mod tests {
+    use catalyst_types::uuid::{UuidV4, UuidV7};
+    use test_case::test_case;
+
+    use super::*;
+    use crate::{
+        builder::tests::Builder, metadata::SupportedField, providers::tests::TestCatalystProvider,
+        DocLocator, DocumentRef,
+    };
+
+    #[test_case(
+        |allowed_type, provider| {
+            let json_schema = serde_json::to_vec(&serde_json::json!({})).unwrap();
+            let template_ref = DocumentRef::new(
+                UuidV7::new(),
+                UuidV7::new(),
+                DocLocator::default(),
+            );
+            let doc = Builder::new()
+                .with_metadata_field(SupportedField::Id(*template_ref.id()))
+                .with_metadata_field(SupportedField::Ver(*template_ref.ver()))
+                .with_metadata_field(SupportedField::Type(allowed_type))
+                .with_metadata_field(SupportedField::ContentType(ContentType::Json))
+                .with_content(json_schema)
+                .build();
+            provider.add_document(None, &doc).unwrap();
+
+            let json_content = serde_json::to_vec(&serde_json::json!({})).unwrap();
+            Builder::new()
+                .with_metadata_field(SupportedField::Template(
+                    vec![template_ref].into(),
+                ))
+                .with_content(json_content)
+                .build()
+        }
+        => true
+        ;
+        "content is complied with the referenced template json schema"
+    )]
+    #[test_case(
+        |allowed_type, provider| {
+            let json_schema = serde_json::to_vec(&serde_json::json!({})).unwrap();
+            let template_ref = DocumentRef::new(
+                UuidV7::new(),
+                UuidV7::new(),
+                DocLocator::default(),
+            );
+            let doc = Builder::new()
+                .with_metadata_field(SupportedField::Id(*template_ref.id()))
+                .with_metadata_field(SupportedField::Ver(*template_ref.ver()))
+                .with_metadata_field(SupportedField::Type(allowed_type))
+                .with_metadata_field(SupportedField::ContentType(ContentType::Json))
+                .with_content(json_schema)
+                .build();
+            provider.add_document(None, &doc).unwrap();
+
+            let json_content = serde_json::to_vec(&serde_json::json!({})).unwrap();
+            Builder::new()
+                .with_content(json_content)
+                .build()
+        }
+        => false
+        ;
+        "missing template field"
+    )]
+    #[test_case(
+        |allowed_type, provider| {
+            let json_schema = serde_json::to_vec(&serde_json::json!({})).unwrap();
+            let template_ref = DocumentRef::new(
+                UuidV7::new(),
+                UuidV7::new(),
+                DocLocator::default(),
+            );
+            let doc = Builder::new()
+                .with_metadata_field(SupportedField::Id(*template_ref.id()))
+                .with_metadata_field(SupportedField::Ver(*template_ref.ver()))
+                .with_metadata_field(SupportedField::Type(allowed_type))
+                .with_metadata_field(SupportedField::ContentType(ContentType::Json))
+                .with_content(json_schema)
+                .build();
+            provider.add_document(None, &doc).unwrap();
+
+            Builder::new()
+                .with_metadata_field(SupportedField::Template(
+                    vec![template_ref].into(),
+                ))
+                .build()
+        }
+        => false
+        ;
+        "missing content"
+    )]
+    #[test_case(
+        |allowed_type, provider| {
+            let json_schema = serde_json::to_vec(&serde_json::json!({})).unwrap();
+            let template_ref = DocumentRef::new(
+                UuidV7::new(),
+                UuidV7::new(),
+                DocLocator::default(),
+            );
+            let doc = Builder::new()
+                .with_metadata_field(SupportedField::Id(*template_ref.id()))
+                .with_metadata_field(SupportedField::Ver(*template_ref.ver()))
+                .with_metadata_field(SupportedField::Type(allowed_type))
+                .with_metadata_field(SupportedField::ContentType(ContentType::Json))
+                .with_content(json_schema)
+                .build();
+            provider.add_document(None, &doc).unwrap();
+
+            Builder::new()
+                .with_metadata_field(SupportedField::Template(
+                    vec![template_ref].into(),
+                ))
+                .with_content(vec![1, 2, 3,])
+                .build()
+        }
+        => false
+        ;
+        "content is not valid JSON"
+    )]
+    #[test_case(
+        |_, provider| {
+            let json_schema = serde_json::to_vec(&serde_json::json!({})).unwrap();
+            let template_ref = DocumentRef::new(
+                UuidV7::new(),
+                UuidV7::new(),
+                DocLocator::default(),
+            );
+            let doc = Builder::new()
+                .with_metadata_field(SupportedField::Id(*template_ref.id()))
+                .with_metadata_field(SupportedField::Ver(*template_ref.ver()))
+                .with_metadata_field(SupportedField::Type(UuidV4::new().into()))
+                .with_metadata_field(SupportedField::ContentType(ContentType::Json))
+                .with_content(json_schema)
+                .build();
+            provider.add_document(None, &doc).unwrap();
+
+            let json_content = serde_json::to_vec(&serde_json::json!({})).unwrap();
+            Builder::new()
+                .with_metadata_field(SupportedField::Template(
+                    vec![template_ref].into(),
+                ))
+                .with_content(json_content)
+                .build()
+        }
+        => false
+        ;
+        "wrong 'type' in the referenced template document"
+    )]
+    #[test_case(
+        |_, provider| {
+            let json_schema = serde_json::to_vec(&serde_json::json!({})).unwrap();
+            let template_ref = DocumentRef::new(
+                UuidV7::new(),
+                UuidV7::new(),
+                DocLocator::default(),
+            );
+            let doc = Builder::new()
+                .with_metadata_field(SupportedField::Id(*template_ref.id()))
+                .with_metadata_field(SupportedField::Ver(*template_ref.ver()))
+                .with_metadata_field(SupportedField::ContentType(ContentType::Json))
+                .with_content(json_schema)
+                .build();
+            provider.add_document(None, &doc).unwrap();
+
+            let json_content = serde_json::to_vec(&serde_json::json!({})).unwrap();
+            Builder::new()
+                .with_metadata_field(SupportedField::Template(
+                    vec![template_ref].into(),
+                ))
+                .with_content(json_content)
+                .build()
+        }
+        => false
+        ;
+        "missing 'type' field in the referenced template document"
+    )]
+    #[test_case(
+        |allowed_type, provider| {
+            let json_schema = serde_json::to_vec(&serde_json::json!({})).unwrap();
+            let template_ref = DocumentRef::new(
+                UuidV7::new(),
+                UuidV7::new(),
+                DocLocator::default(),
+            );
+            let doc = Builder::new()
+                .with_metadata_field(SupportedField::Id(*template_ref.id()))
+                .with_metadata_field(SupportedField::Ver(*template_ref.ver()))
+                .with_metadata_field(SupportedField::Type(allowed_type))
+                .with_content(json_schema)
+                .build();
+            provider.add_document(None, &doc).unwrap();
+
+            let json_content = serde_json::to_vec(&serde_json::json!({})).unwrap();
+            Builder::new()
+                .with_metadata_field(SupportedField::Template(
+                    vec![template_ref].into(),
+                ))
+                .with_content(json_content)
+                .build()
+        }
+        => false
+        ;
+        "missing 'content-type' field in the referenced template document'"
+    )]
+    #[test_case(
+        |allowed_type, provider| {
+            let template_ref = DocumentRef::new(
+                UuidV7::new(),
+                UuidV7::new(),
+                DocLocator::default(),
+            );
+            let doc = Builder::new()
+                .with_metadata_field(SupportedField::Id(*template_ref.id()))
+                .with_metadata_field(SupportedField::Ver(*template_ref.ver()))
+                .with_metadata_field(SupportedField::Type(allowed_type))
+                .with_metadata_field(SupportedField::ContentType(ContentType::Json))
+                .build();
+            provider.add_document(None, &doc).unwrap();
+
+            let json_content = serde_json::to_vec(&serde_json::json!({})).unwrap();
+            Builder::new()
+                .with_metadata_field(SupportedField::Template(
+                    vec![template_ref].into(),
+                ))
+                .with_content(json_content)
+                .build()
+        }
+        => false
+        ;
+        "missing content in the referenced template document"
+    )]
+    #[test_case(
+        |allowed_type, provider| {
+            let template_ref = DocumentRef::new(
+                UuidV7::new(),
+                UuidV7::new(),
+                DocLocator::default(),
+            );
+            let doc = Builder::new()
+                .with_metadata_field(SupportedField::Id(*template_ref.id()))
+                .with_metadata_field(SupportedField::Ver(*template_ref.ver()))
+                .with_metadata_field(SupportedField::Type(allowed_type))
+                .with_metadata_field(SupportedField::ContentType(ContentType::Json))
+                .with_content(vec![1,2 ,3])
+                .build();
+            provider.add_document(None, &doc).unwrap();
+
+            let json_content = serde_json::to_vec(&serde_json::json!({})).unwrap();
+            Builder::new()
+                .with_metadata_field(SupportedField::Template(
+                    vec![template_ref].into(),
+                ))
+                .with_content(json_content)
+                .build()
+        }
+        => false
+        ;
+        "content is not a JSON schema in the referenced template document"
+    )]
+    #[test_case(
+        |_, _| {
+            let template_ref = DocumentRef::new(
+                UuidV7::new(),
+                UuidV7::new(),
+                DocLocator::default(),
+            );
+
+            let json_content = serde_json::to_vec(&serde_json::json!({})).unwrap();
+            Builder::new()
+                .with_metadata_field(SupportedField::Template(
+                    vec![template_ref].into(),
+                ))
+                .with_content(json_content)
+                .build()
+        }
+        => false
+        ;
+        "referencing to uknown document"
+    )]
+    #[tokio::test]
+    async fn template_specified_test(
+        doc_gen: impl FnOnce(DocType, &mut TestCatalystProvider) -> CatalystSignedDocument
+    ) -> bool {
+        let mut provider = TestCatalystProvider::default();
+
+        let allowed_type: DocType = UuidV4::new().into();
+
+        let doc = doc_gen(allowed_type.clone(), &mut provider);
+
+        TemplateRule::Specified { allowed_type }
+            .check(&doc, &provider)
+            .await
+            .unwrap()
+    }
+
+    #[test_case(
+        |_, _| {
+            Builder::new()
+                .build()
+        }
+        => true
+        ;
+        "missing 'template' field"
+    )]
+    #[test_case(
+        |allowed_type, provider| {
+            let json_schema = serde_json::to_vec(&serde_json::json!({})).unwrap();
+            let template_ref = DocumentRef::new(
+                UuidV7::new(),
+                UuidV7::new(),
+                DocLocator::default(),
+            );
+            let doc = Builder::new()
+                .with_metadata_field(SupportedField::Id(*template_ref.id()))
+                .with_metadata_field(SupportedField::Ver(*template_ref.ver()))
+                .with_metadata_field(SupportedField::Type(allowed_type))
+                .with_metadata_field(SupportedField::ContentType(ContentType::Json))
+                .with_content(json_schema)
+                .build();
+            provider.add_document(None, &doc).unwrap();
+
+            let json_content = serde_json::to_vec(&serde_json::json!({})).unwrap();
+            Builder::new()
+                .with_metadata_field(SupportedField::Template(
+                    vec![template_ref].into(),
+                ))
+                .with_content(json_content)
+                .build()
+        }
+        => false
+        ;
+        "content is complied with the referenced template json schema for non specified 'template' field"
+    )]
+    #[tokio::test]
+    async fn reply_rule_not_specified_test(
+        doc_gen: impl FnOnce(DocType, &mut TestCatalystProvider) -> CatalystSignedDocument
+    ) -> bool {
+        let allowed_type: DocType = UuidV4::new().into();
+        let mut provider = TestCatalystProvider::default();
+
+        let doc = doc_gen(allowed_type, &mut provider);
+        TemplateRule::NotSpecified
+            .check(&doc, &provider)
+            .await
+            .unwrap()
+    }
+}

--- a/rust/signed_doc/src/validator/rules/utils.rs
+++ b/rust/signed_doc/src/validator/rules/utils.rs
@@ -1,0 +1,51 @@
+//! utility functions for validation rules
+
+use std::fmt::Write;
+
+use crate::{validator::json_schema::JsonSchema, CatalystSignedDocument};
+
+/// Validating the document's content against the provided JSON schema
+pub(crate) fn content_json_schema_check(
+    doc: &CatalystSignedDocument,
+    schema: &JsonSchema,
+) -> bool {
+    const CONTEXT: &str = "Document content JSON schema validation";
+
+    let Ok(doc_content) = doc.decoded_content() else {
+        doc.report().functional_validation(
+            "Invalid Document content, cannot get decoded bytes",
+            CONTEXT,
+        );
+        return false;
+    };
+    if doc_content.is_empty() {
+        doc.report()
+            .missing_field("payload", "Document must have a content");
+        return false;
+    }
+    let Ok(doc_json) = serde_json::from_slice(&doc_content) else {
+        doc.report()
+            .functional_validation("Document content must be json encoded", CONTEXT);
+        return false;
+    };
+
+    let schema_validation_errors =
+        schema
+            .iter_errors(&doc_json)
+            .fold(String::new(), |mut str, e| {
+                let _ = write!(str, "{{ {e} }}, ");
+                str
+            });
+
+    if !schema_validation_errors.is_empty() {
+        doc.report().functional_validation(
+            &format!(
+                "Proposal document content does not compliant with the json schema. [{schema_validation_errors}]"
+            ),
+            CONTEXT,
+        );
+        return false;
+    }
+
+    true
+}


### PR DESCRIPTION
# Description

Refactor and slightly update the current `ContentRule` by splitting it into two validation types `ContentRule` and `TemplateRule` following the latest comment from the issue ticket https://github.com/input-output-hk/catalyst-libs/issues/537#issuecomment-3258071236

## Related Issue(s)

Closes https://github.com/input-output-hk/catalyst-libs/issues/537

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
