### PR TITLE
feat(rust/signed-doc): Include admin roles during `SignatureKidRule` initialisation

### DIFF
--- a/rust/catalyst-signed-doc-spec/src/signers/roles.rs
+++ b/rust/catalyst-signed-doc-spec/src/signers/roles.rs
@@ -4,17 +4,52 @@
 #[derive(serde::Deserialize)]
 #[allow(clippy::missing_docs_in_private_items)]
 pub struct Roles {
-    pub user: Vec<Role>,
+    #[serde(default)]
+    pub user: Vec<UserRole>,
+    #[serde(default)]
+    pub admin: Vec<AdminRole>,
 }
 
 /// Role definition
 #[derive(serde::Deserialize)]
 #[allow(clippy::missing_docs_in_private_items)]
-pub enum Role {
+pub enum UserRole {
     /// Role 0 - A registered User / Voter - Base Role
     Registered,
     /// Registered for posting proposals
     Proposer,
     /// Registered as a rep for voting purposes.
     Representative,
+}
+
+#[derive(serde::Deserialize)]
+#[allow(clippy::missing_docs_in_private_items)]
+pub enum AdminRole {
+    /// Root Certificate Authority role.
+    #[serde(rename = "Root CA")]
+    RootCA,
+    /// Brand Certificate Authority role.
+    #[serde(rename = "Brand CA")]
+    BrandCA,
+    /// Campaign Certificate Authority role.
+    #[serde(rename = "Campaign CA")]
+    CampaignCA,
+    /// Category Certificate Authority role.
+    #[serde(rename = "Category CA")]
+    CategoryCA,
+    /// Root Admin role.
+    #[serde(rename = "Root Admin")]
+    RootAdmin,
+    /// Brand Admin role.
+    #[serde(rename = "Brand Admin")]
+    BrandAdmin,
+    /// Campaign Admin role.
+    #[serde(rename = "Campaign Admin")]
+    CampaignAdmin,
+    /// Category Admin role.
+    #[serde(rename = "Category Admin")]
+    CategoryAdmin,
+    /// Moderator role.
+    #[serde(rename = "Moderator")]
+    Moderator,
 }

--- a/rust/signed_doc/Cargo.toml
+++ b/rust/signed_doc/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-catalyst-types = { version = "0.0.7", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "catalyst-types/v0.0.7" }
+catalyst-types = { version = "0.0.8", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "catalyst-types/v0.0.8" }
 cbork-utils = { version = "0.0.2", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "cbork-utils-v0.0.2" }
 
 catalyst-signed-doc-macro = { version = "0.0.1", path = "../catalyst-signed-doc-macro" }

--- a/rust/signed_doc/src/providers.rs
+++ b/rust/signed_doc/src/providers.rs
@@ -7,10 +7,12 @@ use ed25519_dalek::VerifyingKey;
 
 use crate::{CatalystSignedDocument, DocumentRef};
 
-/// `VerifyingKey` Provider trait
-pub trait VerifyingKeyProvider: Send + Sync {
-    /// Try to get `VerifyingKey`
-    fn try_get_key(
+/// `CatalystId` Provider trait
+pub trait CatalystIdProvider: Send + Sync {
+    /// Try to get `VerifyingKey` by the provided `CatalystId` and corresponding `RoleId`
+    /// and `KeyRotation` Return `None` if the provided `CatalystId` with the
+    /// corresponding `RoleId` and `KeyRotation` has not been registered.
+    fn try_get_registered_key(
         &self,
         kid: &CatalystId,
     ) -> impl Future<Output = anyhow::Result<Option<VerifyingKey>>> + Send;
@@ -48,8 +50,8 @@ pub mod tests {
     use std::{collections::HashMap, time::Duration};
 
     use super::{
-        CatalystId, CatalystSignedDocument, CatalystSignedDocumentProvider, VerifyingKey,
-        VerifyingKeyProvider,
+        CatalystId, CatalystIdProvider, CatalystSignedDocument, CatalystSignedDocumentProvider,
+        VerifyingKey,
     };
     use crate::{DocLocator, DocumentRef};
 
@@ -123,8 +125,8 @@ pub mod tests {
         }
     }
 
-    impl VerifyingKeyProvider for TestCatalystProvider {
-        async fn try_get_key(
+    impl CatalystIdProvider for TestCatalystProvider {
+        async fn try_get_registered_key(
             &self,
             kid: &CatalystId,
         ) -> anyhow::Result<Option<VerifyingKey>> {

--- a/rust/signed_doc/src/validator/mod.rs
+++ b/rust/signed_doc/src/validator/mod.rs
@@ -17,7 +17,7 @@ use crate::{
         PROPOSAL_COMMENT_FORM_TEMPLATE, PROPOSAL_FORM_TEMPLATE, PROPOSAL_SUBMISSION_ACTION,
     },
     metadata::DocType,
-    providers::{CatalystSignedDocumentProvider, VerifyingKeyProvider},
+    providers::{CatalystIdProvider, CatalystSignedDocumentProvider},
     validator::rules::{CollaboratorsRule, SignatureRule, TemplateRule},
     CatalystSignedDocument, ContentEncoding, ContentType,
 };
@@ -196,7 +196,7 @@ pub async fn validate<Provider>(
     provider: &Provider,
 ) -> anyhow::Result<bool>
 where
-    Provider: CatalystSignedDocumentProvider + VerifyingKeyProvider,
+    Provider: CatalystSignedDocumentProvider + CatalystIdProvider,
 {
     let Ok(doc_type) = doc.doc_type() else {
         doc.report().missing_field(

--- a/rust/signed_doc/src/validator/rules/mod.rs
+++ b/rust/signed_doc/src/validator/rules/mod.rs
@@ -4,7 +4,7 @@
 use futures::FutureExt;
 
 use crate::{
-    providers::{CatalystSignedDocumentProvider, VerifyingKeyProvider},
+    providers::{CatalystIdProvider, CatalystSignedDocumentProvider},
     CatalystSignedDocument,
 };
 
@@ -80,7 +80,7 @@ impl Rules {
         provider: &Provider,
     ) -> anyhow::Result<bool>
     where
-        Provider: CatalystSignedDocumentProvider + VerifyingKeyProvider,
+        Provider: CatalystSignedDocumentProvider + CatalystIdProvider,
     {
         let rules = [
             self.id.check(doc, provider).boxed(),
@@ -139,7 +139,7 @@ impl Rules {
                 section: SectionRule::NotSpecified,
                 collaborators: CollaboratorsRule::NotSpecified,
                 content: ContentRule::new(&doc_spec.payload)?,
-                kid: SignatureKidRule::new(&doc_spec.signers.roles),
+                kid: SignatureKidRule::new(&doc_spec.signers.roles)?,
                 signature: SignatureRule { mutlisig: false },
                 original_author: OriginalAuthorRule,
             };

--- a/rust/signed_doc/src/validator/rules/signature.rs
+++ b/rust/signed_doc/src/validator/rules/signature.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use catalyst_types::problem_report::ProblemReport;
 
 use crate::{
-    providers::{CatalystSignedDocumentProvider, VerifyingKeyProvider},
+    providers::{CatalystIdProvider, CatalystSignedDocumentProvider},
     signature::{tbs_data, Signature},
     CatalystSignedDocument,
 };
@@ -28,7 +28,7 @@ impl SignatureRule {
         provider: &Provider,
     ) -> anyhow::Result<bool>
     where
-        Provider: CatalystSignedDocumentProvider + VerifyingKeyProvider,
+        Provider: CatalystSignedDocumentProvider + CatalystIdProvider,
     {
         if doc.signatures().is_empty() {
             doc.report().other(
@@ -74,11 +74,11 @@ async fn validate_signature<Provider>(
     report: &ProblemReport,
 ) -> anyhow::Result<bool>
 where
-    Provider: VerifyingKeyProvider,
+    Provider: CatalystIdProvider,
 {
     let kid = sign.kid();
 
-    let Some(pk) = provider.try_get_key(kid).await? else {
+    let Some(pk) = provider.try_get_registered_key(kid).await? else {
         report.other(
             &format!("Missing public key for {kid}."),
             "During public key extraction",


### PR DESCRIPTION
# Description

Modifying `SignatureKidRule::new` method, by including Admin roles into the `allowed_roles` set.

## Related Issue(s)

Part of https://github.com/input-output-hk/catalyst-internal-docs/issues/266

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
