### PR TITLE
feat(rust/catalyst-types): New `catalyst types` crate version `v0.0.9`

### DIFF
--- a/rust/catalyst-types/Cargo.toml
+++ b/rust/catalyst-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catalyst-types"
-version = "0.0.8"
+version = "0.0.9"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true


### PR DESCRIPTION
# Description

Bumping a `catalyst types` crate to version `v0.0.9`, preparing for a new release.