### PR TITLE
chore(general): Bump cat-ci versions to `v3.6.6`

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -3,8 +3,8 @@ VERSION 0.8
 IMPORT github.com/input-output-hk/catalyst-ci/earthly/mdlint:v3.6.6 AS mdlint-ci
 IMPORT github.com/input-output-hk/catalyst-ci/earthly/cspell:v3.6.6 AS cspell-ci
 IMPORT github.com/input-output-hk/catalyst-ci/earthly/python:v3.6.6 AS python-ci
-IMPORT github.com/input-output-hk/catalyst-ci:v3.6.0 AS cat-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/debian:v3.6.1 AS debian
+IMPORT github.com/input-output-hk/catalyst-ci:v3.6.6 AS cat-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/debian:v3.6.6 AS debian
 
 
 # check-markdown : markdown check using catalyst-ci.

--- a/rust/c509-certificate/Earthfile
+++ b/rust/c509-certificate/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust::v3.6.1 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust::v3.6.6 AS rust-ci
 
 IMPORT .. AS rust-local
 IMPORT ../.. AS repo


### PR DESCRIPTION
# Description

Bumping cat-ci version to `v3.6.6` for some targets.