### PR TITLE
chore(rust/signed-doc): `CollaboratorsRule::check_inner` boolean flag 

### DIFF
--- a/rust/signed_doc/src/validator/rules/collaborators/mod.rs
+++ b/rust/signed_doc/src/validator/rules/collaborators/mod.rs
@@ -27,7 +27,8 @@ impl CatalystSignedDocumentValidationRule for CollaboratorsRule {
         doc: &CatalystSignedDocument,
         _provider: &dyn Provider,
     ) -> anyhow::Result<bool> {
-        Ok(self.check_inner(doc))
+        self.check_inner(doc);
+        Ok(!doc.report().is_problematic())
     }
 }
 
@@ -49,7 +50,7 @@ impl CollaboratorsRule {
     fn check_inner(
         &self,
         doc: &CatalystSignedDocument,
-    ) -> bool {
+    ) {
         if let Self::Specified { optional } = self
             && doc.doc_meta().collaborators().is_empty()
             && !optional
@@ -58,7 +59,6 @@ impl CollaboratorsRule {
                 "collaborators",
                 "Document must have at least one entry in 'collaborators' field",
             );
-            return false;
         }
         if let Self::NotSpecified = self
             && !doc.doc_meta().collaborators().is_empty()
@@ -75,9 +75,6 @@ impl CollaboratorsRule {
                 ),
                 "Document does not expect to have a 'collaborators' field",
             );
-            return false;
         }
-
-        true
     }
 }

--- a/rust/signed_doc/src/validator/rules/collaborators/tests.rs
+++ b/rust/signed_doc/src/validator/rules/collaborators/tests.rs
@@ -8,7 +8,7 @@ use crate::{
 
 #[test_case(
     || {
-        Builder::new()
+        Builder::with_required_fields()
             .with_metadata_field(SupportedField::Collaborators(
                     vec![create_dummy_key_pair(RoleId::Role0).1].into()
                 ))
@@ -20,7 +20,7 @@ use crate::{
 )]
 #[test_case(
     || {
-        Builder::new().build()
+        Builder::with_required_fields().build()
     }
     => true
     ;
@@ -31,12 +31,13 @@ fn section_rule_specified_optional_test(doc_gen: impl FnOnce() -> CatalystSigned
     let rule = CollaboratorsRule::Specified { optional: true };
 
     let doc = doc_gen();
-    rule.check_inner(&doc)
+    rule.check_inner(&doc);
+    !doc.report().is_problematic()
 }
 
 #[test_case(
     || {
-        Builder::new()
+        Builder::with_required_fields()
             .with_metadata_field(SupportedField::Collaborators(
                     vec![create_dummy_key_pair(RoleId::Role0).1].into()
                 ))
@@ -48,7 +49,7 @@ fn section_rule_specified_optional_test(doc_gen: impl FnOnce() -> CatalystSigned
 )]
 #[test_case(
     || {
-        Builder::new().build()
+        Builder::with_required_fields().build()
     }
     => false
     ;
@@ -61,12 +62,13 @@ fn section_rule_specified_not_optional_test(
     let rule = CollaboratorsRule::Specified { optional: false };
 
     let doc = doc_gen();
-    rule.check_inner(&doc)
+    rule.check_inner(&doc);
+    !doc.report().is_problematic()
 }
 
 #[test_case(
     || {
-        Builder::new().build()
+        Builder::with_required_fields().build()
     }
     => true
     ;
@@ -74,7 +76,7 @@ fn section_rule_specified_not_optional_test(
 )]
 #[test_case(
     || {
-        Builder::new()
+        Builder::with_required_fields()
             .with_metadata_field(SupportedField::Collaborators(
                     vec![create_dummy_key_pair(RoleId::Role0).1].into()
                 ))
@@ -89,5 +91,6 @@ fn section_rule_not_specified_test(doc_gen: impl FnOnce() -> CatalystSignedDocum
     let rule = CollaboratorsRule::NotSpecified;
 
     let doc = doc_gen();
-    rule.check_inner(&doc)
+    rule.check_inner(&doc);
+    !doc.report().is_problematic()
 }


### PR DESCRIPTION
# Description

Remove the boolean flag from the collaborators rule.

## Related Issue(s)

Part of https://github.com/input-output-hk/catalyst-libs/issues/800

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
