### PR TITLE
feat(rust/cardano-chain-follower): Bump `cardano-chain-follower` with the latest cardano-blockchain-types `0.0.9` version

### DIFF
--- a/rust/cardano-chain-follower/Cargo.toml
+++ b/rust/cardano-chain-follower/Cargo.toml
@@ -60,7 +60,7 @@ test-log = { version = "0.2.16", default-features = false, features = [
     "trace",
 ] }
 clap = "4.5.23"
-rbac-registration = { version = "0.0.14", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "rbac-registration/v0.0.14" }
+rbac-registration = { version = "0.0.15", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "rbac-registration/v0.0.15" }
 minicbor = { version = "2.0.0", features = ["alloc", "half"] }
 
 # Note, these features are for support of features exposed by dependencies.


### PR DESCRIPTION
# Description

Preparation for a new release of `cardano-chain-follower` with the latest `cardano-blockchain-types` `0.0.9` version