### PR TITLE
feat(rust/cardano-blockchain-types): Bump `catalyst-types` version for `cardano-blockchain-types`

### DIFF
--- a/rust/cardano-blockchain-types/Cargo.toml
+++ b/rust/cardano-blockchain-types/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cardano-blockchain-types"
 description = "Common Cardano Blockchain data types for use in both applications and crates"
 keywords = ["cardano", "catalyst", ]
-version = "0.0.7"
+version = "0.0.8"
 authors = [
     "Steven Johnson <steven.johnson@iohk.io>"
 ]
@@ -18,7 +18,7 @@ crate-type = ["cdylib", "rlib"]
 workspace = true
 
 [dependencies]
-catalyst-types = { version = "0.0.9", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "catalyst-types/v0.0.9" }
+catalyst-types = { version = "0.0.10", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "catalyst-types/v0.0.10" }
 cbork-utils = { version = "0.0.2", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "cbork-utils-v0.0.2" }
 
 ouroboros = "0.18.4"


### PR DESCRIPTION
# Description

Using the latest release of `catalyst-types` crate for `cardano-blockchain-types` and preparing an new version of `cardano-blockchain-types`.

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
