### PR TITLE
feat(rust/catalyst-types): Admin roles for the `RoleId` enum

### DIFF
--- a/rust/catalyst-types/Cargo.toml
+++ b/rust/catalyst-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catalyst-types"
-version = "0.0.7"
+version = "0.0.8"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/rust/catalyst-types/src/catalyst_id/role_index.rs
+++ b/rust/catalyst-types/src/catalyst_id/role_index.rs
@@ -51,7 +51,7 @@ pub enum RoleId {
     CampaignAdmin = 106,
     /// Category Admin role.
     CategoryAdmin = 107,
-    /// Mederator role.
+    /// Moderator role.
     Moderator = 108,
     /// A custom role.
     Unknown(u8),

--- a/rust/catalyst-types/src/catalyst_id/role_index.rs
+++ b/rust/catalyst-types/src/catalyst_id/role_index.rs
@@ -31,13 +31,28 @@ pub enum RoleIdError {
 pub enum RoleId {
     /// Primary required role use for voting and commenting.
     Role0 = 0,
-
     /// Delegated representative (dRep) that vote on behalf of delegators.
     DelegatedRepresentative = 1,
-
     /// Proposer that enabling creation, collaboration, and submission of proposals.
     Proposer = 3,
-
+    ///
+    RootCA = 100,
+    ///
+    BrandCA = 101,
+    ///
+    CampaignCA = 102,
+    ///
+    CategoryCA = 103,
+    ///
+    RootAdmin = 104,
+    ///
+    BrandAdmin = 105,
+    ///
+    CampaignAdmin = 106,
+    ///
+    CategoryAdmin = 107,
+    ///
+    Moderator = 108,
     /// A custom role.
     Unknown(u8),
 }
@@ -56,6 +71,15 @@ impl RoleId {
             RoleId::Role0 => 0,
             RoleId::DelegatedRepresentative => 1,
             RoleId::Proposer => 3,
+            RoleId::RootCA => 100,
+            RoleId::BrandCA => 101,
+            RoleId::CampaignCA => 102,
+            RoleId::CategoryCA => 103,
+            RoleId::RootAdmin => 104,
+            RoleId::BrandAdmin => 105,
+            RoleId::CampaignAdmin => 106,
+            RoleId::CategoryAdmin => 107,
+            RoleId::Moderator => 108,
             RoleId::Unknown(b) => b,
         }
     }
@@ -73,6 +97,15 @@ impl From<u8> for RoleId {
             0 => Self::Role0,
             1 => Self::DelegatedRepresentative,
             3 => Self::Proposer,
+            100 => Self::RootCA,
+            101 => Self::BrandCA,
+            102 => Self::CampaignCA,
+            103 => Self::CategoryCA,
+            104 => Self::RootAdmin,
+            105 => Self::BrandAdmin,
+            106 => Self::CampaignAdmin,
+            107 => Self::CategoryAdmin,
+            108 => Self::Moderator,
             b => Self::Unknown(b),
         }
     }

--- a/rust/catalyst-types/src/catalyst_id/role_index.rs
+++ b/rust/catalyst-types/src/catalyst_id/role_index.rs
@@ -35,23 +35,23 @@ pub enum RoleId {
     DelegatedRepresentative = 1,
     /// Proposer that enabling creation, collaboration, and submission of proposals.
     Proposer = 3,
-    ///
+    /// Root Certificate Authority role.
     RootCA = 100,
-    ///
+    /// Brand Certificate Authority role.
     BrandCA = 101,
-    ///
+    /// Campaign Certificate Authority role.
     CampaignCA = 102,
-    ///
+    /// Category Certificate Authority role.
     CategoryCA = 103,
-    ///
+    /// Root Admin role.
     RootAdmin = 104,
-    ///
+    /// Brand Admin role.
     BrandAdmin = 105,
-    ///
+    /// Campaign Admin role.
     CampaignAdmin = 106,
-    ///
+    /// Category Admin role.
     CategoryAdmin = 107,
-    ///
+    /// Mederator role.
     Moderator = 108,
     /// A custom role.
     Unknown(u8),


### PR DESCRIPTION
# Description

Define a new Admin roles as part of the `enum RoleId`.

## Related Issue(s)

Part of https://github.com/input-output-hk/catalyst-internal-docs/issues/266

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
