### PR TITLE
chore(rust/signed-doc): `Campaign Parameters Form Template` and `Category Parameters` test improvements

### DIFF
--- a/rust/signed_doc/tests/campaign_parameters_form_template.rs
+++ b/rust/signed_doc/tests/campaign_parameters_form_template.rs
@@ -5,8 +5,9 @@ use catalyst_signed_doc::{
     builder::Builder,
     providers::tests::TestCatalystProvider,
     tests_utils::{
-        brand_parameters_doc, brand_parameters_form_template_doc,
+        brand_parameters_doc, brand_parameters_form_template_doc, build_verify_and_publish,
         campaign_parameters_form_template_doc, create_dummy_admin_key_pair, create_dummy_key_pair,
+        create_key_pair_and_publish,
     },
     validator::Validator,
     *,
@@ -16,25 +17,23 @@ use ed25519_dalek::ed25519::signature::Signer;
 use test_case::test_case;
 
 #[test_case(
-    |provider| {
-        let template = brand_parameters_form_template_doc(provider).inspect(|v| provider.add_document(v).unwrap())?;
-        let parameters = brand_parameters_doc(&template, provider).inspect(|v| provider.add_document(v).unwrap())?;
-        campaign_parameters_form_template_doc(&parameters, provider)
+    |p| {
+        let template = build_verify_and_publish(p, brand_parameters_form_template_doc)?;
+        let parameters = build_verify_and_publish(p, |p| brand_parameters_doc(&template, p))?;
+        campaign_parameters_form_template_doc(&parameters, p)
     }
     => true
     ;
     "valid document"
 )]
 #[test_case(
-    |provider| {
-        let template = brand_parameters_form_template_doc(provider).inspect(|v| provider.add_document(v).unwrap())?;
-        let parameters = brand_parameters_doc(&template, provider).inspect(|v| provider.add_document(v).unwrap())?;
+    |p| {
+        let template = build_verify_and_publish(p, brand_parameters_form_template_doc)?;
+        let parameters = build_verify_and_publish(p, |p| brand_parameters_doc(&template, p))?;
+
+        let (sk, kid) = create_key_pair_and_publish(p, || create_dummy_key_pair(RoleId::Role0));
         let id = uuid::UuidV7::new();
-        let (sk, kid) = create_dummy_key_pair(RoleId::Role0);
-        provider.add_sk(kid.clone(), sk.clone());
-
         let parameters_ref = parameters.doc_ref()?;
-
         Builder::new()
             .with_json_metadata(serde_json::json!({
                 "content-type": ContentType::SchemaJson,
@@ -53,15 +52,13 @@ use test_case::test_case;
     "wrong role"
 )]
 #[test_case(
-    |provider| {
-        let template = brand_parameters_form_template_doc(provider).inspect(|v| provider.add_document(v).unwrap())?;
-        let parameters = brand_parameters_doc(&template, provider).inspect(|v| provider.add_document(v).unwrap())?;
+    |p| {
+        let template = build_verify_and_publish(p, brand_parameters_form_template_doc)?;
+        let parameters = build_verify_and_publish(p, |p| brand_parameters_doc(&template, p))?;
+
+        let (sk, kid) = create_key_pair_and_publish(p, create_dummy_admin_key_pair);
         let id = uuid::UuidV7::new();
-        let (sk, kid) = create_dummy_admin_key_pair();
-        provider.add_sk(kid.clone(), sk.clone());
-
         let parameters_ref = parameters.doc_ref()?;
-
         Builder::new()
             .with_json_metadata(serde_json::json!({
                 "content-type": ContentType::SchemaJson,
@@ -80,15 +77,13 @@ use test_case::test_case;
     "empty content"
 )]
 #[test_case(
-    |provider| {
-        let template = brand_parameters_form_template_doc(provider).inspect(|v| provider.add_document(v).unwrap())?;
-        let parameters = brand_parameters_doc(&template, provider).inspect(|v| provider.add_document(v).unwrap())?;
+    |p| {
+        let template = build_verify_and_publish(p, brand_parameters_form_template_doc)?;
+        let parameters = build_verify_and_publish(p, |p| brand_parameters_doc(&template, p))?;
+
+        let (sk, kid) = create_key_pair_and_publish(p, create_dummy_admin_key_pair);
         let id = uuid::UuidV7::new();
-        let (sk, kid) = create_dummy_admin_key_pair();
-        provider.add_sk(kid.clone(), sk.clone());
-
         let parameters_ref = parameters.doc_ref()?;
-
         Builder::new()
             .with_json_metadata(serde_json::json!({
                 "content-type": ContentType::SchemaJson,
@@ -106,10 +101,9 @@ use test_case::test_case;
     "missing 'content-encoding' (optional)"
 )]
 #[test_case(
-    |provider| {
+    |p| {
+        let (sk, kid) = create_key_pair_and_publish(p, create_dummy_admin_key_pair);
         let id = uuid::UuidV7::new();
-        let (sk, kid) = create_dummy_admin_key_pair();
-        provider.add_sk(kid.clone(), sk.clone());
         Builder::new()
             .with_json_metadata(serde_json::json!({
                 "content-type": ContentType::SchemaJson,

--- a/rust/signed_doc/tests/category_parameters.rs
+++ b/rust/signed_doc/tests/category_parameters.rs
@@ -5,9 +5,10 @@ use catalyst_signed_doc::{
     builder::Builder,
     providers::tests::TestCatalystProvider,
     tests_utils::{
-        brand_parameters_doc, brand_parameters_form_template_doc, campaign_parameters_doc,
-        campaign_parameters_form_template_doc, category_parameters_doc,
+        brand_parameters_doc, brand_parameters_form_template_doc, build_verify_and_publish,
+        campaign_parameters_doc, campaign_parameters_form_template_doc, category_parameters_doc,
         category_parameters_form_template_doc, create_dummy_admin_key_pair, create_dummy_key_pair,
+        create_key_pair_and_publish,
     },
     validator::Validator,
     *,
@@ -17,32 +18,30 @@ use ed25519_dalek::ed25519::signature::Signer;
 use test_case::test_case;
 
 #[test_case(
-    |provider| {
-        let template = brand_parameters_form_template_doc(provider).inspect(|v| provider.add_document(v).unwrap())?;
-        let parameters = brand_parameters_doc(&template, provider).inspect(|v| provider.add_document(v).unwrap())?;
-        let template = campaign_parameters_form_template_doc(&parameters, provider).inspect(|v| provider.add_document(v).unwrap())?;
-        let parameters = campaign_parameters_doc(&template, &parameters, provider).inspect(|v| provider.add_document(v).unwrap())?;
-        let template = category_parameters_form_template_doc(&parameters, provider).inspect(|v| provider.add_document(v).unwrap())?;
-        category_parameters_doc(&template, &parameters, provider)
+    |p| {
+        let template = build_verify_and_publish(p, brand_parameters_form_template_doc)?;
+        let parameters = build_verify_and_publish(p, |p| brand_parameters_doc(&template, p))?;
+        let template = build_verify_and_publish(p, |p| campaign_parameters_form_template_doc(&parameters, p))?;
+        let parameters = build_verify_and_publish(p, |p| campaign_parameters_doc(&template, &parameters, p))?;
+        let template = build_verify_and_publish(p, |p| category_parameters_form_template_doc(&parameters, p))?;
+        category_parameters_doc(&template, &parameters, p)
     }
     => true
     ;
     "valid document"
 )]
 #[test_case(
-    |provider| {
-        let template = brand_parameters_form_template_doc(provider).inspect(|v| provider.add_document(v).unwrap())?;
-        let parameters = brand_parameters_doc(&template, provider).inspect(|v| provider.add_document(v).unwrap())?;
-        let template = campaign_parameters_form_template_doc(&parameters, provider).inspect(|v| provider.add_document(v).unwrap())?;
-        let parameters = campaign_parameters_doc(&template, &parameters, provider).inspect(|v| provider.add_document(v).unwrap())?;
-        let template = category_parameters_form_template_doc(&parameters, provider).inspect(|v| provider.add_document(v).unwrap())?;
-        let id = uuid::UuidV7::new();
-        let (sk, kid) = create_dummy_key_pair(RoleId::Role0);
-        provider.add_sk(kid.clone(), sk.clone());
+    |p| {
+        let template = build_verify_and_publish(p, brand_parameters_form_template_doc)?;
+        let parameters = build_verify_and_publish(p, |p| brand_parameters_doc(&template, p))?;
+        let template = build_verify_and_publish(p, |p| campaign_parameters_form_template_doc(&parameters, p))?;
+        let parameters = build_verify_and_publish(p, |p| campaign_parameters_doc(&template, &parameters, p))?;
+        let template = build_verify_and_publish(p, |p| category_parameters_form_template_doc(&parameters, p))?;
 
+        let (sk, kid) = create_key_pair_and_publish(p, || create_dummy_key_pair(RoleId::Role0));
+        let id = uuid::UuidV7::new();
         let template_ref = template.doc_ref()?;
         let parameters_ref = parameters.doc_ref()?;
-
         Builder::new()
             .with_json_metadata(serde_json::json!({
                 "content-type": ContentType::Json,
@@ -62,19 +61,17 @@ use test_case::test_case;
     "wrong role"
 )]
 #[test_case(
-    |provider| {
-        let template = brand_parameters_form_template_doc(provider).inspect(|v| provider.add_document(v).unwrap())?;
-        let parameters = brand_parameters_doc(&template, provider).inspect(|v| provider.add_document(v).unwrap())?;
-        let template = campaign_parameters_form_template_doc(&parameters, provider).inspect(|v| provider.add_document(v).unwrap())?;
-        let parameters = campaign_parameters_doc(&template, &parameters, provider).inspect(|v| provider.add_document(v).unwrap())?;
-        let template = category_parameters_form_template_doc(&parameters, provider).inspect(|v| provider.add_document(v).unwrap())?;
-        let id = uuid::UuidV7::new();
-        let (sk, kid) = create_dummy_admin_key_pair();
-        provider.add_sk(kid.clone(), sk.clone());
+    |p| {
+        let template = build_verify_and_publish(p, brand_parameters_form_template_doc)?;
+        let parameters = build_verify_and_publish(p, |p| brand_parameters_doc(&template, p))?;
+        let template = build_verify_and_publish(p, |p| campaign_parameters_form_template_doc(&parameters, p))?;
+        let parameters = build_verify_and_publish(p, |p| campaign_parameters_doc(&template, &parameters, p))?;
+        let template = build_verify_and_publish(p, |p| category_parameters_form_template_doc(&parameters, p))?;
 
+        let (sk, kid) = create_key_pair_and_publish(p, create_dummy_admin_key_pair);
+        let id = uuid::UuidV7::new();
         let template_ref = template.doc_ref()?;
         let parameters_ref = parameters.doc_ref()?;
-
         Builder::new()
             .with_json_metadata(serde_json::json!({
                 "content-type": ContentType::Json,
@@ -94,19 +91,17 @@ use test_case::test_case;
     "empty content"
 )]
 #[test_case(
-    |provider| {
-        let template = brand_parameters_form_template_doc(provider).inspect(|v| provider.add_document(v).unwrap())?;
-        let parameters = brand_parameters_doc(&template, provider).inspect(|v| provider.add_document(v).unwrap())?;
-        let template = campaign_parameters_form_template_doc(&parameters, provider).inspect(|v| provider.add_document(v).unwrap())?;
-        let parameters = campaign_parameters_doc(&template, &parameters, provider).inspect(|v| provider.add_document(v).unwrap())?;
-        let template = category_parameters_form_template_doc(&parameters, provider).inspect(|v| provider.add_document(v).unwrap())?;
-        let id = uuid::UuidV7::new();
-        let (sk, kid) = create_dummy_admin_key_pair();
-        provider.add_sk(kid.clone(), sk.clone());
+    |p| {
+        let template = build_verify_and_publish(p, brand_parameters_form_template_doc)?;
+        let parameters = build_verify_and_publish(p, |p| brand_parameters_doc(&template, p))?;
+        let template = build_verify_and_publish(p, |p| campaign_parameters_form_template_doc(&parameters, p))?;
+        let parameters = build_verify_and_publish(p, |p| campaign_parameters_doc(&template, &parameters, p))?;
+        let template = build_verify_and_publish(p, |p| category_parameters_form_template_doc(&parameters, p))?;
 
+        let (sk, kid) = create_key_pair_and_publish(p, create_dummy_admin_key_pair);
+        let id = uuid::UuidV7::new();
         let template_ref = template.doc_ref()?;
         let parameters_ref = parameters.doc_ref()?;
-
         Builder::new()
             .with_json_metadata(serde_json::json!({
                 "content-type": ContentType::Json,
@@ -125,17 +120,15 @@ use test_case::test_case;
     "missing 'content-encoding' (optional)"
 )]
 #[test_case(
-    |provider| {
-        let template = brand_parameters_form_template_doc(provider).inspect(|v| provider.add_document(v).unwrap())?;
-        let parameters = brand_parameters_doc(&template, provider).inspect(|v| provider.add_document(v).unwrap())?;
-        let template = campaign_parameters_form_template_doc(&parameters, provider).inspect(|v| provider.add_document(v).unwrap())?;
-        let parameters = campaign_parameters_doc(&template, &parameters, provider).inspect(|v| provider.add_document(v).unwrap())?;
+    |p| {
+        let template = build_verify_and_publish(p, brand_parameters_form_template_doc)?;
+        let parameters = build_verify_and_publish(p, |p| brand_parameters_doc(&template, p))?;
+        let template = build_verify_and_publish(p, |p| campaign_parameters_form_template_doc(&parameters, p))?;
+        let parameters = build_verify_and_publish(p, |p| campaign_parameters_doc(&template, &parameters, p))?;
+
+        let (sk, kid) = create_key_pair_and_publish(p, create_dummy_admin_key_pair);
         let id = uuid::UuidV7::new();
-        let (sk, kid) = create_dummy_admin_key_pair();
-        provider.add_sk(kid.clone(), sk.clone());
-
         let parameters_ref = parameters.doc_ref()?;
-
         Builder::new()
             .with_json_metadata(serde_json::json!({
                 "content-type": ContentType::Json,
@@ -154,18 +147,16 @@ use test_case::test_case;
     "missing 'template'"
 )]
 #[test_case(
-    |provider| {
-        let template = brand_parameters_form_template_doc(provider).inspect(|v| provider.add_document(v).unwrap())?;
-        let parameters = brand_parameters_doc(&template, provider).inspect(|v| provider.add_document(v).unwrap())?;
-        let template = campaign_parameters_form_template_doc(&parameters, provider).inspect(|v| provider.add_document(v).unwrap())?;
-        let parameters = campaign_parameters_doc(&template, &parameters, provider).inspect(|v| provider.add_document(v).unwrap())?;
-        let template = category_parameters_form_template_doc(&parameters, provider).inspect(|v| provider.add_document(v).unwrap())?;
+    |p| {
+        let template = build_verify_and_publish(p, brand_parameters_form_template_doc)?;
+        let parameters = build_verify_and_publish(p, |p| brand_parameters_doc(&template, p))?;
+        let template = build_verify_and_publish(p, |p| campaign_parameters_form_template_doc(&parameters, p))?;
+        let parameters = build_verify_and_publish(p, |p| campaign_parameters_doc(&template, &parameters, p))?;
+        let template = build_verify_and_publish(p, |p| category_parameters_form_template_doc(&parameters, p))?;
+
+        let (sk, kid) = create_key_pair_and_publish(p, create_dummy_admin_key_pair);
         let id = uuid::UuidV7::new();
-        let (sk, kid) = create_dummy_admin_key_pair();
-        provider.add_sk(kid.clone(), sk.clone());
-
         let template_ref = template.doc_ref()?;
-
         Builder::new()
             .with_json_metadata(serde_json::json!({
                 "content-type": ContentType::Json,
@@ -187,15 +178,15 @@ use test_case::test_case;
 fn test_category_parameters_doc(
     doc_gen: impl FnOnce(&mut TestCatalystProvider) -> anyhow::Result<CatalystSignedDocument>
 ) -> bool {
-    let mut provider = TestCatalystProvider::default();
+    let mut p = TestCatalystProvider::default();
 
-    let doc = doc_gen(&mut provider).unwrap();
+    let doc = doc_gen(&mut p).unwrap();
     assert_eq!(
         *doc.doc_type().unwrap(),
         doc_types::CATEGORY_PARAMETERS.clone()
     );
 
-    Validator::new().validate(&doc, &provider).unwrap();
+    Validator::new().validate(&doc, &p).unwrap();
     println!("{:?}", doc.report());
     !doc.report().is_problematic()
 }


### PR DESCRIPTION
# Description

Updated `Campaign Parameters Form Template`, `Category Parameters` tests by using `build_verify_and_publish` and `create_key_pair_and_publish` helper functions

## Related Issue(s)

Part of https://github.com/input-output-hk/catalyst-libs/issues/828

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
