### PR TITLE
feat(rust/rbac-registration): private `Cip0134UriSet`

### DIFF
--- a/rust/rbac-registration/src/cardano/cip509/mod.rs
+++ b/rust/rbac-registration/src/cardano/cip509/mod.rs
@@ -9,7 +9,7 @@ pub use types::{
     CertKeyHash, CertOrPk, KeyLocalRef, LocalRefInt, Payment, PaymentHistory, PointData,
     PointTxnIdx, RoleData, RoleDataRecord, TxInputHash, ValidationSignature,
 };
-pub use utils::{Cip0134UriSet, extract_key};
+pub(crate) use utils::{Cip0134UriSet, extract_key};
 
 #[allow(clippy::module_inception)]
 mod cip509;

--- a/rust/rbac-registration/src/cardano/cip509/rbac/metadata.rs
+++ b/rust/rbac-registration/src/cardano/cip509/rbac/metadata.rs
@@ -28,9 +28,9 @@ use crate::cardano::cip509::{
 #[allow(clippy::module_name_repetitions)]
 pub struct Cip509RbacMetadata {
     /// A potentially empty list of x509 certificates.
-    pub x509_certs: Vec<X509DerCert>,
+    pub(crate) x509_certs: Vec<X509DerCert>,
     /// A potentially empty list of c509 certificates.
-    pub c509_certs: Vec<C509Cert>,
+    pub(crate) c509_certs: Vec<C509Cert>,
     /// A set of URIs contained in both x509 and c509 certificates.
     ///
     /// URIs from different certificate types are stored separately and certificate
@@ -38,21 +38,21 @@ pub struct Cip509RbacMetadata {
     ///
     /// This field isn't present in the encoded format and is populated by processing both
     /// `x509_certs` and `c509_certs` fields.
-    pub certificate_uris: Cip0134UriSet,
+    pub(crate) certificate_uris: Cip0134UriSet,
     /// A list of public keys that can be used instead of storing full certificates.
     ///
     /// Check [this section] to understand how certificates and the public keys list are
     /// related.
     ///
     /// [this section]: https://github.com/input-output-hk/catalyst-CIPs/tree/x509-role-registration-metadata/CIP-XXXX#storing-certificates-and-public-key
-    pub pub_keys: Vec<SimplePublicKeyType>,
+    pub(crate) pub_keys: Vec<SimplePublicKeyType>,
     /// A potentially empty list of revoked certificates.
-    pub revocation_list: Vec<CertKeyHash>,
+    pub(crate) revocation_list: Vec<CertKeyHash>,
     /// A potentially empty role data.
-    pub role_data: HashMap<RoleId, RoleData>,
+    pub(crate) role_data: HashMap<RoleId, RoleData>,
     /// Optional map of purpose key data.
     /// Empty map if no purpose key data is present.
-    pub purpose_key_data: HashMap<u16, Vec<u8>>,
+    pub(crate) purpose_key_data: HashMap<u16, Vec<u8>>,
 }
 
 /// The first valid purpose key.

--- a/rust/rbac-registration/src/cardano/cip509/utils/cip134_uri_set.rs
+++ b/rust/rbac-registration/src/cardano/cip509/utils/cip134_uri_set.rs
@@ -30,7 +30,7 @@ type UrisMap = HashMap<usize, Box<[Cip0134Uri]>>;
 /// This structure uses [`Arc`] internally, so it is cheap to clone.
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[allow(clippy::module_name_repetitions)]
-pub struct Cip0134UriSet(Arc<Cip0134UriSetInner>);
+pub(crate) struct Cip0134UriSet(Arc<Cip0134UriSetInner>);
 
 /// Internal `Cip0134UriSet` data.
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/rust/rbac-registration/src/cardano/cip509/utils/mod.rs
+++ b/rust/rbac-registration/src/cardano/cip509/utils/mod.rs
@@ -2,6 +2,6 @@
 
 pub mod cip19;
 pub mod extract_key;
-pub use cip134_uri_set::Cip0134UriSet;
+pub(crate) use cip134_uri_set::Cip0134UriSet;
 
 mod cip134_uri_set;


### PR DESCRIPTION
# Description

Making `Cip0134UriSet` to not expose it for the public usage, as its an internal implementation detail of the `rbac-registration` library.

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
