### PR TITLE
feat(rust/signed-doc): `catalyst-signed-doc-spec` WASM compatible

### DIFF
--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -99,6 +99,7 @@ build:
     END
 
     DO ./catalyst-types+WASM_BUILD
+    DO ./catalyst-signed-doc-spec+WASM_BUILD
 
     SAVE ARTIFACT target/doc doc
     SAVE ARTIFACT target/release/cbork cbork

--- a/rust/catalyst-signed-doc-spec/Cargo.toml
+++ b/rust/catalyst-signed-doc-spec/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-catalyst-types = { version = "0.0.11", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "catalyst-types/v0.0.11" }
+catalyst-types = { version = "0.0.12", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "catalyst-types/v0.0.12" }
 #cbork-cddl-parser = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "cbork-cddl-parser/v0.0.3" }
 
 serde_json = "1.0.145"

--- a/rust/catalyst-signed-doc-spec/Earthfile
+++ b/rust/catalyst-signed-doc-spec/Earthfile
@@ -1,0 +1,10 @@
+VERSION 0.8
+
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.6.9 AS rust-ci
+
+# wasm32-wasip2
+WASM_BUILD:
+    FUNCTION
+
+    DO rust-ci+EXECUTE \
+            --cmd="cargo b --release -p catalyst-signed-doc-spec --target wasm32-wasip2"


### PR DESCRIPTION
# Description

Apply the latest `catalyst-types` crate version, which is fully WASM compatible.

## Related Issue(s)

Part of https://github.com/input-output-hk/catalyst-libs/issues/725

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
