### PR TITLE
chore(catalyst-ci): Update catalyst-ci to v3.6.10

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,10 +1,10 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/mdlint:v3.6.9 AS mdlint-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cspell:v3.6.9 AS cspell-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/python:v3.6.9 AS python-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/mdlint:v3.6.10 AS mdlint-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cspell:v3.6.10 AS cspell-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/python:v3.6.10 AS python-ci
 IMPORT github.com/input-output-hk/catalyst-ci:v3.6.9 AS cat-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/debian:v3.6.9 AS debian
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/debian:v3.6.10 AS debian
 
 
 # check-markdown : markdown check using catalyst-ci.

--- a/catalyst-python/Earthfile
+++ b/catalyst-python/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/python:v3.6.9 AS python-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/python:v3.6.10 AS python-ci
 
 builder:
     FROM python-ci+python-base

--- a/docs/Earthfile
+++ b/docs/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.6.9 AS docs-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.6.10 AS docs-ci
 
 IMPORT .. AS repo
 

--- a/docs/src/architecture/08_concepts/signed_doc/cddl/Earthfile
+++ b/docs/src/architecture/08_concepts/signed_doc/cddl/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:v3.6.9 AS cddl-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cddl:v3.6.10 AS cddl-ci
 
 check-cddl:
     FROM cddl-ci+cddl-base

--- a/rust/Earthfile
+++ b/rust/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.6.9 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.6.10 AS rust-ci
 IMPORT ../ AS repo-ci
 
 COPY_SRC:

--- a/rust/catalyst-signed-doc-spec/Earthfile
+++ b/rust/catalyst-signed-doc-spec/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.6.9 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.6.10 AS rust-ci
 
 # wasm32-wasip2
 WASM_BUILD:

--- a/rust/catalyst-types/Earthfile
+++ b/rust/catalyst-types/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.6.9 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.6.10 AS rust-ci
 
 # wasm32-wasip2
 WASM_BUILD:

--- a/specs/Earthfile
+++ b/specs/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/python:v3.6.9 AS python-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/python:v3.6.10 AS python-ci
 
 IMPORT ../docs AS docs
 

--- a/utilities/docs-preview/Earthfile
+++ b/utilities/docs-preview/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.6.9 AS docs-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.6.10 AS docs-ci
 
 # update-docs-dev-script: get the latest docs dev script from CI.
 update-docs-dev-script:


### PR DESCRIPTION
Update catalyst-ci to v3.6.10. Release: https://github.com/input-output-hk/catalyst-ci/releases/tag/v3.6.10