### PR TITLE
feat(rust/signed-doc): Signed Document validation rules change

### DIFF
--- a/rust/signed_doc/src/validator/mod.rs
+++ b/rust/signed_doc/src/validator/mod.rs
@@ -61,7 +61,7 @@ fn document_rules_init() -> HashMap<Uuid, Rules> {
         },
         parameters: ParametersRule::Specified {
             exp_parameters_type: expect_uuidv4(CATEGORY_DOCUMENT_UUID_TYPE),
-            optional: true,
+            optional: false,
         },
         doc_ref: RefRule::NotSpecified,
         reply: ReplyRule::NotSpecified,
@@ -92,8 +92,11 @@ fn document_rules_init() -> HashMap<Uuid, Rules> {
             exp_reply_type: expect_uuidv4(COMMENT_DOCUMENT_UUID_TYPE),
             optional: true,
         },
-        section: SectionRule::Specified { optional: true },
-        parameters: ParametersRule::NotSpecified,
+        parameters: ParametersRule::Specified {
+            exp_parameters_type: expect_uuidv4(CATEGORY_DOCUMENT_UUID_TYPE),
+            optional: false,
+        },
+        section: SectionRule::NotSpecified,
         kid: SignatureKidRule {
             exp: &[RoleId::Role0],
         },
@@ -120,7 +123,7 @@ fn document_rules_init() -> HashMap<Uuid, Rules> {
         content: ContentRule::Static(ContentSchema::Json(proposal_action_json_schema)),
         parameters: ParametersRule::Specified {
             exp_parameters_type: expect_uuidv4(CATEGORY_DOCUMENT_UUID_TYPE),
-            optional: true,
+            optional: false,
         },
         doc_ref: RefRule::Specified {
             exp_ref_type: expect_uuidv4(PROPOSAL_DOCUMENT_UUID_TYPE),

--- a/rust/signed_doc/src/validator/mod.rs
+++ b/rust/signed_doc/src/validator/mod.rs
@@ -96,7 +96,7 @@ fn document_rules_init() -> HashMap<Uuid, Rules> {
             exp_parameters_type: expect_uuidv4(CATEGORY_DOCUMENT_UUID_TYPE),
             optional: false,
         },
-        section: SectionRule::NotSpecified,
+        section: SectionRule::Specified { optional: true },
         kid: SignatureKidRule {
             exp: &[RoleId::Role0],
         },

--- a/rust/signed_doc/src/validator/rules/parameters.rs
+++ b/rust/signed_doc/src/validator/rules/parameters.rs
@@ -19,6 +19,7 @@ pub(crate) enum ParametersRule {
         optional: bool,
     },
     /// `parameters` is not specified
+    #[allow(dead_code)]
     NotSpecified,
 }
 

--- a/rust/signed_doc/src/validator/rules/section.rs
+++ b/rust/signed_doc/src/validator/rules/section.rs
@@ -5,6 +5,7 @@ use crate::CatalystSignedDocument;
 /// `section` field validation rule
 pub(crate) enum SectionRule {
     /// Is 'section' specified
+    #[allow(dead_code)]
     Specified {
         /// optional flag for the `section` field
         optional: bool,


### PR DESCRIPTION
# Description

Updating the existing validation rules initialisation for the `Proposal`, `Comment` and `Proposal Submission Action` documents.