### PR TITLE
chore(rust/signed-doc): Update `Validator::validate` return type

### DIFF
--- a/rust/catalyst-contest/src/contest_ballot/tests.rs
+++ b/rust/catalyst-contest/src/contest_ballot/tests.rs
@@ -80,16 +80,16 @@ fn contest_ballot(
     let mut validator = Validator::new();
     validator.extend_rules_per_document(doc_types::CONTEST_BALLOT.clone(), ContestBallotRule {});
 
-    let is_valid = validator.validate(&doc, &provider).unwrap();
+    validator.validate(&doc, &provider).unwrap();
     println!("{:?}", doc.report());
-    assert_eq!(is_valid, !doc.report().is_problematic());
+    let is_valid = !doc.report().is_problematic();
 
     // Generate similar `CatalystSignedDocument` instance to have a clean internal problem
     // report.
     let doc = doc_gen(&mut provider).unwrap();
     let contest_ballot = ContestBallot::new(&doc, &provider).unwrap();
-    assert_eq!(is_valid, !contest_ballot.report().is_problematic());
     println!("{:?}", contest_ballot.report());
+    assert_eq!(is_valid, !contest_ballot.report().is_problematic());
 
     is_valid
 }

--- a/rust/catalyst-contest/src/contest_delegation/tests.rs
+++ b/rust/catalyst-contest/src/contest_delegation/tests.rs
@@ -128,16 +128,16 @@ fn contest_delegation(
     validator
         .extend_rules_per_document(doc_types::CONTEST_DELEGATION.clone(), ContestDelegationRule);
 
-    let is_valid = validator.validate(&doc, &p).unwrap();
+    validator.validate(&doc, &p).unwrap();
     println!("{:?}", doc.report());
-    assert_eq!(is_valid, !doc.report().is_problematic());
+    let is_valid = !doc.report().is_problematic();
 
     // Generate similar `CatalystSignedDocument` instance to have a clean internal problem
     // report
     let doc = doc_gen(&mut p).unwrap();
     let contest_delegation = ContestDelegation::new(&doc, &p).unwrap();
-    assert_eq!(is_valid, !contest_delegation.report().is_problematic());
     println!("{:?}", contest_delegation.report());
+    assert_eq!(is_valid, !contest_delegation.report().is_problematic());
 
     is_valid
 }

--- a/rust/catalyst-contest/src/contest_parameters/tests.rs
+++ b/rust/catalyst-contest/src/contest_parameters/tests.rs
@@ -57,9 +57,9 @@ fn contest_parameters(
     validator
         .extend_rules_per_document(doc_types::CONTEST_PARAMETERS.clone(), ContestParametersRule);
 
-    let is_valid = validator.validate(&doc, &p).unwrap();
+    validator.validate(&doc, &p).unwrap();
     println!("{:?}", doc.report());
-    assert_eq!(is_valid, !doc.report().is_problematic());
+    let is_valid = !doc.report().is_problematic();
 
     // Generate similar `CatalystSignedDocument` instance to have a clean internal problem
     // report

--- a/rust/signed_doc/tests/brand_parameters.rs
+++ b/rust/signed_doc/tests/brand_parameters.rs
@@ -135,8 +135,7 @@ fn test_brand_parameters_doc(
         doc_types::BRAND_PARAMETERS.clone()
     );
 
-    let is_valid = Validator::new().validate(&doc, &provider).unwrap();
-    assert_eq!(is_valid, !doc.report().is_problematic());
+    Validator::new().validate(&doc, &provider).unwrap();
     println!("{:?}", doc.report());
-    is_valid
+    !doc.report().is_problematic()
 }

--- a/rust/signed_doc/tests/brand_parameters_form_template.rs
+++ b/rust/signed_doc/tests/brand_parameters_form_template.rs
@@ -96,8 +96,7 @@ fn test_brand_parameters_form_template_doc(
         doc_types::BRAND_PARAMETERS_FORM_TEMPLATE.clone()
     );
 
-    let is_valid = Validator::new().validate(&doc, &provider).unwrap();
-    assert_eq!(is_valid, !doc.report().is_problematic());
+    Validator::new().validate(&doc, &provider).unwrap();
     println!("{:?}", doc.report());
-    is_valid
+    !doc.report().is_problematic()
 }

--- a/rust/signed_doc/tests/campaign_parameters.rs
+++ b/rust/signed_doc/tests/campaign_parameters.rs
@@ -182,8 +182,7 @@ fn test_campaign_parameters_doc(
         doc_types::CAMPAIGN_PARAMETERS.clone()
     );
 
-    let is_valid = Validator::new().validate(&doc, &provider).unwrap();
-    assert_eq!(is_valid, !doc.report().is_problematic());
+    Validator::new().validate(&doc, &provider).unwrap();
     println!("{:?}", doc.report());
-    is_valid
+    !doc.report().is_problematic()
 }

--- a/rust/signed_doc/tests/campaign_parameters_form_template.rs
+++ b/rust/signed_doc/tests/campaign_parameters_form_template.rs
@@ -138,8 +138,7 @@ fn test_campaign_parameters_form_template_doc(
         doc_types::CAMPAIGN_PARAMETERS_FORM_TEMPLATE.clone()
     );
 
-    let is_valid = Validator::new().validate(&doc, &provider).unwrap();
-    assert_eq!(is_valid, !doc.report().is_problematic());
+    Validator::new().validate(&doc, &provider).unwrap();
     println!("{:?}", doc.report());
-    is_valid
+    !doc.report().is_problematic()
 }

--- a/rust/signed_doc/tests/category_parameters.rs
+++ b/rust/signed_doc/tests/category_parameters.rs
@@ -195,8 +195,7 @@ fn test_category_parameters_doc(
         doc_types::CATEGORY_PARAMETERS.clone()
     );
 
-    let is_valid = Validator::new().validate(&doc, &provider).unwrap();
-    assert_eq!(is_valid, !doc.report().is_problematic());
+    Validator::new().validate(&doc, &provider).unwrap();
     println!("{:?}", doc.report());
-    is_valid
+    !doc.report().is_problematic()
 }

--- a/rust/signed_doc/tests/category_parameters_form_template.rs
+++ b/rust/signed_doc/tests/category_parameters_form_template.rs
@@ -147,8 +147,7 @@ fn test_category_parameters_form_template_doc(
         doc_types::CATEGORY_PARAMETERS_FORM_TEMPLATE.clone()
     );
 
-    let is_valid = Validator::new().validate(&doc, &provider).unwrap();
-    assert_eq!(is_valid, !doc.report().is_problematic());
+    Validator::new().validate(&doc, &provider).unwrap();
     println!("{:?}", doc.report());
-    is_valid
+    !doc.report().is_problematic()
 }

--- a/rust/signed_doc/tests/contest_ballot.rs
+++ b/rust/signed_doc/tests/contest_ballot.rs
@@ -232,8 +232,7 @@ fn contest_ballot(
     let doc = doc_gen(&mut provider).unwrap();
     assert_eq!(*doc.doc_type().unwrap(), doc_types::CONTEST_BALLOT.clone());
 
-    let is_valid = Validator::new().validate(&doc, &provider).unwrap();
-    assert_eq!(is_valid, !doc.report().is_problematic());
+    Validator::new().validate(&doc, &provider).unwrap();
     println!("{:?}", doc.report());
-    is_valid
+    !doc.report().is_problematic()
 }

--- a/rust/signed_doc/tests/contest_ballot_checkpoint.rs
+++ b/rust/signed_doc/tests/contest_ballot_checkpoint.rs
@@ -287,8 +287,7 @@ fn contest_ballot_checkpoint(
         doc_types::CONTEST_BALLOT_CHECKPOINT.clone()
     );
 
-    let is_valid = Validator::new().validate(&doc, &provider).unwrap();
-    assert_eq!(is_valid, !doc.report().is_problematic());
+    Validator::new().validate(&doc, &provider).unwrap();
     println!("{:?}", doc.report());
-    is_valid
+    !doc.report().is_problematic()
 }

--- a/rust/signed_doc/tests/contest_delegation.rs
+++ b/rust/signed_doc/tests/contest_delegation.rs
@@ -211,8 +211,7 @@ fn contest_delegation(
         doc_types::CONTEST_DELEGATION.clone()
     );
 
-    let is_valid = Validator::new().validate(&doc, &provider).unwrap();
-    assert_eq!(is_valid, !doc.report().is_problematic());
+    Validator::new().validate(&doc, &provider).unwrap();
     println!("{:?}", doc.report());
-    is_valid
+    !doc.report().is_problematic()
 }

--- a/rust/signed_doc/tests/contest_parameters.rs
+++ b/rust/signed_doc/tests/contest_parameters.rs
@@ -211,8 +211,7 @@ fn contest_parameters(
         doc_types::CONTEST_PARAMETERS.clone()
     );
 
-    let is_valid = Validator::new().validate(&doc, &provider).unwrap();
-    assert_eq!(is_valid, !doc.report().is_problematic());
+    Validator::new().validate(&doc, &provider).unwrap();
     println!("{:?}", doc.report());
-    is_valid
+    !doc.report().is_problematic()
 }

--- a/rust/signed_doc/tests/contest_parameters_form_template.rs
+++ b/rust/signed_doc/tests/contest_parameters_form_template.rs
@@ -166,8 +166,7 @@ fn contest_parameters_form_template(
         doc_types::CONTEST_PARAMETERS_FORM_TEMPLATE.clone()
     );
 
-    let is_valid = Validator::new().validate(&doc, &provider).unwrap();
-    assert_eq!(is_valid, !doc.report().is_problematic());
+    Validator::new().validate(&doc, &provider).unwrap();
     println!("{:?}", doc.report());
-    is_valid
+    !doc.report().is_problematic()
 }

--- a/rust/signed_doc/tests/proposal.rs
+++ b/rust/signed_doc/tests/proposal.rs
@@ -210,8 +210,7 @@ fn test_proposal_doc(
     let doc = doc_gen(&mut provider).unwrap();
     assert_eq!(*doc.doc_type().unwrap(), doc_types::PROPOSAL.clone());
 
-    let is_valid = Validator::new().validate(&doc, &provider).unwrap();
-    assert_eq!(is_valid, !doc.report().is_problematic());
+    Validator::new().validate(&doc, &provider).unwrap();
     println!("{:?}", doc.report());
-    is_valid
+    !doc.report().is_problematic()
 }

--- a/rust/signed_doc/tests/proposal_comment.rs
+++ b/rust/signed_doc/tests/proposal_comment.rs
@@ -311,8 +311,7 @@ fn test_proposal_comment_doc(
         doc_types::PROPOSAL_COMMENT.clone()
     );
 
-    let is_valid = Validator::new().validate(&doc, &provider).unwrap();
-    assert_eq!(is_valid, !doc.report().is_problematic());
+    Validator::new().validate(&doc, &provider).unwrap();
     println!("{:?}", doc.report());
-    is_valid
+    !doc.report().is_problematic()
 }

--- a/rust/signed_doc/tests/proposal_comment_form_template.rs
+++ b/rust/signed_doc/tests/proposal_comment_form_template.rs
@@ -166,8 +166,7 @@ fn test_proposal_comment_form_template_doc(
         doc_types::PROPOSAL_COMMENT_FORM_TEMPLATE.clone()
     );
 
-    let is_valid = Validator::new().validate(&doc, &provider).unwrap();
-    assert_eq!(is_valid, !doc.report().is_problematic());
+    Validator::new().validate(&doc, &provider).unwrap();
     println!("{:?}", doc.report());
-    is_valid
+    !doc.report().is_problematic()
 }

--- a/rust/signed_doc/tests/proposal_form_template.rs
+++ b/rust/signed_doc/tests/proposal_form_template.rs
@@ -166,8 +166,7 @@ fn test_proposal_form_template_doc(
         doc_types::PROPOSAL_FORM_TEMPLATE.clone()
     );
 
-    let is_valid = Validator::new().validate(&doc, &provider).unwrap();
-    assert_eq!(is_valid, !doc.report().is_problematic());
+    Validator::new().validate(&doc, &provider).unwrap();
     println!("{:?}", doc.report());
-    is_valid
+    !doc.report().is_problematic()
 }

--- a/rust/signed_doc/tests/proposal_submission_action.rs
+++ b/rust/signed_doc/tests/proposal_submission_action.rs
@@ -300,8 +300,7 @@ fn test_proposal_submission_action_doc(
         doc_types::PROPOSAL_SUBMISSION_ACTION.clone()
     );
 
-    let is_valid = Validator::new().validate(&doc, &provider).unwrap();
-    assert_eq!(is_valid, !doc.report().is_problematic());
+    Validator::new().validate(&doc, &provider).unwrap();
     println!("{:?}", doc.report());
-    is_valid
+    !doc.report().is_problematic()
 }

--- a/rust/signed_doc/tests/rep_nomination.rs
+++ b/rust/signed_doc/tests/rep_nomination.rs
@@ -254,8 +254,7 @@ fn test_brand_parameters_doc(
     let doc = doc_gen(&mut provider).unwrap();
     assert_eq!(*doc.doc_type().unwrap(), doc_types::REP_NOMINATION.clone());
 
-    let is_valid = Validator::new().validate(&doc, &provider).unwrap();
-    assert_eq!(is_valid, !doc.report().is_problematic());
+    Validator::new().validate(&doc, &provider).unwrap();
     println!("{:?}", doc.report());
-    is_valid
+    !doc.report().is_problematic()
 }

--- a/rust/signed_doc/tests/rep_nomination_form_template.rs
+++ b/rust/signed_doc/tests/rep_nomination_form_template.rs
@@ -149,8 +149,7 @@ fn test_category_parameters_form_template_doc(
         doc_types::REP_NOMINATION_FORM_TEMPLATE.clone()
     );
 
-    let is_valid = Validator::new().validate(&doc, &provider).unwrap();
-    assert_eq!(is_valid, !doc.report().is_problematic());
+    Validator::new().validate(&doc, &provider).unwrap();
     println!("{:?}", doc.report());
-    is_valid
+    !doc.report().is_problematic()
 }

--- a/rust/signed_doc/tests/rep_profile.rs
+++ b/rust/signed_doc/tests/rep_profile.rs
@@ -179,8 +179,7 @@ fn test_brand_parameters_doc(
     let doc = doc_gen(&mut provider).unwrap();
     assert_eq!(*doc.doc_type().unwrap(), doc_types::REP_PROFILE.clone());
 
-    let is_valid = Validator::new().validate(&doc, &provider).unwrap();
-    assert_eq!(is_valid, !doc.report().is_problematic());
+    Validator::new().validate(&doc, &provider).unwrap();
     println!("{:?}", doc.report());
-    is_valid
+    !doc.report().is_problematic()
 }

--- a/rust/signed_doc/tests/rep_profile_form_template.rs
+++ b/rust/signed_doc/tests/rep_profile_form_template.rs
@@ -139,8 +139,7 @@ fn test_category_parameters_form_template_doc(
         doc_types::REP_PROFILE_FORM_TEMPLATE.clone()
     );
 
-    let is_valid = Validator::new().validate(&doc, &provider).unwrap();
-    assert_eq!(is_valid, !doc.report().is_problematic());
+    Validator::new().validate(&doc, &provider).unwrap();
     println!("{:?}", doc.report());
-    is_valid
+    !doc.report().is_problematic()
 }


### PR DESCRIPTION
# Description

Modify `Validator::validate` return type.
Do not return boolean flag which is a duplication of the filling `doc.report()`.

## Related Issue(s)

Part of https://github.com/input-output-hk/catalyst-libs/issues/634

## Description of Changes

Provide a clear and concise description of what the pull request changes.

## Breaking Changes

- `Validator::validate` return type. Instead of relying on the returned boolean flag, use `doc.report().is_problematic()`

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
