### PR TITLE
feat(rust/rbac-registration): Expose some `Cip0134UriSet` data

### DIFF
--- a/rust/rbac-registration/src/cardano/cip509/cip509.rs
+++ b/rust/rbac-registration/src/cardano/cip509/cip509.rs
@@ -310,7 +310,7 @@ impl Cip509 {
 
     /// Returns URIs contained in both x509 and c509 certificates of `Cip509` metadata.
     #[must_use]
-    pub(crate) fn certificate_uris(&self) -> Option<&Cip0134UriSet> {
+    pub fn certificate_uris(&self) -> Option<&Cip0134UriSet> {
         self.metadata.as_ref().map(|m| &m.certificate_uris)
     }
 

--- a/rust/rbac-registration/src/cardano/cip509/mod.rs
+++ b/rust/rbac-registration/src/cardano/cip509/mod.rs
@@ -9,7 +9,7 @@ pub use types::{
     CertKeyHash, CertOrPk, KeyLocalRef, LocalRefInt, Payment, PaymentHistory, PointData,
     PointTxnIdx, RoleData, RoleDataRecord, TxInputHash, ValidationSignature,
 };
-pub(crate) use utils::{Cip0134UriSet, extract_key};
+pub use utils::{Cip0134UriSet, extract_key};
 
 #[allow(clippy::module_inception)]
 mod cip509;

--- a/rust/rbac-registration/src/cardano/cip509/utils/cip134_uri_set.rs
+++ b/rust/rbac-registration/src/cardano/cip509/utils/cip134_uri_set.rs
@@ -30,7 +30,7 @@ type UrisMap = HashMap<usize, Box<[Cip0134Uri]>>;
 /// This structure uses [`Arc`] internally, so it is cheap to clone.
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[allow(clippy::module_name_repetitions)]
-pub(crate) struct Cip0134UriSet(Arc<Cip0134UriSetInner>);
+pub struct Cip0134UriSet(Arc<Cip0134UriSetInner>);
 
 /// Internal `Cip0134UriSet` data.
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -74,7 +74,7 @@ impl Cip0134UriSet {
     }
 
     /// Returns an iterator over of `Cip0134Uri`.
-    pub(crate) fn values(&self) -> impl Iterator<Item = &Cip0134Uri> {
+    pub fn values(&self) -> impl Iterator<Item = &Cip0134Uri> {
         self.x_uris()
             .values()
             .chain(self.c_uris().values())
@@ -82,8 +82,8 @@ impl Cip0134UriSet {
     }
 
     /// Returns `true` if both x509 and c509 certificate maps are empty.
-    #[cfg(test)]
-    pub(crate) fn is_empty(&self) -> bool {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
         self.x_uris().is_empty() && self.c_uris().is_empty()
     }
 
@@ -124,7 +124,7 @@ impl Cip0134UriSet {
 
     /// Returns a set of all active (without taken) stake addresses.
     #[must_use]
-    pub(crate) fn stake_addresses(&self) -> HashSet<StakeAddress> {
+    pub fn stake_addresses(&self) -> HashSet<StakeAddress> {
         self.values()
             .filter_map(|uri| {
                 match uri.address() {

--- a/rust/rbac-registration/src/cardano/cip509/utils/mod.rs
+++ b/rust/rbac-registration/src/cardano/cip509/utils/mod.rs
@@ -2,6 +2,6 @@
 
 pub mod cip19;
 pub mod extract_key;
-pub(crate) use cip134_uri_set::Cip0134UriSet;
+pub use cip134_uri_set::Cip0134UriSet;
 
 mod cip134_uri_set;

--- a/rust/rbac-registration/src/registration/cardano/mod.rs
+++ b/rust/rbac-registration/src/registration/cardano/mod.rs
@@ -320,6 +320,12 @@ impl RegistrationChain {
             .and_then(|rdr| rdr.encryption_key_from_rotation(rotation))
     }
 
+    /// Returns most recent URIs contained from both x509 and c509 certificates.
+    #[must_use]
+    pub fn certificate_uris(&self) -> &Cip0134UriSet {
+        &self.inner.certificate_uris
+    }
+
     /// Returns all stake addresses associated to this chain.
     #[must_use]
     pub fn stake_addresses(&self) -> HashSet<StakeAddress> {


### PR DESCRIPTION
# Description

Chaning visibility scope for the `Cip0134UriSet` by making some methods of `Cip0134UriSet`, `Cip509` and `RegistrationChain` types  public.

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
