### PR TITLE
chore(catalyst-ci): Update catalyst-ci to v3.5.28

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,8 +1,8 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/mdlint:v3.5.27 AS mdlint-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cspell:v3.5.27 AS cspell-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/python:v3.5.27 AS python-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/mdlint:v3.5.28 AS mdlint-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cspell:v3.5.28 AS cspell-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/python:v3.5.28 AS python-ci
 IMPORT github.com/input-output-hk/catalyst-ci:v3.5.27 AS cat-ci
 
 FROM debian:stable-slim

--- a/docs/Earthfile
+++ b/docs/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.5.27 AS docs-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.5.28 AS docs-ci
 
 IMPORT .. AS repo
 

--- a/docs/src/architecture/08_concepts/catalyst_voting/cddl/Earthfile
+++ b/docs/src/architecture/08_concepts/catalyst_voting/cddl/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:v3.5.27 AS cddl-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:v3.5.28 AS cddl-ci
 
 check-cddl:
     FROM cddl-ci+cddl-base

--- a/docs/src/architecture/08_concepts/immutable_ledger/cddl/Earthfile
+++ b/docs/src/architecture/08_concepts/immutable_ledger/cddl/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:v3.5.27 AS cddl-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:v3.5.28 AS cddl-ci
 
 check-cddl:
     FROM cddl-ci+cddl-base

--- a/docs/src/architecture/08_concepts/signed_doc/cddl/Earthfile
+++ b/docs/src/architecture/08_concepts/signed_doc/cddl/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:v3.5.27 AS cddl-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:v3.5.28 AS cddl-ci
 
 check-cddl:
     FROM cddl-ci+cddl-base

--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.5.27 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.5.28 AS rust-ci
 IMPORT ../ AS repo-ci
 
 COPY_SRC:

--- a/specs/Earthfile
+++ b/specs/Earthfile
@@ -1,8 +1,8 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/python:v3.5.27 AS python-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/debian:v3.5.27 AS debian
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cue:v3.5.27 AS cue
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/python:v3.5.28 AS python-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/debian:v3.5.28 AS debian
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cue:v3.5.28 AS cue
 
 IMPORT ../docs AS docs
 

--- a/utilities/docs-preview/Earthfile
+++ b/utilities/docs-preview/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.5.27 AS docs-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.5.28 AS docs-ci
 
 # update-docs-dev-script: get the latest docs dev script from CI.
 update-docs-dev-script:


### PR DESCRIPTION
Update catalyst-ci to v3.5.28. Release: https://github.com/input-output-hk/catalyst-ci/releases/tag/v3.5.28