### PR TITLE
feat(rust/signed-doc): Use `catalyst-signed-doc-spec` to `0.2.2`

### DIFF
--- a/rust/signed_doc/Cargo.toml
+++ b/rust/signed_doc/Cargo.toml
@@ -16,7 +16,7 @@ cbork-utils = { version = "0.0.3", git = "https://github.com/input-output-hk/cat
 
 # When updating the specification version, it should also be updated for the `catalyst-signed-doc-macro` crate.
 catalyst-signed-doc-macro = { version = "0.0.1", path = "../catalyst-signed-doc-macro" }
-catalyst-signed-doc-spec = { version = "0.2.1", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "catalyst-signed-doc-spec/v0.2.1" }
+catalyst-signed-doc-spec = { version = "0.2.2", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "catalyst-signed-doc-spec/v0.2.2" }
 
 anyhow = "1.0.95"
 serde = { version = "1.0.217", features = ["derive"] }

--- a/rust/signed_doc/src/tests_utils/rep_nomination.rs
+++ b/rust/signed_doc/src/tests_utils/rep_nomination.rs
@@ -2,7 +2,7 @@ use ed25519_dalek::ed25519::signature::Signer;
 
 use crate::{
     Builder, CatalystSignedDocument, ContentEncoding, ContentType, catalyst_id::role_index::RoleId,
-    doc_types, providers::tests::TestCatalystProvider, tests_utils::create_dummy_key_pair,
+    doc_types, providers::tests::TestCatalystProvider, tests_utils::get_doc_kid_and_sk,
     uuid::UuidV7,
 };
 
@@ -14,8 +14,9 @@ pub fn rep_nomination_doc(
     provider: &mut TestCatalystProvider,
 ) -> anyhow::Result<CatalystSignedDocument> {
     let id = UuidV7::new();
-    let (sk, kid) = create_dummy_key_pair(RoleId::DelegatedRepresentative);
-    provider.add_sk(kid.clone(), sk.clone());
+    let (sk, kid) = get_doc_kid_and_sk(provider, ref_doc, 0)
+        .map(|(sk, kid)| (sk, kid.with_role(RoleId::DelegatedRepresentative)))
+        .inspect(|(sk, kid)| provider.add_sk(kid.clone(), sk.clone()))?;
 
     let template_ref = template_doc.doc_ref()?;
     let ref_ref = ref_doc.doc_ref()?;

--- a/rust/signed_doc/tests/rep_nomination.rs
+++ b/rust/signed_doc/tests/rep_nomination.rs
@@ -5,7 +5,7 @@ use catalyst_signed_doc::{
     providers::tests::TestCatalystProvider,
     tests_utils::{
         brand_parameters_doc, brand_parameters_form_template_doc, contest_parameters_doc,
-        contest_parameters_form_template_doc, create_dummy_key_pair, rep_nomination_doc,
+        contest_parameters_form_template_doc, get_doc_kid_and_sk, rep_nomination_doc,
         rep_nomination_form_template_doc, rep_profile_doc, rep_profile_form_template_doc,
     },
     *,
@@ -39,8 +39,9 @@ use test_case::test_case;
         let contest = contest_parameters_doc(&template, &brand, provider).inspect(|v| provider.add_document(v).unwrap())?;
         let template = rep_nomination_form_template_doc(&contest, provider).inspect(|v| provider.add_document(v).unwrap())?;
         let id = uuid::UuidV7::new();
-        let (sk, kid) = create_dummy_key_pair(RoleId::Role0);
-        provider.add_sk(kid.clone(), sk.clone());
+        let (sk, kid) = get_doc_kid_and_sk(provider, &rep_profile, 0)
+            .map(|(sk, kid)| (sk, kid.with_role(RoleId::Role0)))
+            .inspect(|(sk, kid)| provider.add_sk(kid.clone(), sk.clone()))?;
 
         let template_ref = template.doc_ref()?;
         let ref_ref = rep_profile.doc_ref()?;
@@ -75,8 +76,9 @@ use test_case::test_case;
         let contest = contest_parameters_doc(&template, &brand, provider).inspect(|v| provider.add_document(v).unwrap())?;
         let template = rep_nomination_form_template_doc(&contest, provider).inspect(|v| provider.add_document(v).unwrap())?;
         let id = uuid::UuidV7::new();
-        let (sk, kid) = create_dummy_key_pair(RoleId::DelegatedRepresentative);
-        provider.add_sk(kid.clone(), sk.clone());
+        let (sk, kid) = get_doc_kid_and_sk(provider, &rep_profile, 0)
+            .map(|(sk, kid)| (sk, kid.with_role(RoleId::DelegatedRepresentative)))
+            .inspect(|(sk, kid)| provider.add_sk(kid.clone(), sk.clone()))?;
 
         let template_ref = template.doc_ref()?;
         let ref_ref = rep_profile.doc_ref()?;
@@ -111,8 +113,9 @@ use test_case::test_case;
         let contest = contest_parameters_doc(&template, &brand, provider).inspect(|v| provider.add_document(v).unwrap())?;
         let template = rep_nomination_form_template_doc(&contest, provider).inspect(|v| provider.add_document(v).unwrap())?;
         let id = uuid::UuidV7::new();
-        let (sk, kid) = create_dummy_key_pair(RoleId::DelegatedRepresentative);
-        provider.add_sk(kid.clone(), sk.clone());
+        let (sk, kid) = get_doc_kid_and_sk(provider, &rep_profile, 0)
+            .map(|(sk, kid)| (sk, kid.with_role(RoleId::DelegatedRepresentative)))
+            .inspect(|(sk, kid)| provider.add_sk(kid.clone(), sk.clone()))?;
 
         let template_ref = template.doc_ref()?;
         let ref_ref = rep_profile.doc_ref()?;
@@ -145,8 +148,9 @@ use test_case::test_case;
         let template = contest_parameters_form_template_doc(&brand, provider).inspect(|v| provider.add_document(v).unwrap())?;
         let contest = contest_parameters_doc(&template, &brand, provider).inspect(|v| provider.add_document(v).unwrap())?;
         let id = uuid::UuidV7::new();
-        let (sk, kid) = create_dummy_key_pair(RoleId::DelegatedRepresentative);
-        provider.add_sk(kid.clone(), sk.clone());
+        let (sk, kid) = get_doc_kid_and_sk(provider, &rep_profile, 0)
+            .map(|(sk, kid)| (sk, kid.with_role(RoleId::DelegatedRepresentative)))
+            .inspect(|(sk, kid)| provider.add_sk(kid.clone(), sk.clone()))?;
 
         let ref_ref = rep_profile.doc_ref()?;
         let parameters_ref = contest.doc_ref()?;
@@ -173,12 +177,15 @@ use test_case::test_case;
     |provider| {
         let template = brand_parameters_form_template_doc(provider).inspect(|v| provider.add_document(v).unwrap())?;
         let brand = brand_parameters_doc(&template, provider).inspect(|v| provider.add_document(v).unwrap())?;
+        let template = rep_profile_form_template_doc(&brand, provider).inspect(|v| provider.add_document(v).unwrap())?;
+        let rep_profile = rep_profile_doc(&template, &brand, provider).inspect(|v| provider.add_document(v).unwrap())?;
         let template = contest_parameters_form_template_doc(&brand, provider).inspect(|v| provider.add_document(v).unwrap())?;
         let contest = contest_parameters_doc(&template, &brand, provider).inspect(|v| provider.add_document(v).unwrap())?;
         let template = rep_nomination_form_template_doc(&contest, provider).inspect(|v| provider.add_document(v).unwrap())?;
         let id = uuid::UuidV7::new();
-        let (sk, kid) = create_dummy_key_pair(RoleId::DelegatedRepresentative);
-        provider.add_sk(kid.clone(), sk.clone());
+        let (sk, kid) = get_doc_kid_and_sk(provider, &rep_profile, 0)
+            .map(|(sk, kid)| (sk, kid.with_role(RoleId::DelegatedRepresentative)))
+            .inspect(|(sk, kid)| provider.add_sk(kid.clone(), sk.clone()))?;
 
         let template_ref = template.doc_ref()?;
         let parameters_ref = contest.doc_ref()?;
@@ -211,8 +218,9 @@ use test_case::test_case;
         let contest = contest_parameters_doc(&template, &brand, provider).inspect(|v| provider.add_document(v).unwrap())?;
         let template = rep_nomination_form_template_doc(&contest, provider).inspect(|v| provider.add_document(v).unwrap())?;
         let id = uuid::UuidV7::new();
-        let (sk, kid) = create_dummy_key_pair(RoleId::DelegatedRepresentative);
-        provider.add_sk(kid.clone(), sk.clone());
+        let (sk, kid) = get_doc_kid_and_sk(provider, &rep_profile, 0)
+            .map(|(sk, kid)| (sk, kid.with_role(RoleId::DelegatedRepresentative)))
+            .inspect(|(sk, kid)| provider.add_sk(kid.clone(), sk.clone()))?;
 
         let template_ref = template.doc_ref()?;
         let ref_ref = rep_profile.doc_ref()?;


### PR DESCRIPTION
# Description

Use `catalyst-signed-doc-spec` to `0.2.2` for `catalyst-signed-doc` crate.
Update `Rep Nomination` tests

## Related Issue(s)

Closes https://github.com/input-output-hk/catalyst-libs/issues/710

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
