### PR TITLE
chore(deps): Bump `hermes-ipfs` version

### DIFF
--- a/rust/hermes-ipfs/Cargo.toml
+++ b/rust/hermes-ipfs/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "hermes-ipfs"
-version = "0.0.5"
+version = "0.0.6"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true


### PR DESCRIPTION
# Description

Bump the version of `hermes-ipfs` to `0.0.6`.
