### PR TITLE
fix(rust/signed-doc): Replacing `SystemTime::now` with `Utc::now`

### DIFF
--- a/rust/signed_doc/Cargo.toml
+++ b/rust/signed_doc/Cargo.toml
@@ -27,6 +27,7 @@ jsonschema = "0.28.3"
 jsonpath-rust = "0.7.5"
 futures = "0.3.31"
 ed25519-bip32 = "0.4.1" # used by the `mk_signed_doc` cli tool
+chrono = "0.4.42"
 
 
 [dev-dependencies]


### PR DESCRIPTION
# Description

Replacing the usage of `SystemTime::now` with `Utc::now`.

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
