### PR TITLE
chore(rust/signed-doc): Remove the boolean flag from the type rule validation

### DIFF
--- a/rust/signed_doc/src/validator/rules/type/mod.rs
+++ b/rust/signed_doc/src/validator/rules/type/mod.rs
@@ -17,7 +17,8 @@ impl CatalystSignedDocumentValidationRule for TypeRule {
         doc: &CatalystSignedDocument,
         provider: &dyn Provider,
     ) -> anyhow::Result<bool> {
-        Self::check_inner(doc, provider)
+        Self::check_inner(doc, provider)?;
+        Ok(!doc.report().is_problematic())
     }
 }
 
@@ -27,20 +28,20 @@ impl TypeRule {
     fn check_inner(
         doc: &CatalystSignedDocument,
         provider: &dyn Provider,
-    ) -> anyhow::Result<bool> {
+    ) -> anyhow::Result<()> {
         let Ok(id) = doc.doc_id() else {
             doc.report().missing_field(
                 "id",
                 "Cannot get the document field during the field validation",
             );
-            return Ok(false);
+            return Ok(());
         };
         let Ok(ver) = doc.doc_ver() else {
             doc.report().missing_field(
                 "ver",
                 "Cannot get the document field during the field validation",
             );
-            return Ok(false);
+            return Ok(());
         };
 
         if id != ver {
@@ -52,30 +53,28 @@ impl TypeRule {
                         "Missing `type` field in the latest known document. Last known document id: {id}."
                     ),
                 );
-                    return Ok(false);
+                    return Ok(());
                 };
 
                 let Ok(doc_type) = doc.doc_type() else {
                     doc.report().missing_field("type", "Missing `type` field.");
-                    return Ok(false);
+                    return Ok(());
                 };
 
                 if last_doc_type != doc_type {
                     doc.report().functional_validation(
-                    &format!("New document type should be the same that the submitted latest known. New document type: {doc_type}, latest known ver: {last_doc_type}"),
-                    &format!("Document's type should be the same for all documents with the same id {id}"),
-                );
-                    return Ok(false);
+                        &format!("New document type should be the same that the submitted latest known. New document type: {doc_type}, latest known ver: {last_doc_type}"),
+                        &format!("Document's type should be the same for all documents with the same id {id}"),
+                    );
                 }
             } else {
                 doc.report().functional_validation(
                     &format!("`ver` and `id` are not equal, ver: {ver}, id: {id}. Document with `id` and `ver` being equal MUST exist"),
                     "Cannot get a first version document from the provider, document for which `id` and `ver` are equal.",
                 );
-                return Ok(false);
             }
         }
 
-        Ok(true)
+        Ok(())
     }
 }

--- a/rust/signed_doc/src/validator/rules/type/tests.rs
+++ b/rust/signed_doc/src/validator/rules/type/tests.rs
@@ -131,7 +131,7 @@ fn type_test(doc_gen: impl FnOnce(&mut TestCatalystProvider) -> CatalystSignedDo
     let mut provider = TestCatalystProvider::default();
     let doc = doc_gen(&mut provider);
 
-    let res = TypeRule::check_inner(&doc, &provider).unwrap();
+    TypeRule::check_inner(&doc, &provider).unwrap();
     println!("{:?}", doc.report());
-    res
+    !doc.report().is_problematic()
 }


### PR DESCRIPTION
# Description

Remove the boolean flag from the type rule validation.

## Related Issue(s)

Part of https://github.com/input-output-hk/catalyst-libs/issues/800.