### PR TITLE
feat(rust/signed-doc): `SignatureKidRule` initialisation from spec

### DIFF
--- a/rust/catalyst-signed-doc-spec/src/lib.rs
+++ b/rust/catalyst-signed-doc-spec/src/lib.rs
@@ -7,6 +7,7 @@ pub mod doc_types;
 pub mod headers;
 pub mod is_required;
 pub mod metadata;
+pub mod signers;
 
 use std::{collections::HashMap, fmt::Display};
 

--- a/rust/catalyst-signed-doc-spec/src/lib.rs
+++ b/rust/catalyst-signed-doc-spec/src/lib.rs
@@ -13,7 +13,7 @@ use std::{collections::HashMap, fmt::Display};
 
 use build_info as build_info_lib;
 
-use crate::{copyright::Copyright, headers::Headers, metadata::Metadata};
+use crate::{copyright::Copyright, headers::Headers, metadata::Metadata, signers::Signers};
 
 build_info_lib::build_info!(pub(crate) fn build_info);
 
@@ -65,6 +65,7 @@ pub struct DocSpec {
     pub doc_type: String,
     pub headers: Headers,
     pub metadata: Metadata,
+    pub signers: Signers,
 }
 
 impl CatalystSignedDocSpec {

--- a/rust/catalyst-signed-doc-spec/src/signers/mod.rs
+++ b/rust/catalyst-signed-doc-spec/src/signers/mod.rs
@@ -1,0 +1,10 @@
+//! 'signers' field definition
+
+pub mod roles;
+
+/// Document's 'signers' fields definition
+#[derive(serde::Deserialize)]
+#[allow(clippy::missing_docs_in_private_items)]
+pub struct Signers {
+    pub roles: roles::Roles,
+}

--- a/rust/catalyst-signed-doc-spec/src/signers/roles.rs
+++ b/rust/catalyst-signed-doc-spec/src/signers/roles.rs
@@ -1,0 +1,20 @@
+//! 'roles' field definition
+
+/// Document's 'roles' fields definition
+#[derive(serde::Deserialize)]
+#[allow(clippy::missing_docs_in_private_items)]
+pub struct Roles {
+    pub user: Vec<Role>,
+}
+
+/// Role definition
+#[derive(serde::Deserialize)]
+#[allow(clippy::missing_docs_in_private_items)]
+pub enum Role {
+    /// Role 0 - A registered User / Voter - Base Role
+    Registered,
+    /// Registered for posting proposals
+    Proposer,
+    /// Registered as a rep for voting purposes.
+    Representative,
+}

--- a/rust/signed_doc/src/validator/mod.rs
+++ b/rust/signed_doc/src/validator/mod.rs
@@ -57,7 +57,7 @@ fn proposal_rule() -> Rules {
         section: SectionRule::NotSpecified,
         content: ContentRule::NotNil,
         kid: SignatureKidRule {
-            exp: &[RoleId::Proposer],
+            allowed_roles: vec![RoleId::Proposer],
         },
         signature: SignatureRule { mutlisig: false },
         original_author: OriginalAuthorRule,
@@ -103,7 +103,7 @@ fn proposal_comment_rule() -> Rules {
         },
         content: ContentRule::NotNil,
         kid: SignatureKidRule {
-            exp: &[RoleId::Role0],
+            allowed_roles: vec![RoleId::Role0],
         },
         signature: SignatureRule { mutlisig: false },
         original_author: OriginalAuthorRule,
@@ -155,7 +155,7 @@ fn proposal_submission_action_rule() -> Rules {
         section: SectionRule::NotSpecified,
         content: ContentRule::StaticSchema(ContentSchema::Json(proposal_action_json_schema)),
         kid: SignatureKidRule {
-            exp: &[RoleId::Proposer],
+            allowed_roles: vec![RoleId::Proposer],
         },
         signature: SignatureRule { mutlisig: false },
         original_author: OriginalAuthorRule,

--- a/rust/signed_doc/src/validator/rules/mod.rs
+++ b/rust/signed_doc/src/validator/rules/mod.rs
@@ -129,7 +129,7 @@ impl Rules {
                 reply: ReplyRule::NotSpecified,
                 section: SectionRule::NotSpecified,
                 content: ContentRule::Nil,
-                kid: SignatureKidRule { exp: &[] },
+                kid: SignatureKidRule::new(&doc_spec.signers.roles),
                 signature: SignatureRule { mutlisig: false },
                 original_author: OriginalAuthorRule,
             };


### PR DESCRIPTION
# Description

Added an initialisation of `SignatureKidRule` instance from the spec file.

## Related Issue(s)

Closes https://github.com/input-output-hk/catalyst-libs/issues/516

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
