### PR TITLE
fix(rust/hermes-ipfs): Fix `add_ipfs_file` and `get_ipfs_file`

### DIFF
--- a/.config/dictionaries/project.dic
+++ b/.config/dictionaries/project.dic
@@ -8,8 +8,8 @@ adminer
 admon
 anypolicy
 apskhem
-asat
 Arissara
+asat
 asyncio
 Attributes
 auditability
@@ -27,10 +27,10 @@ blockdiag
 blockfetch
 blosc
 bmac
-bytemuck
 Bogale
 bootstrapper
 BROTLI
+bytemuck
 Cabe
 cantopen
 cardano
@@ -55,6 +55,7 @@ ciphertexts
 Coap
 codegen
 codepoints
+codetable
 Collab
 connexa
 coti
@@ -255,8 +256,8 @@ pubk
 pubkey
 publickey
 pubspec
-pycardano
 pwrite
+pycardano
 pycodestyle
 pydantic
 pydot

--- a/rust/hermes-ipfs/Cargo.toml
+++ b/rust/hermes-ipfs/Cargo.toml
@@ -31,6 +31,7 @@ catalyst-types = { version = "0.0.11", git = "https://github.com/input-output-hk
 tracing = "0.1.43"
 rand = "0.9.2"
 blake3 = { version = "1.8.2", optional = true }
+multihash-codetable = "0.1.4"
 
 [dev-dependencies]
 # Dependencies used by examples

--- a/rust/hermes-ipfs/Cargo.toml
+++ b/rust/hermes-ipfs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermes-ipfs"
-version = "0.0.10"
+version = "0.0.11"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/rust/hermes-ipfs/Cargo.toml
+++ b/rust/hermes-ipfs/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 workspace = true
 
 [features]
-doc-sync = ["minicbor", "ed25519-dalek", "catalyst-types", "blake3"]
+doc-sync = ["ed25519-dalek", "catalyst-types", "blake3"]
 
 [dependencies]
 anyhow = "1.0.100"
@@ -25,7 +25,7 @@ tokio = "1.46.0"
 futures = "0.3.31"
 libp2p = "0.56.0"
 connexa = { version = "0.4.1", features = ["full"] }
-minicbor = { version = "0.25.1", features = ["alloc", "derive", "half"], optional = true }
+minicbor = { version = "0.25.1", features = ["alloc", "derive", "half"] }
 ed25519-dalek = { version = "2.1.1", optional = true }
 catalyst-types = { version = "0.0.11", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "catalyst-types/v0.0.11", optional = true }
 tracing = "0.1.43"

--- a/rust/hermes-ipfs/examples/add-file-with-pinning.rs
+++ b/rust/hermes-ipfs/examples/add-file-with-pinning.rs
@@ -65,7 +65,7 @@ async fn main() -> anyhow::Result<()> {
     println!("");
     println!("* Retrieving from {ipfs_path}");
     let get_file_bytes = hermes_ipfs
-        .get_ipfs_file(
+        .get_ipfs_file_cbor(
             ipfs_path
                 .root()
                 .cid()

--- a/rust/hermes-ipfs/examples/add-file-with-pinning.rs
+++ b/rust/hermes-ipfs/examples/add-file-with-pinning.rs
@@ -25,7 +25,7 @@ async fn main() -> anyhow::Result<()> {
     println!("* Adding file to IPFS:");
     println!("");
     let ipfs_file = b"This is a demo file that is stored in IPFS.".to_vec();
-    let ipfs_path = hermes_ipfs.add_ipfs_file(ipfs_file.into()).await?;
+    let ipfs_path = hermes_ipfs.add_ipfs_file(ipfs_file).await?;
     println!("* IPFS file published at {ipfs_path}");
     let cid = ipfs_path.root().cid().ok_or(anyhow::anyhow!(
         "ERROR! Could not extract CID from IPFS path."
@@ -64,7 +64,14 @@ async fn main() -> anyhow::Result<()> {
     println!("* Get file from IPFS:");
     println!("");
     println!("* Retrieving from {ipfs_path}");
-    let get_file_bytes = hermes_ipfs.get_ipfs_file(ipfs_path.into()).await?;
+    let get_file_bytes = hermes_ipfs
+        .get_ipfs_file(
+            ipfs_path
+                .root()
+                .cid()
+                .ok_or(anyhow::anyhow!("Could not get CID"))?,
+        )
+        .await?;
     println!("* Got file, {} bytes:", get_file_bytes.len());
     let get_file = String::from_utf8(get_file_bytes)?;
     println!("* FILE CONTENTS:");

--- a/rust/hermes-ipfs/examples/hermes-ipfs-cli.rs
+++ b/rust/hermes-ipfs/examples/hermes-ipfs-cli.rs
@@ -63,15 +63,21 @@ async fn main() -> anyhow::Result<()> {
         Commands::AddFile => {
             println!("Adding file");
             let contents = lipsum(42);
-            let ipfs_path = hermes_node
-                .add_ipfs_file(contents.into_bytes().into())
-                .await?;
+            let ipfs_path = hermes_node.add_ipfs_file(contents.into_bytes()).await?;
             println!("Added file: {ipfs_path}");
         },
         Commands::GetFile { ipfs_path_str } => {
             println!("Getting file");
             let ipfs_path: IpfsPath = ipfs_path_str.parse()?;
-            let get_file_bytes = hermes_node.get_ipfs_file(ipfs_path.into()).await?;
+            let get_file_bytes = hermes_node
+                .get_ipfs_file(
+                    ipfs_path
+                        .root()
+                        .cid()
+                        .ok_or(anyhow::anyhow!("Could not get CID"))?,
+                )
+                .await?;
+
             println!("* Got file, {} bytes:", get_file_bytes.len());
             let get_file = String::from_utf8(get_file_bytes)?;
             println!("* FILE CONTENTS:");

--- a/rust/hermes-ipfs/examples/hermes-ipfs-cli.rs
+++ b/rust/hermes-ipfs/examples/hermes-ipfs-cli.rs
@@ -70,7 +70,7 @@ async fn main() -> anyhow::Result<()> {
             println!("Getting file");
             let ipfs_path: IpfsPath = ipfs_path_str.parse()?;
             let get_file_bytes = hermes_node
-                .get_ipfs_file(
+                .get_ipfs_file_cbor(
                     ipfs_path
                         .root()
                         .cid()

--- a/rust/hermes-ipfs/examples/provide-content-dht.rs
+++ b/rust/hermes-ipfs/examples/provide-content-dht.rs
@@ -87,7 +87,7 @@ async fn main() -> anyhow::Result<()> {
     println!("");
     // Fetch the content from the `ipfs_path`.
     let fetched_bytes = hermes_ipfs_b
-        .get_ipfs_file(
+        .get_ipfs_file_cbor(
             ipfs_path
                 .root()
                 .cid()

--- a/rust/hermes-ipfs/examples/provide-content-dht.rs
+++ b/rust/hermes-ipfs/examples/provide-content-dht.rs
@@ -22,7 +22,7 @@ async fn connect_node_a_upload_and_provide(
     println!("***************************************");
     println!("* Adding file to IPFS:");
     println!("");
-    let ipfs_path = hermes_ipfs.add_ipfs_file(file_content.into()).await?;
+    let ipfs_path = hermes_ipfs.add_ipfs_file(file_content).await?;
     println!("* IPFS file published at {ipfs_path}");
     let cid = ipfs_path.root().cid().ok_or(anyhow::anyhow!(
         "ERROR! Could not extract CID from IPFS path."
@@ -85,12 +85,14 @@ async fn main() -> anyhow::Result<()> {
     println!("***************************************");
     println!("* Get content from IPFS path {ipfs_path}");
     println!("");
-    // For illustration, the `ipfs_path` can be obtained from a known CID
-    let ipfs_path_string = format!("{ipfs_path}");
-
     // Fetch the content from the `ipfs_path`.
     let fetched_bytes = hermes_ipfs_b
-        .get_ipfs_file(ipfs_path_string.parse()?)
+        .get_ipfs_file(
+            ipfs_path
+                .root()
+                .cid()
+                .ok_or(anyhow::anyhow!("Could not get CID"))?,
+        )
         .await?;
     assert_eq!(ipfs_file, fetched_bytes);
     let fetched_file = String::from_utf8(fetched_bytes)?;

--- a/rust/hermes-ipfs/src/constant.rs
+++ b/rust/hermes-ipfs/src/constant.rs
@@ -1,0 +1,20 @@
+//! Define constant needed for IPFS and Document Sync
+
+/// Current document synchronization protocol version.
+#[allow(dead_code)]
+pub(crate) const PROTOCOL_VERSION: u8 = 1;
+
+/// `CID` version that Doc Sync supports.
+#[allow(dead_code)]
+pub(crate) const CID_VERSION: u8 = 1;
+
+/// `CID` multihash digest size that Doc Sync supports.
+#[allow(dead_code)]
+pub(crate) const CID_DIGEST_SIZE: u8 = 32;
+
+/// Multihash SHA256.
+#[allow(dead_code)]
+pub(crate) const MULTIHASH_SHA256: u8 = 0x12;
+
+/// Codec CBOR.
+pub(crate) const CODEC_CBOR: u8 = 0x51;

--- a/rust/hermes-ipfs/src/doc_sync/envelope.rs
+++ b/rust/hermes-ipfs/src/doc_sync/envelope.rs
@@ -102,7 +102,7 @@ impl EnvelopePayload {
         let seq: UuidV7 = decoder.decode_with(&mut CborContext::Tagged)?;
         let ver = decoder.u64()?;
 
-        if ver != <u8 as Into<T>>::into(PROTOCOL_VERSION) {
+        if ver != u64::from(PROTOCOL_VERSION) {
             return Err(minicbor::decode::Error::message(format!(
                 "unsupported protocol version: {ver}"
             )));
@@ -172,7 +172,7 @@ impl<'b, C> Decode<'b, C> for EnvelopePayload {
         let seq: UuidV7 = d.decode_with(&mut CborContext::Tagged)?;
         let ver = d.u64()?;
 
-        if ver != <u8 as Into<T>>::into(PROTOCOL_VERSION) {
+        if ver != u64::from(PROTOCOL_VERSION) {
             return Err(minicbor::decode::Error::message(format!(
                 "unsupported protocol version: {ver}"
             )));

--- a/rust/hermes-ipfs/src/doc_sync/envelope.rs
+++ b/rust/hermes-ipfs/src/doc_sync/envelope.rs
@@ -102,7 +102,7 @@ impl EnvelopePayload {
         let seq: UuidV7 = decoder.decode_with(&mut CborContext::Tagged)?;
         let ver = decoder.u64()?;
 
-        if ver != <u8 as Into<T>>::into(PROTOCOL_VERSION) { {
+        if ver != <u8 as Into<T>>::into(PROTOCOL_VERSION) {
             return Err(minicbor::decode::Error::message(format!(
                 "unsupported protocol version: {ver}"
             )));
@@ -173,7 +173,7 @@ impl<'b, C> Decode<'b, C> for EnvelopePayload {
         let ver = d.u64()?;
 
         if ver != <u8 as Into<T>>::into(PROTOCOL_VERSION) {
-               return Err(minicbor::decode::Error::message(format!(
+            return Err(minicbor::decode::Error::message(format!(
                 "unsupported protocol version: {ver}"
             )));
         }

--- a/rust/hermes-ipfs/src/doc_sync/envelope.rs
+++ b/rust/hermes-ipfs/src/doc_sync/envelope.rs
@@ -102,7 +102,7 @@ impl EnvelopePayload {
         let seq: UuidV7 = decoder.decode_with(&mut CborContext::Tagged)?;
         let ver = decoder.u64()?;
 
-        if ver != PROTOCOL_VERSION.into() {
+        if ver != <u8 as Into<T>>::into(PROTOCOL_VERSION) { {
             return Err(minicbor::decode::Error::message(format!(
                 "unsupported protocol version: {ver}"
             )));
@@ -172,8 +172,8 @@ impl<'b, C> Decode<'b, C> for EnvelopePayload {
         let seq: UuidV7 = d.decode_with(&mut CborContext::Tagged)?;
         let ver = d.u64()?;
 
-        if ver != PROTOCOL_VERSION.into() {
-            return Err(minicbor::decode::Error::message(format!(
+        if ver != <u8 as Into<T>>::into(PROTOCOL_VERSION) {
+               return Err(minicbor::decode::Error::message(format!(
                 "unsupported protocol version: {ver}"
             )));
         }

--- a/rust/hermes-ipfs/src/doc_sync/mod.rs
+++ b/rust/hermes-ipfs/src/doc_sync/mod.rs
@@ -12,26 +12,13 @@ pub use envelope::{Envelope, EnvelopePayload};
 use minicbor::{Decode, Encode, Encoder, decode, encode::Write};
 pub use state_machine::{StateMachine, StateSnapshot, SyncState};
 
-/// Current document synchronization protocol version.
-const PROTOCOL_VERSION: u64 = 1;
-
-/// `CID` version that Doc Sync supports.
-const CID_VERSION: u8 = 1;
-
-/// `CID` codec that Doc Sync supports (CBOR).
-const CID_CODEC: u8 = 0x51;
-
-/// `CID` multihash code that Doc Sync supports (SHA256).
-const CID_MULTIHASH_CODE: u8 = 0x12;
-
-/// `CID` multihash digest size that Doc Sync supports.
-const CID_DIGEST_SIZE: u8 = 32;
+use crate::constant::{CID_DIGEST_SIZE, CID_VERSION, CODEC_CBOR, MULTIHASH_SHA256};
 
 /// Validates CID according to Doc Sync specification constraints.
 fn validate_cid(cid: &crate::Cid) -> bool {
     cid.version() as u8 == CID_VERSION
-        && cid.codec() == u64::from(CID_CODEC)
-        && cid.hash().code() == u64::from(CID_MULTIHASH_CODE)
+        && cid.codec() == u64::from(CODEC_CBOR)
+        && cid.hash().code() == u64::from(MULTIHASH_SHA256)
         && cid.hash().digest().len() == usize::from(CID_DIGEST_SIZE)
 }
 

--- a/rust/hermes-ipfs/src/doc_sync/payload.rs
+++ b/rust/hermes-ipfs/src/doc_sync/payload.rs
@@ -544,13 +544,16 @@ mod tests {
     mod body {
         use minicbor::data::{Tag, Token};
 
+        use crate::constant::{CID_DIGEST_SIZE, CODEC_CBOR, MULTIHASH_SHA256, PROTOCOL_VERSION};
+
         // Generates a valid Doc Sync `CID` (according to the spec).
         const fn generate_cid(seed: u8) -> [u8; 36] {
-            const VERSION: u8 = 1;
-            const CODEC_CBOR: u8 = 0x51;
-            const CODE_SHA_256: u8 = 0x12;
-            const DIGEST_32: u8 = 0x20;
-            let prefix = [VERSION, CODEC_CBOR, CODE_SHA_256, DIGEST_32];
+            let prefix = [
+                PROTOCOL_VERSION,
+                CODEC_CBOR,
+                MULTIHASH_SHA256,
+                CID_DIGEST_SIZE,
+            ];
             let mut ret = [seed; 36];
             ret.split_at_mut(prefix.len()).0.copy_from_slice(&prefix);
             ret

--- a/rust/hermes-ipfs/src/lib.rs
+++ b/rust/hermes-ipfs/src/lib.rs
@@ -229,12 +229,16 @@ impl HermesIpfs {
     }
 
     /// Get file with provider
-    pub async fn get_ipfs_file_cbor_with_provider(
+    pub async fn get_ipfs_file_cbor_with_providers(
         &self,
         cid: &Cid,
-        peer_id: PeerId,
     ) -> anyhow::Result<Vec<u8>> {
-        let block = self.node.get_block(cid).provider(peer_id).await?;
+        let mut providers = self.node.get_providers(cid.clone()).await?;
+        let mut provider_list = Vec::new();
+        while let Some(Ok(peer_set)) = providers.next().await {
+            provider_list.extend(peer_set);
+        }
+        let block = self.node.get_block(cid).providers(provider_list).await?;
         Ok(block.data().to_vec())
     }
 

--- a/rust/hermes-ipfs/src/lib.rs
+++ b/rust/hermes-ipfs/src/lib.rs
@@ -206,13 +206,18 @@ impl HermesIpfs {
     pub async fn get_ipfs_file_cbor(
         &self,
         cid: &Cid,
-        peer_id: Option<PeerId>,
     ) -> anyhow::Result<Vec<u8>> {
-        let block = match peer_id {
-            Some(peer_id) => self.node.get_block(cid).provider(peer_id).await?,
-            None => self.node.get_block(cid).await?,
-        };
+        let block = self.node.get_block(cid).await?;
+        Ok(block.data().to_vec())
+    }
 
+    /// Get file with provider
+    pub async fn get_ipfs_file_cbor_with_provider(
+        &self,
+        cid: &Cid,
+        peer_id: PeerId,
+    ) -> anyhow::Result<Vec<u8>> {
+        let block = self.node.get_block(cid).provider(peer_id).await?;
         Ok(block.data().to_vec())
     }
 

--- a/rust/hermes-ipfs/src/lib.rs
+++ b/rust/hermes-ipfs/src/lib.rs
@@ -36,9 +36,6 @@ use rust_ipfs::{
     dag::ResolveError, dummy, gossipsub::IntoGossipsubTopic,
 };
 
-/// Codec for Hermes CID.
-const CODEC_CBOR: u64 = 0x51;
-
 #[derive(Debug, Display, From, Into)]
 /// `PubSub` Message ID.
 pub struct MessageId(pub PubsubMessageId);
@@ -180,6 +177,9 @@ impl HermesIpfs {
         &self,
         data: Vec<u8>,
     ) -> anyhow::Result<IpfsPath> {
+        /// Codec for Hermes CID.
+        const CODEC_CBOR: u64 = 0x51;
+
         let cbor_data = minicbor::to_vec(data)
             .map_err(|e| anyhow::anyhow!("Failed to encode data to CBOR: {e:?}"))?;
         let cid = Cid::new_v1(CODEC_CBOR, Code::Sha2_256.digest(&cbor_data));

--- a/rust/hermes-ipfs/src/lib.rs
+++ b/rust/hermes-ipfs/src/lib.rs
@@ -204,10 +204,11 @@ impl HermesIpfs {
     /// Returns an error if the file fails to download.
     pub async fn get_ipfs_file(
         &self,
-        ipfs_path: GetIpfsFile,
+        cid: Cid,
+        _ipfs_path: GetIpfsFile,
     ) -> anyhow::Result<Vec<u8>> {
-        let stream_bytes = self.node.cat_unixfs(ipfs_path).await?;
-        Ok(stream_bytes.to_vec())
+        let block = self.node.get_block(cid).await?;
+        Ok(block.data().to_vec())
     }
 
     /// Pin content to IPFS.

--- a/rust/hermes-ipfs/src/lib.rs
+++ b/rust/hermes-ipfs/src/lib.rs
@@ -33,7 +33,7 @@ pub use rust_ipfs::path::IpfsPath;
 pub use rust_ipfs::repo::StorageTypes;
 use rust_ipfs::{
     Block, GossipsubMessage, NetworkBehaviour, Quorum, ToRecordKey, builder::IpfsBuilder,
-    dag::ResolveError, dummy, gossipsub::IntoGossipsubTopic, unixfs::AddOpt,
+    dag::ResolveError, dummy, gossipsub::IntoGossipsubTopic,
 };
 
 /// Codec for Hermes CID.
@@ -617,56 +617,6 @@ impl HermesIpfs {
 impl From<Ipfs> for HermesIpfs {
     fn from(node: Ipfs) -> Self {
         Self { node }
-    }
-}
-
-/// File that will be added to IPFS
-pub enum AddIpfsFile {
-    /// Path in local disk storage to the file.
-    Path(std::path::PathBuf),
-    /// Stream of file bytes, with an optional name.
-    /// **NOTE** current implementation of `rust-ipfs` does not add names to published
-    /// files.
-    Stream((Option<String>, Vec<u8>)),
-}
-
-impl From<AddIpfsFile> for AddOpt {
-    fn from(value: AddIpfsFile) -> Self {
-        match value {
-            AddIpfsFile::Path(file_path) => file_path.into(),
-            AddIpfsFile::Stream((None, bytes)) => bytes.into(),
-            AddIpfsFile::Stream((Some(name), bytes)) => (name, bytes).into(),
-        }
-    }
-}
-
-impl From<String> for AddIpfsFile {
-    fn from(value: String) -> Self {
-        Self::Path(value.into())
-    }
-}
-
-impl From<std::path::PathBuf> for AddIpfsFile {
-    fn from(value: std::path::PathBuf) -> Self {
-        Self::Path(value)
-    }
-}
-
-impl From<Vec<u8>> for AddIpfsFile {
-    fn from(value: Vec<u8>) -> Self {
-        Self::Stream((None, value))
-    }
-}
-
-impl From<(String, Vec<u8>)> for AddIpfsFile {
-    fn from((name, stream): (String, Vec<u8>)) -> Self {
-        Self::Stream((Some(name), stream))
-    }
-}
-
-impl From<(Option<String>, Vec<u8>)> for AddIpfsFile {
-    fn from(value: (Option<String>, Vec<u8>)) -> Self {
-        Self::Stream(value)
     }
 }
 

--- a/rust/hermes-ipfs/src/lib.rs
+++ b/rust/hermes-ipfs/src/lib.rs
@@ -204,7 +204,7 @@ impl HermesIpfs {
     /// Returns an error if the file fails to download.
     pub async fn get_ipfs_file(
         &self,
-        cid: Cid,
+        cid: &Cid,
     ) -> anyhow::Result<Vec<u8>> {
         let block = self.node.get_block(cid).await?;
         Ok(block.data().to_vec())

--- a/rust/hermes-ipfs/src/lib.rs
+++ b/rust/hermes-ipfs/src/lib.rs
@@ -206,8 +206,13 @@ impl HermesIpfs {
     pub async fn get_ipfs_file_cbor(
         &self,
         cid: &Cid,
+        peer_id: Option<PeerId>,
     ) -> anyhow::Result<Vec<u8>> {
-        let block = self.node.get_block(cid).await?;
+        let block = match peer_id {
+            Some(peer_id) => self.node.get_block(cid).provider(peer_id).await?,
+            None => self.node.get_block(cid).await?,
+        };
+
         Ok(block.data().to_vec())
     }
 

--- a/rust/hermes-ipfs/src/lib.rs
+++ b/rust/hermes-ipfs/src/lib.rs
@@ -183,7 +183,7 @@ impl HermesIpfs {
         Ok(ipfs_path)
     }
 
-    /// Get a block from IPFS
+    /// Get a file from IPFS
     ///
     /// ## Parameters
     ///
@@ -191,16 +191,17 @@ impl HermesIpfs {
     ///
     /// ## Returns
     ///
-    /// * `A result with Block`.
+    /// * `A result with Vec<u8>`.
     ///
     /// ## Errors
     ///
-    /// Returns an error if the block fails to retrieve.
-    pub async fn get_ipfs_block(
+    /// Returns an error if the file fails to download.
+    pub async fn get_ipfs_file(
         &self,
         cid: Cid,
-    ) -> anyhow::Result<Block> {
-        self.node.get_block(cid).await
+    ) -> anyhow::Result<Vec<u8>> {
+        let block = self.node.get_block(cid).await?;
+        Ok(block.data().to_vec())
     }
 
     /// Pin content to IPFS.

--- a/rust/hermes-ipfs/src/lib.rs
+++ b/rust/hermes-ipfs/src/lib.rs
@@ -190,7 +190,7 @@ impl HermesIpfs {
         Ok(ipfs_path)
     }
 
-    /// Get a file from IPFS
+    /// Get a file from IPFS as CBOR encoded data.
     ///
     /// ## Parameters
     ///
@@ -203,7 +203,7 @@ impl HermesIpfs {
     /// ## Errors
     ///
     /// Returns an error if the file fails to download.
-    pub async fn get_ipfs_file(
+    pub async fn get_ipfs_file_cbor(
         &self,
         cid: &Cid,
     ) -> anyhow::Result<Vec<u8>> {


### PR DESCRIPTION
# Description

Fix `add_ipfs_file` and `get_ipfs_file`

## Related Issue(s)

https://github.com/input-output-hk/hermes/issues/736

## Description of Changes

`add_ipfs_file`
- Creating a block using custom CID and data to store the file instead of using unixfs

`get_ipfs_file`
- Get a file from a block using CID instead of getting it from unixfs

- Remove 
**Note** : The underlying implementation of unixfs undergoes a chunking mechanism when the file is big. 
This create block doesn't handle that process and yet it is safe since the documents size is limit to ~2MB

## Breaking Changes
- New implementation of `add_ipfs_file` and `get_ipfs_file`
- `AddIpfsFile` is removed

## Related Pull Requests

https://github.com/input-output-hk/hermes/pull/750

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
