### PR TITLE
chore(rust/rbac-registration): Bump the rbac-registration crate version

### DIFF
--- a/rust/rbac-registration/Cargo.toml
+++ b/rust/rbac-registration/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rbac-registration"
 description = "Role Based Access Control Registration"
 keywords = ["cardano", "catalyst", "rbac registration"]
-version = "0.0.11"
+version = "0.0.12"
 authors = [
     "Arissara Chotivichit <arissara.chotivichit@iohk.io>"
 ]
@@ -34,5 +34,5 @@ thiserror = "2.0.11"
 
 c509-certificate = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "c509-certificate-v0.0.3" }
 cbork-utils = { version = "0.0.2", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "cbork-utils-v0.0.2" }
-cardano-blockchain-types = { version = "0.0.6", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "cardano-blockchain-types/v0.0.6" }
+cardano-blockchain-types = { version = "0.0.7", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "cardano-blockchain-types/v0.0.7" }
 catalyst-types = { version = "0.0.8", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "catalyst-types/v0.0.8" }

--- a/rust/rbac-registration/src/cardano/cip509/validation.rs
+++ b/rust/rbac-registration/src/cardano/cip509/validation.rs
@@ -357,7 +357,7 @@ fn validate_x509_self_signed_cert(
 #[allow(clippy::similar_names)]
 pub fn validate_role_data(
     metadata: &Cip509RbacMetadata,
-    subnet: Network,
+    subnet: &Network,
     report: &ProblemReport,
 ) -> Option<CatalystId> {
     let context = "Role data validation";
@@ -474,7 +474,7 @@ pub fn validate_role_data(
 fn validate_role_0(
     role: &RoleData,
     metadata: &Cip509RbacMetadata,
-    subnet: Network,
+    subnet: &Network,
     context: &str,
     report: &ProblemReport,
 ) -> Option<CatalystId> {


### PR DESCRIPTION
# Description

Bump the `rbac-registration` crate version.

## Related Pull Requests

https://github.com/input-output-hk/catalyst-libs/pull/593
