### PR TITLE
chore(rust): Add `to_hex()` to `Blake3256` for convenient logging

### DIFF
--- a/rust/hermes-ipfs/src/doc_sync/mod.rs
+++ b/rust/hermes-ipfs/src/doc_sync/mod.rs
@@ -94,6 +94,13 @@ impl<'b, C> Decode<'b, C> for Signature {
 #[derive(Clone, Debug, PartialEq, Eq, Copy)]
 pub struct Blake3256(blake3::Hash);
 
+impl Blake3256 {
+    /// Hex string representation of the hash.
+    pub fn to_hex(&self) -> String {
+        self.0.to_hex().to_string()
+    }
+}
+
 impl<C> Encode<C> for Blake3256 {
     fn encode<W: Write>(
         &self,


### PR DESCRIPTION
# Description

This PR provide a small utility function to make the debug prints of the hash easier.

## Related Issue(s)

n/a

## Description of Changes

See **Description** above.

## Breaking Changes

n/a

## Screenshots

n/a

## Related Pull Requests

https://github.com/input-output-hk/hermes/pull/801

## Please confirm the following checks

* [X] My code follows the style guidelines of this project
* [X] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [X] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [X] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
