### PR TITLE
feat(rust/rbac-registration): New `rbac-registration`  version `0.0.15`

### DIFF
--- a/rust/rbac-registration/Cargo.toml
+++ b/rust/rbac-registration/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rbac-registration"
 description = "Role Based Access Control Registration"
 keywords = ["cardano", "catalyst", "rbac registration"]
-version = "0.0.14"
+version = "0.0.15"
 authors = [
     "Arissara Chotivichit <arissara.chotivichit@iohk.io>"
 ]


### PR DESCRIPTION
# Description

Bumping `rbac-registration` crate version to `0.0.15`