### PR TITLE
chore(catalyst-ci): Update catalyst-ci to v3.6.5

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,8 +1,8 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/mdlint:v3.6.1 AS mdlint-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cspell:v3.6.1 AS cspell-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/python:v3.6.1 AS python-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/mdlint:v3.6.5 AS mdlint-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cspell:v3.6.5 AS cspell-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/python:v3.6.5 AS python-ci
 IMPORT github.com/input-output-hk/catalyst-ci:v3.6.0 AS cat-ci
 
 FROM debian:stable-slim

--- a/docs/Earthfile
+++ b/docs/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.6.1 AS docs-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.6.5 AS docs-ci
 
 IMPORT .. AS repo
 

--- a/docs/src/architecture/08_concepts/signed_doc/cddl/Earthfile
+++ b/docs/src/architecture/08_concepts/signed_doc/cddl/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:v3.6.1 AS cddl-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:v3.6.5 AS cddl-ci
 
 check-cddl:
     FROM cddl-ci+cddl-base

--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.6.1 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.6.5 AS rust-ci
 IMPORT ../ AS repo-ci
 
 COPY_SRC:

--- a/specs/Earthfile
+++ b/specs/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/python:v3.6.1 AS python-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/python:v3.6.5 AS python-ci
 
 IMPORT ../docs AS docs
 

--- a/utilities/docs-preview/Earthfile
+++ b/utilities/docs-preview/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.6.1 AS docs-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.6.5 AS docs-ci
 
 # update-docs-dev-script: get the latest docs dev script from CI.
 update-docs-dev-script:


### PR DESCRIPTION
Update catalyst-ci to v3.6.5. Release: https://github.com/input-output-hk/catalyst-ci/releases/tag/v3.6.5