### PR TITLE
feat(rust/signed-doc): Use latest `catalyst-signed-doc-spec`

### DIFF
--- a/rust/catalyst-signed-doc-macro/Cargo.toml
+++ b/rust/catalyst-signed-doc-macro/Cargo.toml
@@ -19,5 +19,5 @@ quote = "1.0"
 proc-macro2 = "1.0"
 anyhow = "1.0.99"
 
-catalyst-signed-doc-spec = { version = "0.2.2", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "catalyst-signed-doc-spec/v0.2.2-wasm" }
+catalyst-signed-doc-spec = { version = "0.2.3", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "catalyst-signed-doc-spec/v0.2.3" }
 

--- a/rust/signed_doc/Cargo.toml
+++ b/rust/signed_doc/Cargo.toml
@@ -16,7 +16,7 @@ cbork-utils = { version = "0.0.3", git = "https://github.com/input-output-hk/cat
 
 # When updating the specification version, it should also be updated for the `catalyst-signed-doc-macro` crate.
 catalyst-signed-doc-macro = { version = "0.0.1", path = "../catalyst-signed-doc-macro" }
-catalyst-signed-doc-spec = { version = "0.2.2", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "catalyst-signed-doc-spec/v0.2.2-wasm" }
+catalyst-signed-doc-spec = { version = "0.2.3", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "catalyst-signed-doc-spec/v0.2.3" }
 
 anyhow = "1.0.95"
 serde = { version = "1.0.217", features = ["derive"] }


### PR DESCRIPTION
# Description

Use the latest `catalyst-signed-doc-spec` release  `0.2.3`
