### PR TITLE
chore(rust/hermes-ipfs): Bump `hermes-ipfs` version

### DIFF
--- a/rust/hermes-ipfs/Cargo.toml
+++ b/rust/hermes-ipfs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermes-ipfs"
-version = "0.0.11"
+version = "0.0.12"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true


### PR DESCRIPTION
# Description
This PR bumps the version of `hermes-ipfs` crate.

