### PR TITLE
fix(rust/signed-doc): Downgrade `build-info-build` as it causes problem in cat-gateway

### DIFF
--- a/rust/signed_doc/Cargo.toml
+++ b/rust/signed_doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catalyst-signed-doc"
-version = "0.0.8"
+version = "0.0.7"
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
# Description

- Release v0.0.8 for catalyst-signed-doc, fixing issue form `build-info-build` when integrating with Catalyst Gateway

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
