### PR TITLE
chore(rust/signed-doc): Remove the boolean flag from the revocations rule

### DIFF
--- a/rust/signed_doc/src/validator/rules/revocations/mod.rs
+++ b/rust/signed_doc/src/validator/rules/revocations/mod.rs
@@ -27,7 +27,8 @@ impl CatalystSignedDocumentValidationRule for RevocationsRule {
         doc: &CatalystSignedDocument,
         _provider: &dyn Provider,
     ) -> anyhow::Result<bool> {
-        Ok(self.check_inner(doc))
+        self.check_inner(doc);
+        Ok(!doc.report().is_problematic())
     }
 }
 
@@ -49,7 +50,7 @@ impl RevocationsRule {
     fn check_inner(
         &self,
         doc: &CatalystSignedDocument,
-    ) -> bool {
+    ) {
         if let Self::Specified { optional } = self
             && doc.doc_meta().revocations().is_none()
             && !optional
@@ -58,7 +59,6 @@ impl RevocationsRule {
                 "revocations",
                 "Document must have 'revocations' field specified",
             );
-            return false;
         }
         if let Self::NotSpecified = self
             && doc.doc_meta().revocations().is_some()
@@ -71,9 +71,6 @@ impl RevocationsRule {
                 ),
                 "Document does not expect to have a 'revocations' field",
             );
-            return false;
         }
-
-        true
     }
 }

--- a/rust/signed_doc/src/validator/rules/revocations/tests.rs
+++ b/rust/signed_doc/src/validator/rules/revocations/tests.rs
@@ -5,7 +5,7 @@ use crate::{builder::tests::Builder, metadata::SupportedField};
 
 #[test_case(
     || {
-        Builder::new()
+        Builder::with_required_fields()
             .with_metadata_field(SupportedField::Revocations(
                     vec![].into()
                 ))
@@ -17,23 +17,23 @@ use crate::{builder::tests::Builder, metadata::SupportedField};
 )]
 #[test_case(
     || {
-        Builder::new().build()
+        Builder::with_required_fields().build()
     }
     => true
     ;
     "missing 'revocations' field"
 )]
-
 fn rule_specified_optional_test(doc_gen: impl FnOnce() -> CatalystSignedDocument) -> bool {
     let rule = RevocationsRule::Specified { optional: true };
 
     let doc = doc_gen();
-    rule.check_inner(&doc)
+    rule.check_inner(&doc);
+    !doc.report().is_problematic()
 }
 
 #[test_case(
     || {
-        Builder::new()
+        Builder::with_required_fields()
             .with_metadata_field(SupportedField::Revocations(
                     vec![].into()
                 ))
@@ -45,7 +45,7 @@ fn rule_specified_optional_test(doc_gen: impl FnOnce() -> CatalystSignedDocument
 )]
 #[test_case(
     || {
-        Builder::new().build()
+        Builder::with_required_fields().build()
     }
     => false
     ;
@@ -56,12 +56,13 @@ fn rule_specified_not_optional_test(doc_gen: impl FnOnce() -> CatalystSignedDocu
     let rule = RevocationsRule::Specified { optional: false };
 
     let doc = doc_gen();
-    rule.check_inner(&doc)
+    rule.check_inner(&doc);
+    !doc.report().is_problematic()
 }
 
 #[test_case(
     || {
-        Builder::new().build()
+        Builder::with_required_fields().build()
     }
     => true
     ;
@@ -69,7 +70,7 @@ fn rule_specified_not_optional_test(doc_gen: impl FnOnce() -> CatalystSignedDocu
 )]
 #[test_case(
     || {
-        Builder::new()
+        Builder::with_required_fields()
             .with_metadata_field(SupportedField::Revocations(
                     vec![].into()
                 ))
@@ -84,5 +85,6 @@ fn rule_not_specified_test(doc_gen: impl FnOnce() -> CatalystSignedDocument) -> 
     let rule = RevocationsRule::NotSpecified;
 
     let doc = doc_gen();
-    rule.check_inner(&doc)
+    rule.check_inner(&doc);
+    !doc.report().is_problematic()
 }


### PR DESCRIPTION
# Description

Remove the boolean flag from the revocations rule.

## Related Issue(s)

Part of https://github.com/input-output-hk/catalyst-libs/issues/800.